### PR TITLE
Adding the basic struct for the ExternalEncryptionConfig

### DIFF
--- a/cpp/src/parquet/encryption/crypto_factory.h
+++ b/cpp/src/parquet/encryption/crypto_factory.h
@@ -88,7 +88,7 @@ struct PARQUET_EXPORT EncryptionConfiguration {
 
 /// Helper struct for use in per column encryption specification.
 /// The ExternalEncryptionConfiguration will use this to send encryption parameters per column.
-struct PARQUET_EXPORT ColumnEncryptionPropertiesParams {
+struct PARQUET_EXPORT ColumnEncryptionAttributes {
     /// Which type of encryptor to use.
     ParquetCipher::type parquet_cipher;
 
@@ -104,7 +104,7 @@ struct PARQUET_EXPORT ExternalEncryptionConfiguration : public EncryptionConfigu
       : EncryptionConfiguration(footer_key) {}
 
   /// Map of the columns to encrypt to their associated encryption parameters. The id of the map
-  /// is the column name, and the value is a ColumnEncryptionPropertiesParams struct that can be
+  /// is the column name, and the value is a ColumnEncryptionAttributes struct that can be
   /// used to construct the ColumnEncryptionProperties in the CryptoFactory.
   /// As with the EncryptionConfiguration, either:
   /// (1) uniform_encryption = true
@@ -116,7 +116,7 @@ struct PARQUET_EXPORT ExternalEncryptionConfiguration : public EncryptionConfigu
   /// If a column name appears in the new per_column_encryption map, it will be encrypted using the
   /// per column specific algorithm and key.
   /// If a column name appears in both, the per_column_encryption values will take precedence.
-  std::unordered_map<std::string, ColumnEncryptionPropertiesParams> per_column_encryption;
+  std::unordered_map<std::string, ColumnEncryptionAttributes> per_column_encryption;
 
   /// External encryption services may use additional context provided by the application to
   /// enforce robust access control. The values sent to the external service depend on each

--- a/cpp/src/parquet/encryption/crypto_factory.h
+++ b/cpp/src/parquet/encryption/crypto_factory.h
@@ -118,9 +118,8 @@ struct PARQUET_EXPORT ExternalEncryptionConfiguration : public EncryptionConfigu
   /// External encryption services may use additional context provided by the application to
   /// enforce robust access control. The values sent to the external service depend on each
   /// implementation. 
-  /// The string represents a key/value based dictionary that may have nested dictionaries
-  // and or lists. The values are parsed and sent "as is" to the external service.
-  /// Format: "userId:value,location:{lat:value,long:value},roles:[role1,role2]"
+  /// This values must be a valid JSON-formatted string.
+  /// Format: "{}"
   std::string app_context;
   
   /// Key/value list of the location of configuration files needed by the external

--- a/cpp/src/parquet/encryption/crypto_factory.h
+++ b/cpp/src/parquet/encryption/crypto_factory.h
@@ -86,6 +86,11 @@ struct PARQUET_EXPORT EncryptionConfiguration {
   int32_t data_key_length_bits = kDefaultDataKeyLengthBits;
 };
 
+struct PARQUET_EXPORT ColumnEncryptionPropertiesBuilderParams {
+    ParquetCipher::type encryption_alg_;
+    std::string key_id_;
+};
+
 /// Encryption Configuration for use with External Encryption services. 
 /// Extends the already existing EncryptionConfiguration with more context and with
 /// the capability of specifying encryption algorithm per column.


### PR DESCRIPTION
Following discussion in 
https://docs.google.com/document/d/1Tjb45rQ2x9FydFmFIRo-U6PNJnEQ5_CfdCC4EU8M6D0/edit?tab=t.0

Creating a struct that extends the original EncryptionConfiguration and adds the three new parameters needed for external encryption service.

Note:
1. All params are represented as strings, following the column_keys map of the EncryptionConfig. This string is parsed later in crypto_factory.cc, and we will also add parsers when we're ready to convert the config.
2. This is just the definition of the struct. I am not modifying any test because I am not converting this struct or using it anywhere, as this requires a lot more work in crypto_factory.cc, plus extending the ColumnEncryptionProperties object.
3. Sending the struct to review to unblock Cris and his work on the Cython bindings.