### PR TITLE
Adding a ParquetCipher field to the ColumnEncryptionProperties. Neede…

### DIFF
--- a/cpp/src/parquet/encryption/encryption.cc
+++ b/cpp/src/parquet/encryption/encryption.cc
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include <map>
+#include <optional>
 #include <utility>
 
 #include "arrow/util/logging_internal.h"
@@ -77,6 +78,12 @@ ColumnEncryptionProperties::Builder* ColumnEncryptionProperties::Builder::key_id
 
   DCHECK(!key_id.empty());
   this->key_metadata(key_id);
+  return this;
+}
+
+ColumnEncryptionProperties::Builder* ColumnEncryptionProperties::Builder::parquet_cipher(
+    ParquetCipher::type parquet_cipher) {
+  this->parquet_cipher_ = parquet_cipher;
   return this;
 }
 
@@ -181,11 +188,10 @@ FileEncryptionProperties::Builder::disable_aad_prefix_storage() {
   return this;
 }
 
-ColumnEncryptionProperties::ColumnEncryptionProperties(bool encrypted,
-                                                       const std::string& column_path,
-                                                       const std::string& key,
-                                                       const std::string& key_metadata)
-    : column_path_(column_path) {
+ColumnEncryptionProperties::ColumnEncryptionProperties(
+        std::optional<ParquetCipher::type> parquet_cipher, bool encrypted,
+        const std::string& column_path, const std::string& key, const std::string& key_metadata)
+    : parquet_cipher_(parquet_cipher), column_path_(column_path) {
   DCHECK(!column_path.empty());
   if (!encrypted) {
     DCHECK(key.empty() && key_metadata.empty());

--- a/cpp/src/parquet/encryption/encryption.cc
+++ b/cpp/src/parquet/encryption/encryption.cc
@@ -189,9 +189,9 @@ FileEncryptionProperties::Builder::disable_aad_prefix_storage() {
 }
 
 ColumnEncryptionProperties::ColumnEncryptionProperties(
-        std::optional<ParquetCipher::type> parquet_cipher, bool encrypted,
-        const std::string& column_path, const std::string& key, const std::string& key_metadata)
-    : parquet_cipher_(parquet_cipher), column_path_(column_path) {
+        bool encrypted, const std::string& column_path, const std::string& key,
+        const std::string& key_metadata, std::optional<ParquetCipher::type> parquet_cipher)
+    : column_path_(column_path), parquet_cipher_(parquet_cipher) {
   DCHECK(!column_path.empty());
   if (!encrypted) {
     DCHECK(key.empty() && key_metadata.empty());

--- a/cpp/src/parquet/encryption/encryption.h
+++ b/cpp/src/parquet/encryption/encryption.h
@@ -147,12 +147,13 @@ class PARQUET_EXPORT ColumnEncryptionProperties {
         : column_path_(path), encrypted_(encrypted) {}
   };
 
-  /// Check whether the optional has a value before using.
   std::string column_path() const { return column_path_; }
   bool is_encrypted() const { return encrypted_; }
   bool is_encrypted_with_footer_key() const { return encrypted_with_footer_key_; }
   std::string key() const { return key_; }
   std::string key_metadata() const { return key_metadata_; }
+
+  /// Check whether the optional has a value before using.
   std::optional<ParquetCipher::type> parquet_cipher() const { return parquet_cipher_; }
 
   ColumnEncryptionProperties() = default;

--- a/cpp/src/parquet/encryption/encryption.h
+++ b/cpp/src/parquet/encryption/encryption.h
@@ -133,27 +133,27 @@ class PARQUET_EXPORT ColumnEncryptionProperties {
 
     std::shared_ptr<ColumnEncryptionProperties> build() {
       return std::shared_ptr<ColumnEncryptionProperties>(new ColumnEncryptionProperties(
-        parquet_cipher_, encrypted_, column_path_, key_, key_metadata_));
+        encrypted_, column_path_, key_, key_metadata_, parquet_cipher_));
     }
 
    private:
-    std::optional<ParquetCipher::type> parquet_cipher_;
     const std::string column_path_;
     bool encrypted_;
     std::string key_;
     std::string key_metadata_;
+    std::optional<ParquetCipher::type> parquet_cipher_;
 
     Builder(const std::string path, bool encrypted)
         : column_path_(path), encrypted_(encrypted) {}
   };
 
   /// Check whether the optional has a value before using.
-  std::optional<ParquetCipher::type> parquet_cipher() const { return parquet_cipher_; }
   std::string column_path() const { return column_path_; }
   bool is_encrypted() const { return encrypted_; }
   bool is_encrypted_with_footer_key() const { return encrypted_with_footer_key_; }
   std::string key() const { return key_; }
   std::string key_metadata() const { return key_metadata_; }
+  std::optional<ParquetCipher::type> parquet_cipher() const { return parquet_cipher_; }
 
   ColumnEncryptionProperties() = default;
   ColumnEncryptionProperties(const ColumnEncryptionProperties& other) = default;
@@ -162,15 +162,15 @@ class PARQUET_EXPORT ColumnEncryptionProperties {
   ~ColumnEncryptionProperties() { key_.clear(); }
 
  private:
-  std::optional<ParquetCipher::type> parquet_cipher_;
   const std::string column_path_;
   bool encrypted_;
   bool encrypted_with_footer_key_;
   std::string key_;
   std::string key_metadata_;
-  explicit ColumnEncryptionProperties(std::optional<ParquetCipher::type> parquet_cipher,
-                                      bool encrypted, const std::string& column_path,
-                                      const std::string& key, const std::string& key_metadata);
+  std::optional<ParquetCipher::type> parquet_cipher_;
+  explicit ColumnEncryptionProperties(bool encrypted, const std::string& column_path,
+                                      const std::string& key, const std::string& key_metadata,
+                                      std::optional<ParquetCipher::type> parquet_cipher);
 };
 
 class PARQUET_EXPORT ColumnDecryptionProperties {

--- a/cpp/src/parquet/encryption/encryption.h
+++ b/cpp/src/parquet/encryption/encryption.h
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -125,12 +126,18 @@ class PARQUET_EXPORT ColumnEncryptionProperties {
     /// key_id will be converted to metadata (UTF-8 array).
     Builder* key_id(const std::string& key_id);
 
+    /// Set ParquetCipher type to use.
+    /// This field is declared as optional. If the value is not set, then the ParquetCipher
+    /// declared in the FileEncryptionProperties will be used.
+    Builder* parquet_cipher(ParquetCipher::type parquet_cipher);
+
     std::shared_ptr<ColumnEncryptionProperties> build() {
-      return std::shared_ptr<ColumnEncryptionProperties>(
-          new ColumnEncryptionProperties(encrypted_, column_path_, key_, key_metadata_));
+      return std::shared_ptr<ColumnEncryptionProperties>(new ColumnEncryptionProperties(
+        parquet_cipher_, encrypted_, column_path_, key_, key_metadata_));
     }
 
    private:
+    std::optional<ParquetCipher::type> parquet_cipher_;
     const std::string column_path_;
     bool encrypted_;
     std::string key_;
@@ -140,6 +147,8 @@ class PARQUET_EXPORT ColumnEncryptionProperties {
         : column_path_(path), encrypted_(encrypted) {}
   };
 
+  /// Check whether the optional has a value before using.
+  std::optional<ParquetCipher::type> parquet_cipher() const { return parquet_cipher_; }
   std::string column_path() const { return column_path_; }
   bool is_encrypted() const { return encrypted_; }
   bool is_encrypted_with_footer_key() const { return encrypted_with_footer_key_; }
@@ -153,14 +162,15 @@ class PARQUET_EXPORT ColumnEncryptionProperties {
   ~ColumnEncryptionProperties() { key_.clear(); }
 
  private:
+  std::optional<ParquetCipher::type> parquet_cipher_;
   const std::string column_path_;
   bool encrypted_;
   bool encrypted_with_footer_key_;
   std::string key_;
   std::string key_metadata_;
-  explicit ColumnEncryptionProperties(bool encrypted, const std::string& column_path,
-                                      const std::string& key,
-                                      const std::string& key_metadata);
+  explicit ColumnEncryptionProperties(std::optional<ParquetCipher::type> parquet_cipher,
+                                      bool encrypted, const std::string& column_path,
+                                      const std::string& key, const std::string& key_metadata);
 };
 
 class PARQUET_EXPORT ColumnDecryptionProperties {

--- a/cpp/src/parquet/encryption/properties_test.cc
+++ b/cpp/src/parquet/encryption/properties_test.cc
@@ -48,6 +48,26 @@ TEST(TestColumnEncryptionProperties, ColumnEncryptedWithFooterKey) {
   ASSERT_EQ(true, column_props_1->is_encrypted_with_footer_key());
 }
 
+TEST(TestColumnEncryptionProperties, ColumnParquetCipherNotSpecified) {
+  std::string column_path = "column_path";
+  ColumnEncryptionProperties::Builder column_builder(column_path);
+  std::shared_ptr<ColumnEncryptionProperties> properties = column_builder.build();
+
+  ASSERT_EQ(column_path, properties->column_path());
+  ASSERT_EQ(false, properties->parquet_cipher().has_value());
+}
+
+TEST(TestColumnEncryptionProperties, ColumnParquetCipherSpecified) {
+  std::string column_path = "column_path";
+  ColumnEncryptionProperties::Builder column_builder(column_path);
+  column_builder.parquet_cipher(ParquetCipher::AES_GCM_CTR_V1);
+  std::shared_ptr<ColumnEncryptionProperties> properties = column_builder.build();
+
+  ASSERT_EQ(column_path, properties->column_path());
+  ASSERT_EQ(true, properties->parquet_cipher().has_value());
+  ASSERT_EQ(ParquetCipher::AES_GCM_CTR_V1, properties->parquet_cipher().value());
+}
+
 // Encrypt all columns and the footer with the same key.
 // (uniform encryption)
 TEST(TestEncryptionProperties, UniformEncryption) {


### PR DESCRIPTION
Preparing for extending the EncryptionConfig, allow each ColumnEncryptionProperties to specify their own ParquetCipher for the encryption algorithm.

Declaring the field as optional, since it won't be used by every column. If the field is not set, then the regular FileEncryptionProperties ParquetCipher should be used.

Added unit tests.