### PR TITLE
Add GetExternalFileEncryptionProperties method to C++ CryptoFactory 

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -413,7 +413,9 @@ if(PARQUET_REQUIRE_ENCRYPTION)
                    encryption/write_configurations_test.cc
                    encryption/read_configurations_test.cc
                    encryption/properties_test.cc
-                   encryption/test_encryption_util.cc)
+                   encryption/crypto_factory_test.cc
+                   encryption/test_encryption_util.cc
+                   encryption/test_in_memory_kms.cc)
   add_parquet_test(encryption-key-management-test
                    SOURCES
                    encryption/key_management_test.cc

--- a/cpp/src/parquet/encryption/crypto_factory.cc
+++ b/cpp/src/parquet/encryption/crypto_factory.cc
@@ -98,6 +98,14 @@ std::shared_ptr<FileEncryptionProperties> CryptoFactory::GetFileEncryptionProper
   return properties_builder.build();
 }
 
+std::shared_ptr<ExternalFileEncryptionProperties> CryptoFactory::GetExternalFileEncryptionProperties(
+      const KmsConnectionConfig& kms_connection_config,
+      const ExternalEncryptionConfiguration& external_encryption_config,
+      const EncryptionConfiguration& encryption_config, const std::string& file_path,
+      const std::shared_ptr<::arrow::fs::FileSystem>& file_system) {
+  return nullptr;
+}
+
 ColumnPathToEncryptionPropertiesMap CryptoFactory::GetColumnEncryptionProperties(
     int dek_length, const std::string& column_keys, FileKeyWrapper* key_wrapper) {
   ColumnPathToEncryptionPropertiesMap encrypted_columns;

--- a/cpp/src/parquet/encryption/crypto_factory.h
+++ b/cpp/src/parquet/encryption/crypto_factory.h
@@ -122,6 +122,8 @@ struct PARQUET_EXPORT ExternalEncryptionConfiguration : public EncryptionConfigu
   /// enforce robust access control. The values sent to the external service depend on each
   /// implementation. 
   /// This value must be a valid JSON-formatted string.
+  /// Validation of the string will be done by the external encryption service, Arrow will only
+  /// forward this value.
   /// Format: "{\"user_id\": \"abc123\", \"location\": {\"lat\": 9.7489, \"lon\": -83.7534}}"
   std::string app_context;
   

--- a/cpp/src/parquet/encryption/crypto_factory.h
+++ b/cpp/src/parquet/encryption/crypto_factory.h
@@ -160,6 +160,14 @@ class PARQUET_EXPORT CryptoFactory {
       const EncryptionConfiguration& encryption_config, const std::string& file_path = "",
       const std::shared_ptr<::arrow::fs::FileSystem>& file_system = NULLPTR);
 
+  /// Get the external encryption properties for a Parquet file. Used when encryption
+  /// will be provided by an external service.
+  std::shared_ptr<ExternalFileEncryptionProperties> GetExternalFileEncryptionProperties(
+      const KmsConnectionConfig& kms_connection_config,
+      const ExternalEncryptionConfiguration& external_encryption_config,
+      const EncryptionConfiguration& encryption_config, const std::string& file_path = "",
+      const std::shared_ptr<::arrow::fs::FileSystem>& file_system = NULLPTR);
+
   /// Get decryption properties for a Parquet file.
   /// If external key material is used then a file system and path to the
   /// parquet file must be provided.

--- a/cpp/src/parquet/encryption/crypto_factory.h
+++ b/cpp/src/parquet/encryption/crypto_factory.h
@@ -115,13 +115,13 @@ struct PARQUET_EXPORT ExternalEncryptionConfiguration : public EncryptionConfigu
   /// algorithm specified in the encryption_algorithm field. 
   /// If a column name appears in the new per_column_encryption map, it will be encrypted using the
   /// per column specific algorithm and key.
-  /// If a column name appears in both, the per_column_encryption values will take precedence.
+  /// If a column name appears in both, an exception will be thrown.
   std::unordered_map<std::string, ColumnEncryptionAttributes> per_column_encryption;
 
   /// External encryption services may use additional context provided by the application to
   /// enforce robust access control. The values sent to the external service depend on each
   /// implementation. 
-  /// This values must be a valid JSON-formatted string.
+  /// This value must be a valid JSON-formatted string.
   /// Format: "{\"user_id\": \"abc123\", \"location\": {\"lat\": 9.7489, \"lon\": -83.7534}}"
   std::string app_context;
   
@@ -153,7 +153,7 @@ class PARQUET_EXPORT CryptoFactory {
   void RegisterKmsClientFactory(std::shared_ptr<KmsClientFactory> kms_client_factory);
 
   /// Get the encryption properties for a Parquet file.
-  /// If external key material is used then a file system and path to the
+  /// If key material from outside the file is used, then a file system and path to the
   /// parquet file must be provided.
   std::shared_ptr<FileEncryptionProperties> GetFileEncryptionProperties(
       const KmsConnectionConfig& kms_connection_config,
@@ -165,7 +165,7 @@ class PARQUET_EXPORT CryptoFactory {
   std::shared_ptr<ExternalFileEncryptionProperties> GetExternalFileEncryptionProperties(
       const KmsConnectionConfig& kms_connection_config,
       const ExternalEncryptionConfiguration& external_encryption_config,
-      const EncryptionConfiguration& encryption_config, const std::string& file_path = "",
+      const std::string& file_path = "",
       const std::shared_ptr<::arrow::fs::FileSystem>& file_system = NULLPTR);
 
   /// Get decryption properties for a Parquet file.

--- a/cpp/src/parquet/encryption/encryption.h
+++ b/cpp/src/parquet/encryption/encryption.h
@@ -475,6 +475,43 @@ class PARQUET_EXPORT ExternalFileEncryptionProperties : public FileEncryptionPro
     /// remote service call. 
     Builder* connection_config(const std::map<std::string, std::string>& config);
 
+    /// Forward all base class property methods to the base class Builder so we can return the
+    /// correct Builder type.
+    Builder* set_plaintext_footer() {
+      FileEncryptionProperties::Builder::set_plaintext_footer();
+      return this;
+    }
+
+    Builder* algorithm(ParquetCipher::type parquet_cipher) {
+      FileEncryptionProperties::Builder::algorithm(parquet_cipher);
+      return this;
+    }
+
+    Builder* footer_key_id(const std::string& key_id) {
+      FileEncryptionProperties::Builder::footer_key_id(key_id);
+      return this;
+    }
+
+    Builder* footer_key_metadata(const std::string& footer_key_metadata) {
+      FileEncryptionProperties::Builder::footer_key_metadata(footer_key_metadata);
+      return this;
+    }
+
+    Builder* aad_prefix(const std::string& aad_prefix) {
+      FileEncryptionProperties::Builder::aad_prefix(aad_prefix);
+      return this;
+    }
+
+    Builder* disable_aad_prefix_storage() {
+      FileEncryptionProperties::Builder::disable_aad_prefix_storage();
+      return this;
+    }
+
+    Builder* encrypted_columns(const ColumnPathToEncryptionPropertiesMap& encrypted_columns) {
+      FileEncryptionProperties::Builder::encrypted_columns(encrypted_columns);
+      return this;
+    }
+
     std::shared_ptr<ExternalFileEncryptionProperties> build_external();
 
    private:

--- a/cpp/src/parquet/encryption/properties_test.cc
+++ b/cpp/src/parquet/encryption/properties_test.cc
@@ -283,7 +283,13 @@ TEST(TestExternalFileEncryptionProperties, SuperClassFieldsSetCorrectly) {
 
 // The subclass adds two additional fields
 TEST(TestExternalFileEncryptionProperties, SetExternalContextAndConfig) {
-  std::string app_context = "String containing valid JSON with app context. Not parsed here";
+  std::string app_context = "{\n"
+                   "  \"user_id\": \"abc123\",\n"
+                   "  \"location\": {\n"
+                   "    \"lat\": 10.0,\n"
+                   "    \"lon\": -84.0\n"
+                   "  }\n"
+                   "}";
   std::map<std::string, std::string> connection_config;
   connection_config["lib_location"] = "path/to/lib.so";
   connection_config["config_file"] = "path/to/config/file";


### PR DESCRIPTION
Needed to modify some of the previously added classes to get the code working correctly.

Code is not reused as much as I first thought, since the sanity checks at the beginning of the Get method are different for the FileEncryptionProperties and the ExternalFileEncryptionProperties.

CryptoFactory had no unit test (!), so added that as well.