### PR TITLE
Add external enum

### DIFF
--- a/cpp/src/generated/parquet_types.cpp
+++ b/cpp/src/generated/parquet_types.cpp
@@ -715,24 +715,11 @@ SizeStatistics::SizeStatistics(const SizeStatistics& other12) {
   definition_level_histogram = other12.definition_level_histogram;
   __isset = other12.__isset;
 }
-SizeStatistics::SizeStatistics(SizeStatistics&& other13) noexcept {
+SizeStatistics& SizeStatistics::operator=(const SizeStatistics& other13) {
   unencoded_byte_array_data_bytes = other13.unencoded_byte_array_data_bytes;
-  repetition_level_histogram = std::move(other13.repetition_level_histogram);
-  definition_level_histogram = std::move(other13.definition_level_histogram);
+  repetition_level_histogram = other13.repetition_level_histogram;
+  definition_level_histogram = other13.definition_level_histogram;
   __isset = other13.__isset;
-}
-SizeStatistics& SizeStatistics::operator=(const SizeStatistics& other14) {
-  unencoded_byte_array_data_bytes = other14.unencoded_byte_array_data_bytes;
-  repetition_level_histogram = other14.repetition_level_histogram;
-  definition_level_histogram = other14.definition_level_histogram;
-  __isset = other14.__isset;
-  return *this;
-}
-SizeStatistics& SizeStatistics::operator=(SizeStatistics&& other15) noexcept {
-  unencoded_byte_array_data_bytes = other15.unencoded_byte_array_data_bytes;
-  repetition_level_histogram = std::move(other15.repetition_level_histogram);
-  definition_level_histogram = std::move(other15.definition_level_histogram);
-  __isset = other15.__isset;
   return *this;
 }
 void SizeStatistics::printTo(std::ostream& out) const {
@@ -843,50 +830,27 @@ bool BoundingBox::operator==(const BoundingBox & rhs) const
   return true;
 }
 
-BoundingBox::BoundingBox(const BoundingBox& other16) noexcept {
-  xmin = other16.xmin;
-  xmax = other16.xmax;
-  ymin = other16.ymin;
-  ymax = other16.ymax;
-  zmin = other16.zmin;
-  zmax = other16.zmax;
-  mmin = other16.mmin;
-  mmax = other16.mmax;
-  __isset = other16.__isset;
+BoundingBox::BoundingBox(const BoundingBox& other14) noexcept {
+  xmin = other14.xmin;
+  xmax = other14.xmax;
+  ymin = other14.ymin;
+  ymax = other14.ymax;
+  zmin = other14.zmin;
+  zmax = other14.zmax;
+  mmin = other14.mmin;
+  mmax = other14.mmax;
+  __isset = other14.__isset;
 }
-BoundingBox::BoundingBox(BoundingBox&& other17) noexcept {
-  xmin = other17.xmin;
-  xmax = other17.xmax;
-  ymin = other17.ymin;
-  ymax = other17.ymax;
-  zmin = other17.zmin;
-  zmax = other17.zmax;
-  mmin = other17.mmin;
-  mmax = other17.mmax;
-  __isset = other17.__isset;
-}
-BoundingBox& BoundingBox::operator=(const BoundingBox& other18) noexcept {
-  xmin = other18.xmin;
-  xmax = other18.xmax;
-  ymin = other18.ymin;
-  ymax = other18.ymax;
-  zmin = other18.zmin;
-  zmax = other18.zmax;
-  mmin = other18.mmin;
-  mmax = other18.mmax;
-  __isset = other18.__isset;
-  return *this;
-}
-BoundingBox& BoundingBox::operator=(BoundingBox&& other19) noexcept {
-  xmin = other19.xmin;
-  xmax = other19.xmax;
-  ymin = other19.ymin;
-  ymax = other19.ymax;
-  zmin = other19.zmin;
-  zmax = other19.zmax;
-  mmin = other19.mmin;
-  mmax = other19.mmax;
-  __isset = other19.__isset;
+BoundingBox& BoundingBox::operator=(const BoundingBox& other15) noexcept {
+  xmin = other15.xmin;
+  xmax = other15.xmax;
+  ymin = other15.ymin;
+  ymax = other15.ymax;
+  zmin = other15.zmin;
+  zmax = other15.zmax;
+  mmin = other15.mmin;
+  mmax = other15.mmax;
+  __isset = other15.__isset;
   return *this;
 }
 void BoundingBox::printTo(std::ostream& out) const {
@@ -946,26 +910,15 @@ bool GeospatialStatistics::operator==(const GeospatialStatistics & rhs) const
   return true;
 }
 
-GeospatialStatistics::GeospatialStatistics(const GeospatialStatistics& other26) {
-  bbox = other26.bbox;
-  geospatial_types = other26.geospatial_types;
-  __isset = other26.__isset;
+GeospatialStatistics::GeospatialStatistics(const GeospatialStatistics& other22) {
+  bbox = other22.bbox;
+  geospatial_types = other22.geospatial_types;
+  __isset = other22.__isset;
 }
-GeospatialStatistics::GeospatialStatistics(GeospatialStatistics&& other27) noexcept {
-  bbox = std::move(other27.bbox);
-  geospatial_types = std::move(other27.geospatial_types);
-  __isset = other27.__isset;
-}
-GeospatialStatistics& GeospatialStatistics::operator=(const GeospatialStatistics& other28) {
-  bbox = other28.bbox;
-  geospatial_types = other28.geospatial_types;
-  __isset = other28.__isset;
-  return *this;
-}
-GeospatialStatistics& GeospatialStatistics::operator=(GeospatialStatistics&& other29) noexcept {
-  bbox = std::move(other29.bbox);
-  geospatial_types = std::move(other29.geospatial_types);
-  __isset = other29.__isset;
+GeospatialStatistics& GeospatialStatistics::operator=(const GeospatialStatistics& other23) {
+  bbox = other23.bbox;
+  geospatial_types = other23.geospatial_types;
+  __isset = other23.__isset;
   return *this;
 }
 void GeospatialStatistics::printTo(std::ostream& out) const {
@@ -1087,50 +1040,27 @@ bool Statistics::operator==(const Statistics & rhs) const
   return true;
 }
 
-Statistics::Statistics(const Statistics& other30) {
-  max = other30.max;
-  min = other30.min;
-  null_count = other30.null_count;
-  distinct_count = other30.distinct_count;
-  max_value = other30.max_value;
-  min_value = other30.min_value;
-  is_max_value_exact = other30.is_max_value_exact;
-  is_min_value_exact = other30.is_min_value_exact;
-  __isset = other30.__isset;
+Statistics::Statistics(const Statistics& other24) {
+  max = other24.max;
+  min = other24.min;
+  null_count = other24.null_count;
+  distinct_count = other24.distinct_count;
+  max_value = other24.max_value;
+  min_value = other24.min_value;
+  is_max_value_exact = other24.is_max_value_exact;
+  is_min_value_exact = other24.is_min_value_exact;
+  __isset = other24.__isset;
 }
-Statistics::Statistics(Statistics&& other31) noexcept {
-  max = std::move(other31.max);
-  min = std::move(other31.min);
-  null_count = other31.null_count;
-  distinct_count = other31.distinct_count;
-  max_value = std::move(other31.max_value);
-  min_value = std::move(other31.min_value);
-  is_max_value_exact = other31.is_max_value_exact;
-  is_min_value_exact = other31.is_min_value_exact;
-  __isset = other31.__isset;
-}
-Statistics& Statistics::operator=(const Statistics& other32) {
-  max = other32.max;
-  min = other32.min;
-  null_count = other32.null_count;
-  distinct_count = other32.distinct_count;
-  max_value = other32.max_value;
-  min_value = other32.min_value;
-  is_max_value_exact = other32.is_max_value_exact;
-  is_min_value_exact = other32.is_min_value_exact;
-  __isset = other32.__isset;
-  return *this;
-}
-Statistics& Statistics::operator=(Statistics&& other33) noexcept {
-  max = std::move(other33.max);
-  min = std::move(other33.min);
-  null_count = other33.null_count;
-  distinct_count = other33.distinct_count;
-  max_value = std::move(other33.max_value);
-  min_value = std::move(other33.min_value);
-  is_max_value_exact = other33.is_max_value_exact;
-  is_min_value_exact = other33.is_min_value_exact;
-  __isset = other33.__isset;
+Statistics& Statistics::operator=(const Statistics& other25) {
+  max = other25.max;
+  min = other25.min;
+  null_count = other25.null_count;
+  distinct_count = other25.distinct_count;
+  max_value = other25.max_value;
+  min_value = other25.min_value;
+  is_max_value_exact = other25.is_max_value_exact;
+  is_min_value_exact = other25.is_min_value_exact;
+  __isset = other25.__isset;
   return *this;
 }
 void Statistics::printTo(std::ostream& out) const {
@@ -1171,18 +1101,11 @@ bool StringType::operator==(const StringType & /* rhs */) const
   return true;
 }
 
-StringType::StringType(const StringType& other34) noexcept {
-  (void) other34;
+StringType::StringType(const StringType& other26) noexcept {
+  (void) other26;
 }
-StringType::StringType(StringType&& other35) noexcept {
-  (void) other35;
-}
-StringType& StringType::operator=(const StringType& other36) noexcept {
-  (void) other36;
-  return *this;
-}
-StringType& StringType::operator=(StringType&& other37) noexcept {
-  (void) other37;
+StringType& StringType::operator=(const StringType& other27) noexcept {
+  (void) other27;
   return *this;
 }
 void StringType::printTo(std::ostream& out) const {
@@ -1215,18 +1138,11 @@ bool UUIDType::operator==(const UUIDType & /* rhs */) const
   return true;
 }
 
-UUIDType::UUIDType(const UUIDType& other38) noexcept {
-  (void) other38;
+UUIDType::UUIDType(const UUIDType& other28) noexcept {
+  (void) other28;
 }
-UUIDType::UUIDType(UUIDType&& other39) noexcept {
-  (void) other39;
-}
-UUIDType& UUIDType::operator=(const UUIDType& other40) noexcept {
-  (void) other40;
-  return *this;
-}
-UUIDType& UUIDType::operator=(UUIDType&& other41) noexcept {
-  (void) other41;
+UUIDType& UUIDType::operator=(const UUIDType& other29) noexcept {
+  (void) other29;
   return *this;
 }
 void UUIDType::printTo(std::ostream& out) const {
@@ -1259,18 +1175,11 @@ bool MapType::operator==(const MapType & /* rhs */) const
   return true;
 }
 
-MapType::MapType(const MapType& other42) noexcept {
-  (void) other42;
+MapType::MapType(const MapType& other30) noexcept {
+  (void) other30;
 }
-MapType::MapType(MapType&& other43) noexcept {
-  (void) other43;
-}
-MapType& MapType::operator=(const MapType& other44) noexcept {
-  (void) other44;
-  return *this;
-}
-MapType& MapType::operator=(MapType&& other45) noexcept {
-  (void) other45;
+MapType& MapType::operator=(const MapType& other31) noexcept {
+  (void) other31;
   return *this;
 }
 void MapType::printTo(std::ostream& out) const {
@@ -1303,18 +1212,11 @@ bool ListType::operator==(const ListType & /* rhs */) const
   return true;
 }
 
-ListType::ListType(const ListType& other46) noexcept {
-  (void) other46;
+ListType::ListType(const ListType& other32) noexcept {
+  (void) other32;
 }
-ListType::ListType(ListType&& other47) noexcept {
-  (void) other47;
-}
-ListType& ListType::operator=(const ListType& other48) noexcept {
-  (void) other48;
-  return *this;
-}
-ListType& ListType::operator=(ListType&& other49) noexcept {
-  (void) other49;
+ListType& ListType::operator=(const ListType& other33) noexcept {
+  (void) other33;
   return *this;
 }
 void ListType::printTo(std::ostream& out) const {
@@ -1347,18 +1249,11 @@ bool EnumType::operator==(const EnumType & /* rhs */) const
   return true;
 }
 
-EnumType::EnumType(const EnumType& other50) noexcept {
-  (void) other50;
+EnumType::EnumType(const EnumType& other34) noexcept {
+  (void) other34;
 }
-EnumType::EnumType(EnumType&& other51) noexcept {
-  (void) other51;
-}
-EnumType& EnumType::operator=(const EnumType& other52) noexcept {
-  (void) other52;
-  return *this;
-}
-EnumType& EnumType::operator=(EnumType&& other53) noexcept {
-  (void) other53;
+EnumType& EnumType::operator=(const EnumType& other35) noexcept {
+  (void) other35;
   return *this;
 }
 void EnumType::printTo(std::ostream& out) const {
@@ -1391,18 +1286,11 @@ bool DateType::operator==(const DateType & /* rhs */) const
   return true;
 }
 
-DateType::DateType(const DateType& other54) noexcept {
-  (void) other54;
+DateType::DateType(const DateType& other36) noexcept {
+  (void) other36;
 }
-DateType::DateType(DateType&& other55) noexcept {
-  (void) other55;
-}
-DateType& DateType::operator=(const DateType& other56) noexcept {
-  (void) other56;
-  return *this;
-}
-DateType& DateType::operator=(DateType&& other57) noexcept {
-  (void) other57;
+DateType& DateType::operator=(const DateType& other37) noexcept {
+  (void) other37;
   return *this;
 }
 void DateType::printTo(std::ostream& out) const {
@@ -1435,18 +1323,11 @@ bool Float16Type::operator==(const Float16Type & /* rhs */) const
   return true;
 }
 
-Float16Type::Float16Type(const Float16Type& other58) noexcept {
-  (void) other58;
+Float16Type::Float16Type(const Float16Type& other38) noexcept {
+  (void) other38;
 }
-Float16Type::Float16Type(Float16Type&& other59) noexcept {
-  (void) other59;
-}
-Float16Type& Float16Type::operator=(const Float16Type& other60) noexcept {
-  (void) other60;
-  return *this;
-}
-Float16Type& Float16Type::operator=(Float16Type&& other61) noexcept {
-  (void) other61;
+Float16Type& Float16Type::operator=(const Float16Type& other39) noexcept {
+  (void) other39;
   return *this;
 }
 void Float16Type::printTo(std::ostream& out) const {
@@ -1479,18 +1360,11 @@ bool NullType::operator==(const NullType & /* rhs */) const
   return true;
 }
 
-NullType::NullType(const NullType& other62) noexcept {
-  (void) other62;
+NullType::NullType(const NullType& other40) noexcept {
+  (void) other40;
 }
-NullType::NullType(NullType&& other63) noexcept {
-  (void) other63;
-}
-NullType& NullType::operator=(const NullType& other64) noexcept {
-  (void) other64;
-  return *this;
-}
-NullType& NullType::operator=(NullType&& other65) noexcept {
-  (void) other65;
+NullType& NullType::operator=(const NullType& other41) noexcept {
+  (void) other41;
   return *this;
 }
 void NullType::printTo(std::ostream& out) const {
@@ -1537,22 +1411,13 @@ bool DecimalType::operator==(const DecimalType & rhs) const
   return true;
 }
 
-DecimalType::DecimalType(const DecimalType& other66) noexcept {
-  scale = other66.scale;
-  precision = other66.precision;
+DecimalType::DecimalType(const DecimalType& other42) noexcept {
+  scale = other42.scale;
+  precision = other42.precision;
 }
-DecimalType::DecimalType(DecimalType&& other67) noexcept {
-  scale = other67.scale;
-  precision = other67.precision;
-}
-DecimalType& DecimalType::operator=(const DecimalType& other68) noexcept {
-  scale = other68.scale;
-  precision = other68.precision;
-  return *this;
-}
-DecimalType& DecimalType::operator=(DecimalType&& other69) noexcept {
-  scale = other69.scale;
-  precision = other69.precision;
+DecimalType& DecimalType::operator=(const DecimalType& other43) noexcept {
+  scale = other43.scale;
+  precision = other43.precision;
   return *this;
 }
 void DecimalType::printTo(std::ostream& out) const {
@@ -1587,18 +1452,11 @@ bool MilliSeconds::operator==(const MilliSeconds & /* rhs */) const
   return true;
 }
 
-MilliSeconds::MilliSeconds(const MilliSeconds& other70) noexcept {
-  (void) other70;
+MilliSeconds::MilliSeconds(const MilliSeconds& other44) noexcept {
+  (void) other44;
 }
-MilliSeconds::MilliSeconds(MilliSeconds&& other71) noexcept {
-  (void) other71;
-}
-MilliSeconds& MilliSeconds::operator=(const MilliSeconds& other72) noexcept {
-  (void) other72;
-  return *this;
-}
-MilliSeconds& MilliSeconds::operator=(MilliSeconds&& other73) noexcept {
-  (void) other73;
+MilliSeconds& MilliSeconds::operator=(const MilliSeconds& other45) noexcept {
+  (void) other45;
   return *this;
 }
 void MilliSeconds::printTo(std::ostream& out) const {
@@ -1631,18 +1489,11 @@ bool MicroSeconds::operator==(const MicroSeconds & /* rhs */) const
   return true;
 }
 
-MicroSeconds::MicroSeconds(const MicroSeconds& other74) noexcept {
-  (void) other74;
+MicroSeconds::MicroSeconds(const MicroSeconds& other46) noexcept {
+  (void) other46;
 }
-MicroSeconds::MicroSeconds(MicroSeconds&& other75) noexcept {
-  (void) other75;
-}
-MicroSeconds& MicroSeconds::operator=(const MicroSeconds& other76) noexcept {
-  (void) other76;
-  return *this;
-}
-MicroSeconds& MicroSeconds::operator=(MicroSeconds&& other77) noexcept {
-  (void) other77;
+MicroSeconds& MicroSeconds::operator=(const MicroSeconds& other47) noexcept {
+  (void) other47;
   return *this;
 }
 void MicroSeconds::printTo(std::ostream& out) const {
@@ -1675,18 +1526,11 @@ bool NanoSeconds::operator==(const NanoSeconds & /* rhs */) const
   return true;
 }
 
-NanoSeconds::NanoSeconds(const NanoSeconds& other78) noexcept {
-  (void) other78;
+NanoSeconds::NanoSeconds(const NanoSeconds& other48) noexcept {
+  (void) other48;
 }
-NanoSeconds::NanoSeconds(NanoSeconds&& other79) noexcept {
-  (void) other79;
-}
-NanoSeconds& NanoSeconds::operator=(const NanoSeconds& other80) noexcept {
-  (void) other80;
-  return *this;
-}
-NanoSeconds& NanoSeconds::operator=(NanoSeconds&& other81) noexcept {
-  (void) other81;
+NanoSeconds& NanoSeconds::operator=(const NanoSeconds& other49) noexcept {
+  (void) other49;
   return *this;
 }
 void NanoSeconds::printTo(std::ostream& out) const {
@@ -1748,30 +1592,17 @@ bool TimeUnit::operator==(const TimeUnit & rhs) const
   return true;
 }
 
-TimeUnit::TimeUnit(const TimeUnit& other82) noexcept {
-  MILLIS = other82.MILLIS;
-  MICROS = other82.MICROS;
-  NANOS = other82.NANOS;
-  __isset = other82.__isset;
+TimeUnit::TimeUnit(const TimeUnit& other50) noexcept {
+  MILLIS = other50.MILLIS;
+  MICROS = other50.MICROS;
+  NANOS = other50.NANOS;
+  __isset = other50.__isset;
 }
-TimeUnit::TimeUnit(TimeUnit&& other83) noexcept {
-  MILLIS = std::move(other83.MILLIS);
-  MICROS = std::move(other83.MICROS);
-  NANOS = std::move(other83.NANOS);
-  __isset = other83.__isset;
-}
-TimeUnit& TimeUnit::operator=(const TimeUnit& other84) noexcept {
-  MILLIS = other84.MILLIS;
-  MICROS = other84.MICROS;
-  NANOS = other84.NANOS;
-  __isset = other84.__isset;
-  return *this;
-}
-TimeUnit& TimeUnit::operator=(TimeUnit&& other85) noexcept {
-  MILLIS = std::move(other85.MILLIS);
-  MICROS = std::move(other85.MICROS);
-  NANOS = std::move(other85.NANOS);
-  __isset = other85.__isset;
+TimeUnit& TimeUnit::operator=(const TimeUnit& other51) noexcept {
+  MILLIS = other51.MILLIS;
+  MICROS = other51.MICROS;
+  NANOS = other51.NANOS;
+  __isset = other51.__isset;
   return *this;
 }
 void TimeUnit::printTo(std::ostream& out) const {
@@ -1820,22 +1651,13 @@ bool TimestampType::operator==(const TimestampType & rhs) const
   return true;
 }
 
-TimestampType::TimestampType(const TimestampType& other86) noexcept {
-  isAdjustedToUTC = other86.isAdjustedToUTC;
-  unit = other86.unit;
+TimestampType::TimestampType(const TimestampType& other52) noexcept {
+  isAdjustedToUTC = other52.isAdjustedToUTC;
+  unit = other52.unit;
 }
-TimestampType::TimestampType(TimestampType&& other87) noexcept {
-  isAdjustedToUTC = other87.isAdjustedToUTC;
-  unit = std::move(other87.unit);
-}
-TimestampType& TimestampType::operator=(const TimestampType& other88) noexcept {
-  isAdjustedToUTC = other88.isAdjustedToUTC;
-  unit = other88.unit;
-  return *this;
-}
-TimestampType& TimestampType::operator=(TimestampType&& other89) noexcept {
-  isAdjustedToUTC = other89.isAdjustedToUTC;
-  unit = std::move(other89.unit);
+TimestampType& TimestampType::operator=(const TimestampType& other53) noexcept {
+  isAdjustedToUTC = other53.isAdjustedToUTC;
+  unit = other53.unit;
   return *this;
 }
 void TimestampType::printTo(std::ostream& out) const {
@@ -1883,22 +1705,13 @@ bool TimeType::operator==(const TimeType & rhs) const
   return true;
 }
 
-TimeType::TimeType(const TimeType& other90) noexcept {
-  isAdjustedToUTC = other90.isAdjustedToUTC;
-  unit = other90.unit;
+TimeType::TimeType(const TimeType& other54) noexcept {
+  isAdjustedToUTC = other54.isAdjustedToUTC;
+  unit = other54.unit;
 }
-TimeType::TimeType(TimeType&& other91) noexcept {
-  isAdjustedToUTC = other91.isAdjustedToUTC;
-  unit = std::move(other91.unit);
-}
-TimeType& TimeType::operator=(const TimeType& other92) noexcept {
-  isAdjustedToUTC = other92.isAdjustedToUTC;
-  unit = other92.unit;
-  return *this;
-}
-TimeType& TimeType::operator=(TimeType&& other93) noexcept {
-  isAdjustedToUTC = other93.isAdjustedToUTC;
-  unit = std::move(other93.unit);
+TimeType& TimeType::operator=(const TimeType& other55) noexcept {
+  isAdjustedToUTC = other55.isAdjustedToUTC;
+  unit = other55.unit;
   return *this;
 }
 void TimeType::printTo(std::ostream& out) const {
@@ -1947,22 +1760,13 @@ bool IntType::operator==(const IntType & rhs) const
   return true;
 }
 
-IntType::IntType(const IntType& other94) noexcept {
-  bitWidth = other94.bitWidth;
-  isSigned = other94.isSigned;
+IntType::IntType(const IntType& other56) noexcept {
+  bitWidth = other56.bitWidth;
+  isSigned = other56.isSigned;
 }
-IntType::IntType(IntType&& other95) noexcept {
-  bitWidth = other95.bitWidth;
-  isSigned = other95.isSigned;
-}
-IntType& IntType::operator=(const IntType& other96) noexcept {
-  bitWidth = other96.bitWidth;
-  isSigned = other96.isSigned;
-  return *this;
-}
-IntType& IntType::operator=(IntType&& other97) noexcept {
-  bitWidth = other97.bitWidth;
-  isSigned = other97.isSigned;
+IntType& IntType::operator=(const IntType& other57) noexcept {
+  bitWidth = other57.bitWidth;
+  isSigned = other57.isSigned;
   return *this;
 }
 void IntType::printTo(std::ostream& out) const {
@@ -1997,18 +1801,11 @@ bool JsonType::operator==(const JsonType & /* rhs */) const
   return true;
 }
 
-JsonType::JsonType(const JsonType& other98) noexcept {
-  (void) other98;
+JsonType::JsonType(const JsonType& other58) noexcept {
+  (void) other58;
 }
-JsonType::JsonType(JsonType&& other99) noexcept {
-  (void) other99;
-}
-JsonType& JsonType::operator=(const JsonType& other100) noexcept {
-  (void) other100;
-  return *this;
-}
-JsonType& JsonType::operator=(JsonType&& other101) noexcept {
-  (void) other101;
+JsonType& JsonType::operator=(const JsonType& other59) noexcept {
+  (void) other59;
   return *this;
 }
 void JsonType::printTo(std::ostream& out) const {
@@ -2041,18 +1838,11 @@ bool BsonType::operator==(const BsonType & /* rhs */) const
   return true;
 }
 
-BsonType::BsonType(const BsonType& other102) noexcept {
-  (void) other102;
+BsonType::BsonType(const BsonType& other60) noexcept {
+  (void) other60;
 }
-BsonType::BsonType(BsonType&& other103) noexcept {
-  (void) other103;
-}
-BsonType& BsonType::operator=(const BsonType& other104) noexcept {
-  (void) other104;
-  return *this;
-}
-BsonType& BsonType::operator=(BsonType&& other105) noexcept {
-  (void) other105;
+BsonType& BsonType::operator=(const BsonType& other61) noexcept {
+  (void) other61;
   return *this;
 }
 void BsonType::printTo(std::ostream& out) const {
@@ -2095,22 +1885,13 @@ bool VariantType::operator==(const VariantType & rhs) const
   return true;
 }
 
-VariantType::VariantType(const VariantType& other106) noexcept {
-  specification_version = other106.specification_version;
-  __isset = other106.__isset;
+VariantType::VariantType(const VariantType& other62) noexcept {
+  specification_version = other62.specification_version;
+  __isset = other62.__isset;
 }
-VariantType::VariantType(VariantType&& other107) noexcept {
-  specification_version = other107.specification_version;
-  __isset = other107.__isset;
-}
-VariantType& VariantType::operator=(const VariantType& other108) noexcept {
-  specification_version = other108.specification_version;
-  __isset = other108.__isset;
-  return *this;
-}
-VariantType& VariantType::operator=(VariantType&& other109) noexcept {
-  specification_version = other109.specification_version;
-  __isset = other109.__isset;
+VariantType& VariantType::operator=(const VariantType& other63) noexcept {
+  specification_version = other63.specification_version;
+  __isset = other63.__isset;
   return *this;
 }
 void VariantType::printTo(std::ostream& out) const {
@@ -2154,22 +1935,13 @@ bool GeometryType::operator==(const GeometryType & rhs) const
   return true;
 }
 
-GeometryType::GeometryType(const GeometryType& other110) {
-  crs = other110.crs;
-  __isset = other110.__isset;
+GeometryType::GeometryType(const GeometryType& other64) {
+  crs = other64.crs;
+  __isset = other64.__isset;
 }
-GeometryType::GeometryType(GeometryType&& other111) noexcept {
-  crs = std::move(other111.crs);
-  __isset = other111.__isset;
-}
-GeometryType& GeometryType::operator=(const GeometryType& other112) {
-  crs = other112.crs;
-  __isset = other112.__isset;
-  return *this;
-}
-GeometryType& GeometryType::operator=(GeometryType&& other113) noexcept {
-  crs = std::move(other113.crs);
-  __isset = other113.__isset;
+GeometryType& GeometryType::operator=(const GeometryType& other65) {
+  crs = other65.crs;
+  __isset = other65.__isset;
   return *this;
 }
 void GeometryType::printTo(std::ostream& out) const {
@@ -2224,26 +1996,15 @@ bool GeographyType::operator==(const GeographyType & rhs) const
   return true;
 }
 
-GeographyType::GeographyType(const GeographyType& other115) {
-  crs = other115.crs;
-  algorithm = other115.algorithm;
-  __isset = other115.__isset;
+GeographyType::GeographyType(const GeographyType& other67) {
+  crs = other67.crs;
+  algorithm = other67.algorithm;
+  __isset = other67.__isset;
 }
-GeographyType::GeographyType(GeographyType&& other116) noexcept {
-  crs = std::move(other116.crs);
-  algorithm = other116.algorithm;
-  __isset = other116.__isset;
-}
-GeographyType& GeographyType::operator=(const GeographyType& other117) {
-  crs = other117.crs;
-  algorithm = other117.algorithm;
-  __isset = other117.__isset;
-  return *this;
-}
-GeographyType& GeographyType::operator=(GeographyType&& other118) noexcept {
-  crs = std::move(other118.crs);
-  algorithm = other118.algorithm;
-  __isset = other118.__isset;
+GeographyType& GeographyType::operator=(const GeographyType& other68) {
+  crs = other68.crs;
+  algorithm = other68.algorithm;
+  __isset = other68.__isset;
   return *this;
 }
 void GeographyType::printTo(std::ostream& out) const {
@@ -2447,86 +2208,45 @@ bool LogicalType::operator==(const LogicalType & rhs) const
   return true;
 }
 
-LogicalType::LogicalType(const LogicalType& other119) {
-  STRING = other119.STRING;
-  MAP = other119.MAP;
-  LIST = other119.LIST;
-  ENUM = other119.ENUM;
-  DECIMAL = other119.DECIMAL;
-  DATE = other119.DATE;
-  TIME = other119.TIME;
-  TIMESTAMP = other119.TIMESTAMP;
-  INTEGER = other119.INTEGER;
-  UNKNOWN = other119.UNKNOWN;
-  JSON = other119.JSON;
-  BSON = other119.BSON;
-  UUID = other119.UUID;
-  FLOAT16 = other119.FLOAT16;
-  VARIANT = other119.VARIANT;
-  GEOMETRY = other119.GEOMETRY;
-  GEOGRAPHY = other119.GEOGRAPHY;
-  __isset = other119.__isset;
+LogicalType::LogicalType(const LogicalType& other69) {
+  STRING = other69.STRING;
+  MAP = other69.MAP;
+  LIST = other69.LIST;
+  ENUM = other69.ENUM;
+  DECIMAL = other69.DECIMAL;
+  DATE = other69.DATE;
+  TIME = other69.TIME;
+  TIMESTAMP = other69.TIMESTAMP;
+  INTEGER = other69.INTEGER;
+  UNKNOWN = other69.UNKNOWN;
+  JSON = other69.JSON;
+  BSON = other69.BSON;
+  UUID = other69.UUID;
+  FLOAT16 = other69.FLOAT16;
+  VARIANT = other69.VARIANT;
+  GEOMETRY = other69.GEOMETRY;
+  GEOGRAPHY = other69.GEOGRAPHY;
+  __isset = other69.__isset;
 }
-LogicalType::LogicalType(LogicalType&& other120) noexcept {
-  STRING = std::move(other120.STRING);
-  MAP = std::move(other120.MAP);
-  LIST = std::move(other120.LIST);
-  ENUM = std::move(other120.ENUM);
-  DECIMAL = std::move(other120.DECIMAL);
-  DATE = std::move(other120.DATE);
-  TIME = std::move(other120.TIME);
-  TIMESTAMP = std::move(other120.TIMESTAMP);
-  INTEGER = std::move(other120.INTEGER);
-  UNKNOWN = std::move(other120.UNKNOWN);
-  JSON = std::move(other120.JSON);
-  BSON = std::move(other120.BSON);
-  UUID = std::move(other120.UUID);
-  FLOAT16 = std::move(other120.FLOAT16);
-  VARIANT = std::move(other120.VARIANT);
-  GEOMETRY = std::move(other120.GEOMETRY);
-  GEOGRAPHY = std::move(other120.GEOGRAPHY);
-  __isset = other120.__isset;
-}
-LogicalType& LogicalType::operator=(const LogicalType& other121) {
-  STRING = other121.STRING;
-  MAP = other121.MAP;
-  LIST = other121.LIST;
-  ENUM = other121.ENUM;
-  DECIMAL = other121.DECIMAL;
-  DATE = other121.DATE;
-  TIME = other121.TIME;
-  TIMESTAMP = other121.TIMESTAMP;
-  INTEGER = other121.INTEGER;
-  UNKNOWN = other121.UNKNOWN;
-  JSON = other121.JSON;
-  BSON = other121.BSON;
-  UUID = other121.UUID;
-  FLOAT16 = other121.FLOAT16;
-  VARIANT = other121.VARIANT;
-  GEOMETRY = other121.GEOMETRY;
-  GEOGRAPHY = other121.GEOGRAPHY;
-  __isset = other121.__isset;
-  return *this;
-}
-LogicalType& LogicalType::operator=(LogicalType&& other122) noexcept {
-  STRING = std::move(other122.STRING);
-  MAP = std::move(other122.MAP);
-  LIST = std::move(other122.LIST);
-  ENUM = std::move(other122.ENUM);
-  DECIMAL = std::move(other122.DECIMAL);
-  DATE = std::move(other122.DATE);
-  TIME = std::move(other122.TIME);
-  TIMESTAMP = std::move(other122.TIMESTAMP);
-  INTEGER = std::move(other122.INTEGER);
-  UNKNOWN = std::move(other122.UNKNOWN);
-  JSON = std::move(other122.JSON);
-  BSON = std::move(other122.BSON);
-  UUID = std::move(other122.UUID);
-  FLOAT16 = std::move(other122.FLOAT16);
-  VARIANT = std::move(other122.VARIANT);
-  GEOMETRY = std::move(other122.GEOMETRY);
-  GEOGRAPHY = std::move(other122.GEOGRAPHY);
-  __isset = other122.__isset;
+LogicalType& LogicalType::operator=(const LogicalType& other70) {
+  STRING = other70.STRING;
+  MAP = other70.MAP;
+  LIST = other70.LIST;
+  ENUM = other70.ENUM;
+  DECIMAL = other70.DECIMAL;
+  DATE = other70.DATE;
+  TIME = other70.TIME;
+  TIMESTAMP = other70.TIMESTAMP;
+  INTEGER = other70.INTEGER;
+  UNKNOWN = other70.UNKNOWN;
+  JSON = other70.JSON;
+  BSON = other70.BSON;
+  UUID = other70.UUID;
+  FLOAT16 = other70.FLOAT16;
+  VARIANT = other70.VARIANT;
+  GEOMETRY = other70.GEOMETRY;
+  GEOGRAPHY = other70.GEOGRAPHY;
+  __isset = other70.__isset;
   return *this;
 }
 void LogicalType::printTo(std::ostream& out) const {
@@ -2681,58 +2401,31 @@ bool SchemaElement::operator==(const SchemaElement & rhs) const
   return true;
 }
 
-SchemaElement::SchemaElement(const SchemaElement& other126) {
-  type = other126.type;
-  type_length = other126.type_length;
-  repetition_type = other126.repetition_type;
-  name = other126.name;
-  num_children = other126.num_children;
-  converted_type = other126.converted_type;
-  scale = other126.scale;
-  precision = other126.precision;
-  field_id = other126.field_id;
-  logicalType = other126.logicalType;
-  __isset = other126.__isset;
+SchemaElement::SchemaElement(const SchemaElement& other74) {
+  type = other74.type;
+  type_length = other74.type_length;
+  repetition_type = other74.repetition_type;
+  name = other74.name;
+  num_children = other74.num_children;
+  converted_type = other74.converted_type;
+  scale = other74.scale;
+  precision = other74.precision;
+  field_id = other74.field_id;
+  logicalType = other74.logicalType;
+  __isset = other74.__isset;
 }
-SchemaElement::SchemaElement(SchemaElement&& other127) noexcept {
-  type = other127.type;
-  type_length = other127.type_length;
-  repetition_type = other127.repetition_type;
-  name = std::move(other127.name);
-  num_children = other127.num_children;
-  converted_type = other127.converted_type;
-  scale = other127.scale;
-  precision = other127.precision;
-  field_id = other127.field_id;
-  logicalType = std::move(other127.logicalType);
-  __isset = other127.__isset;
-}
-SchemaElement& SchemaElement::operator=(const SchemaElement& other128) {
-  type = other128.type;
-  type_length = other128.type_length;
-  repetition_type = other128.repetition_type;
-  name = other128.name;
-  num_children = other128.num_children;
-  converted_type = other128.converted_type;
-  scale = other128.scale;
-  precision = other128.precision;
-  field_id = other128.field_id;
-  logicalType = other128.logicalType;
-  __isset = other128.__isset;
-  return *this;
-}
-SchemaElement& SchemaElement::operator=(SchemaElement&& other129) noexcept {
-  type = other129.type;
-  type_length = other129.type_length;
-  repetition_type = other129.repetition_type;
-  name = std::move(other129.name);
-  num_children = other129.num_children;
-  converted_type = other129.converted_type;
-  scale = other129.scale;
-  precision = other129.precision;
-  field_id = other129.field_id;
-  logicalType = std::move(other129.logicalType);
-  __isset = other129.__isset;
+SchemaElement& SchemaElement::operator=(const SchemaElement& other75) {
+  type = other75.type;
+  type_length = other75.type_length;
+  repetition_type = other75.repetition_type;
+  name = other75.name;
+  num_children = other75.num_children;
+  converted_type = other75.converted_type;
+  scale = other75.scale;
+  precision = other75.precision;
+  field_id = other75.field_id;
+  logicalType = other75.logicalType;
+  __isset = other75.__isset;
   return *this;
 }
 void SchemaElement::printTo(std::ostream& out) const {
@@ -2816,38 +2509,21 @@ bool DataPageHeader::operator==(const DataPageHeader & rhs) const
   return true;
 }
 
-DataPageHeader::DataPageHeader(const DataPageHeader& other133) {
-  num_values = other133.num_values;
-  encoding = other133.encoding;
-  definition_level_encoding = other133.definition_level_encoding;
-  repetition_level_encoding = other133.repetition_level_encoding;
-  statistics = other133.statistics;
-  __isset = other133.__isset;
+DataPageHeader::DataPageHeader(const DataPageHeader& other79) {
+  num_values = other79.num_values;
+  encoding = other79.encoding;
+  definition_level_encoding = other79.definition_level_encoding;
+  repetition_level_encoding = other79.repetition_level_encoding;
+  statistics = other79.statistics;
+  __isset = other79.__isset;
 }
-DataPageHeader::DataPageHeader(DataPageHeader&& other134) noexcept {
-  num_values = other134.num_values;
-  encoding = other134.encoding;
-  definition_level_encoding = other134.definition_level_encoding;
-  repetition_level_encoding = other134.repetition_level_encoding;
-  statistics = std::move(other134.statistics);
-  __isset = other134.__isset;
-}
-DataPageHeader& DataPageHeader::operator=(const DataPageHeader& other135) {
-  num_values = other135.num_values;
-  encoding = other135.encoding;
-  definition_level_encoding = other135.definition_level_encoding;
-  repetition_level_encoding = other135.repetition_level_encoding;
-  statistics = other135.statistics;
-  __isset = other135.__isset;
-  return *this;
-}
-DataPageHeader& DataPageHeader::operator=(DataPageHeader&& other136) noexcept {
-  num_values = other136.num_values;
-  encoding = other136.encoding;
-  definition_level_encoding = other136.definition_level_encoding;
-  repetition_level_encoding = other136.repetition_level_encoding;
-  statistics = std::move(other136.statistics);
-  __isset = other136.__isset;
+DataPageHeader& DataPageHeader::operator=(const DataPageHeader& other80) {
+  num_values = other80.num_values;
+  encoding = other80.encoding;
+  definition_level_encoding = other80.definition_level_encoding;
+  repetition_level_encoding = other80.repetition_level_encoding;
+  statistics = other80.statistics;
+  __isset = other80.__isset;
   return *this;
 }
 void DataPageHeader::printTo(std::ostream& out) const {
@@ -2885,18 +2561,11 @@ bool IndexPageHeader::operator==(const IndexPageHeader & /* rhs */) const
   return true;
 }
 
-IndexPageHeader::IndexPageHeader(const IndexPageHeader& other137) noexcept {
-  (void) other137;
+IndexPageHeader::IndexPageHeader(const IndexPageHeader& other81) noexcept {
+  (void) other81;
 }
-IndexPageHeader::IndexPageHeader(IndexPageHeader&& other138) noexcept {
-  (void) other138;
-}
-IndexPageHeader& IndexPageHeader::operator=(const IndexPageHeader& other139) noexcept {
-  (void) other139;
-  return *this;
-}
-IndexPageHeader& IndexPageHeader::operator=(IndexPageHeader&& other140) noexcept {
-  (void) other140;
+IndexPageHeader& IndexPageHeader::operator=(const IndexPageHeader& other82) noexcept {
+  (void) other82;
   return *this;
 }
 void IndexPageHeader::printTo(std::ostream& out) const {
@@ -2955,30 +2624,17 @@ bool DictionaryPageHeader::operator==(const DictionaryPageHeader & rhs) const
   return true;
 }
 
-DictionaryPageHeader::DictionaryPageHeader(const DictionaryPageHeader& other142) noexcept {
-  num_values = other142.num_values;
-  encoding = other142.encoding;
-  is_sorted = other142.is_sorted;
-  __isset = other142.__isset;
+DictionaryPageHeader::DictionaryPageHeader(const DictionaryPageHeader& other84) noexcept {
+  num_values = other84.num_values;
+  encoding = other84.encoding;
+  is_sorted = other84.is_sorted;
+  __isset = other84.__isset;
 }
-DictionaryPageHeader::DictionaryPageHeader(DictionaryPageHeader&& other143) noexcept {
-  num_values = other143.num_values;
-  encoding = other143.encoding;
-  is_sorted = other143.is_sorted;
-  __isset = other143.__isset;
-}
-DictionaryPageHeader& DictionaryPageHeader::operator=(const DictionaryPageHeader& other144) noexcept {
-  num_values = other144.num_values;
-  encoding = other144.encoding;
-  is_sorted = other144.is_sorted;
-  __isset = other144.__isset;
-  return *this;
-}
-DictionaryPageHeader& DictionaryPageHeader::operator=(DictionaryPageHeader&& other145) noexcept {
-  num_values = other145.num_values;
-  encoding = other145.encoding;
-  is_sorted = other145.is_sorted;
-  __isset = other145.__isset;
+DictionaryPageHeader& DictionaryPageHeader::operator=(const DictionaryPageHeader& other85) noexcept {
+  num_values = other85.num_values;
+  encoding = other85.encoding;
+  is_sorted = other85.is_sorted;
+  __isset = other85.__isset;
   return *this;
 }
 void DictionaryPageHeader::printTo(std::ostream& out) const {
@@ -3082,50 +2738,27 @@ bool DataPageHeaderV2::operator==(const DataPageHeaderV2 & rhs) const
   return true;
 }
 
-DataPageHeaderV2::DataPageHeaderV2(const DataPageHeaderV2& other147) {
-  num_values = other147.num_values;
-  num_nulls = other147.num_nulls;
-  num_rows = other147.num_rows;
-  encoding = other147.encoding;
-  definition_levels_byte_length = other147.definition_levels_byte_length;
-  repetition_levels_byte_length = other147.repetition_levels_byte_length;
-  is_compressed = other147.is_compressed;
-  statistics = other147.statistics;
-  __isset = other147.__isset;
+DataPageHeaderV2::DataPageHeaderV2(const DataPageHeaderV2& other87) {
+  num_values = other87.num_values;
+  num_nulls = other87.num_nulls;
+  num_rows = other87.num_rows;
+  encoding = other87.encoding;
+  definition_levels_byte_length = other87.definition_levels_byte_length;
+  repetition_levels_byte_length = other87.repetition_levels_byte_length;
+  is_compressed = other87.is_compressed;
+  statistics = other87.statistics;
+  __isset = other87.__isset;
 }
-DataPageHeaderV2::DataPageHeaderV2(DataPageHeaderV2&& other148) noexcept {
-  num_values = other148.num_values;
-  num_nulls = other148.num_nulls;
-  num_rows = other148.num_rows;
-  encoding = other148.encoding;
-  definition_levels_byte_length = other148.definition_levels_byte_length;
-  repetition_levels_byte_length = other148.repetition_levels_byte_length;
-  is_compressed = other148.is_compressed;
-  statistics = std::move(other148.statistics);
-  __isset = other148.__isset;
-}
-DataPageHeaderV2& DataPageHeaderV2::operator=(const DataPageHeaderV2& other149) {
-  num_values = other149.num_values;
-  num_nulls = other149.num_nulls;
-  num_rows = other149.num_rows;
-  encoding = other149.encoding;
-  definition_levels_byte_length = other149.definition_levels_byte_length;
-  repetition_levels_byte_length = other149.repetition_levels_byte_length;
-  is_compressed = other149.is_compressed;
-  statistics = other149.statistics;
-  __isset = other149.__isset;
-  return *this;
-}
-DataPageHeaderV2& DataPageHeaderV2::operator=(DataPageHeaderV2&& other150) noexcept {
-  num_values = other150.num_values;
-  num_nulls = other150.num_nulls;
-  num_rows = other150.num_rows;
-  encoding = other150.encoding;
-  definition_levels_byte_length = other150.definition_levels_byte_length;
-  repetition_levels_byte_length = other150.repetition_levels_byte_length;
-  is_compressed = other150.is_compressed;
-  statistics = std::move(other150.statistics);
-  __isset = other150.__isset;
+DataPageHeaderV2& DataPageHeaderV2::operator=(const DataPageHeaderV2& other88) {
+  num_values = other88.num_values;
+  num_nulls = other88.num_nulls;
+  num_rows = other88.num_rows;
+  encoding = other88.encoding;
+  definition_levels_byte_length = other88.definition_levels_byte_length;
+  repetition_levels_byte_length = other88.repetition_levels_byte_length;
+  is_compressed = other88.is_compressed;
+  statistics = other88.statistics;
+  __isset = other88.__isset;
   return *this;
 }
 void DataPageHeaderV2::printTo(std::ostream& out) const {
@@ -3166,18 +2799,11 @@ bool SplitBlockAlgorithm::operator==(const SplitBlockAlgorithm & /* rhs */) cons
   return true;
 }
 
-SplitBlockAlgorithm::SplitBlockAlgorithm(const SplitBlockAlgorithm& other151) noexcept {
-  (void) other151;
+SplitBlockAlgorithm::SplitBlockAlgorithm(const SplitBlockAlgorithm& other89) noexcept {
+  (void) other89;
 }
-SplitBlockAlgorithm::SplitBlockAlgorithm(SplitBlockAlgorithm&& other152) noexcept {
-  (void) other152;
-}
-SplitBlockAlgorithm& SplitBlockAlgorithm::operator=(const SplitBlockAlgorithm& other153) noexcept {
-  (void) other153;
-  return *this;
-}
-SplitBlockAlgorithm& SplitBlockAlgorithm::operator=(SplitBlockAlgorithm&& other154) noexcept {
-  (void) other154;
+SplitBlockAlgorithm& SplitBlockAlgorithm::operator=(const SplitBlockAlgorithm& other90) noexcept {
+  (void) other90;
   return *this;
 }
 void SplitBlockAlgorithm::printTo(std::ostream& out) const {
@@ -3219,22 +2845,13 @@ bool BloomFilterAlgorithm::operator==(const BloomFilterAlgorithm & rhs) const
   return true;
 }
 
-BloomFilterAlgorithm::BloomFilterAlgorithm(const BloomFilterAlgorithm& other155) noexcept {
-  BLOCK = other155.BLOCK;
-  __isset = other155.__isset;
+BloomFilterAlgorithm::BloomFilterAlgorithm(const BloomFilterAlgorithm& other91) noexcept {
+  BLOCK = other91.BLOCK;
+  __isset = other91.__isset;
 }
-BloomFilterAlgorithm::BloomFilterAlgorithm(BloomFilterAlgorithm&& other156) noexcept {
-  BLOCK = std::move(other156.BLOCK);
-  __isset = other156.__isset;
-}
-BloomFilterAlgorithm& BloomFilterAlgorithm::operator=(const BloomFilterAlgorithm& other157) noexcept {
-  BLOCK = other157.BLOCK;
-  __isset = other157.__isset;
-  return *this;
-}
-BloomFilterAlgorithm& BloomFilterAlgorithm::operator=(BloomFilterAlgorithm&& other158) noexcept {
-  BLOCK = std::move(other158.BLOCK);
-  __isset = other158.__isset;
+BloomFilterAlgorithm& BloomFilterAlgorithm::operator=(const BloomFilterAlgorithm& other92) noexcept {
+  BLOCK = other92.BLOCK;
+  __isset = other92.__isset;
   return *this;
 }
 void BloomFilterAlgorithm::printTo(std::ostream& out) const {
@@ -3268,18 +2885,11 @@ bool XxHash::operator==(const XxHash & /* rhs */) const
   return true;
 }
 
-XxHash::XxHash(const XxHash& other159) noexcept {
-  (void) other159;
+XxHash::XxHash(const XxHash& other93) noexcept {
+  (void) other93;
 }
-XxHash::XxHash(XxHash&& other160) noexcept {
-  (void) other160;
-}
-XxHash& XxHash::operator=(const XxHash& other161) noexcept {
-  (void) other161;
-  return *this;
-}
-XxHash& XxHash::operator=(XxHash&& other162) noexcept {
-  (void) other162;
+XxHash& XxHash::operator=(const XxHash& other94) noexcept {
+  (void) other94;
   return *this;
 }
 void XxHash::printTo(std::ostream& out) const {
@@ -3321,22 +2931,13 @@ bool BloomFilterHash::operator==(const BloomFilterHash & rhs) const
   return true;
 }
 
-BloomFilterHash::BloomFilterHash(const BloomFilterHash& other163) noexcept {
-  XXHASH = other163.XXHASH;
-  __isset = other163.__isset;
+BloomFilterHash::BloomFilterHash(const BloomFilterHash& other95) noexcept {
+  XXHASH = other95.XXHASH;
+  __isset = other95.__isset;
 }
-BloomFilterHash::BloomFilterHash(BloomFilterHash&& other164) noexcept {
-  XXHASH = std::move(other164.XXHASH);
-  __isset = other164.__isset;
-}
-BloomFilterHash& BloomFilterHash::operator=(const BloomFilterHash& other165) noexcept {
-  XXHASH = other165.XXHASH;
-  __isset = other165.__isset;
-  return *this;
-}
-BloomFilterHash& BloomFilterHash::operator=(BloomFilterHash&& other166) noexcept {
-  XXHASH = std::move(other166.XXHASH);
-  __isset = other166.__isset;
+BloomFilterHash& BloomFilterHash::operator=(const BloomFilterHash& other96) noexcept {
+  XXHASH = other96.XXHASH;
+  __isset = other96.__isset;
   return *this;
 }
 void BloomFilterHash::printTo(std::ostream& out) const {
@@ -3370,18 +2971,11 @@ bool Uncompressed::operator==(const Uncompressed & /* rhs */) const
   return true;
 }
 
-Uncompressed::Uncompressed(const Uncompressed& other167) noexcept {
-  (void) other167;
+Uncompressed::Uncompressed(const Uncompressed& other97) noexcept {
+  (void) other97;
 }
-Uncompressed::Uncompressed(Uncompressed&& other168) noexcept {
-  (void) other168;
-}
-Uncompressed& Uncompressed::operator=(const Uncompressed& other169) noexcept {
-  (void) other169;
-  return *this;
-}
-Uncompressed& Uncompressed::operator=(Uncompressed&& other170) noexcept {
-  (void) other170;
+Uncompressed& Uncompressed::operator=(const Uncompressed& other98) noexcept {
+  (void) other98;
   return *this;
 }
 void Uncompressed::printTo(std::ostream& out) const {
@@ -3423,22 +3017,13 @@ bool BloomFilterCompression::operator==(const BloomFilterCompression & rhs) cons
   return true;
 }
 
-BloomFilterCompression::BloomFilterCompression(const BloomFilterCompression& other171) noexcept {
-  UNCOMPRESSED = other171.UNCOMPRESSED;
-  __isset = other171.__isset;
+BloomFilterCompression::BloomFilterCompression(const BloomFilterCompression& other99) noexcept {
+  UNCOMPRESSED = other99.UNCOMPRESSED;
+  __isset = other99.__isset;
 }
-BloomFilterCompression::BloomFilterCompression(BloomFilterCompression&& other172) noexcept {
-  UNCOMPRESSED = std::move(other172.UNCOMPRESSED);
-  __isset = other172.__isset;
-}
-BloomFilterCompression& BloomFilterCompression::operator=(const BloomFilterCompression& other173) noexcept {
-  UNCOMPRESSED = other173.UNCOMPRESSED;
-  __isset = other173.__isset;
-  return *this;
-}
-BloomFilterCompression& BloomFilterCompression::operator=(BloomFilterCompression&& other174) noexcept {
-  UNCOMPRESSED = std::move(other174.UNCOMPRESSED);
-  __isset = other174.__isset;
+BloomFilterCompression& BloomFilterCompression::operator=(const BloomFilterCompression& other100) noexcept {
+  UNCOMPRESSED = other100.UNCOMPRESSED;
+  __isset = other100.__isset;
   return *this;
 }
 void BloomFilterCompression::printTo(std::ostream& out) const {
@@ -3499,30 +3084,17 @@ bool BloomFilterHeader::operator==(const BloomFilterHeader & rhs) const
   return true;
 }
 
-BloomFilterHeader::BloomFilterHeader(const BloomFilterHeader& other175) noexcept {
-  numBytes = other175.numBytes;
-  algorithm = other175.algorithm;
-  hash = other175.hash;
-  compression = other175.compression;
+BloomFilterHeader::BloomFilterHeader(const BloomFilterHeader& other101) noexcept {
+  numBytes = other101.numBytes;
+  algorithm = other101.algorithm;
+  hash = other101.hash;
+  compression = other101.compression;
 }
-BloomFilterHeader::BloomFilterHeader(BloomFilterHeader&& other176) noexcept {
-  numBytes = other176.numBytes;
-  algorithm = std::move(other176.algorithm);
-  hash = std::move(other176.hash);
-  compression = std::move(other176.compression);
-}
-BloomFilterHeader& BloomFilterHeader::operator=(const BloomFilterHeader& other177) noexcept {
-  numBytes = other177.numBytes;
-  algorithm = other177.algorithm;
-  hash = other177.hash;
-  compression = other177.compression;
-  return *this;
-}
-BloomFilterHeader& BloomFilterHeader::operator=(BloomFilterHeader&& other178) noexcept {
-  numBytes = other178.numBytes;
-  algorithm = std::move(other178.algorithm);
-  hash = std::move(other178.hash);
-  compression = std::move(other178.compression);
+BloomFilterHeader& BloomFilterHeader::operator=(const BloomFilterHeader& other102) noexcept {
+  numBytes = other102.numBytes;
+  algorithm = other102.algorithm;
+  hash = other102.hash;
+  compression = other102.compression;
   return *this;
 }
 void BloomFilterHeader::printTo(std::ostream& out) const {
@@ -3633,50 +3205,27 @@ bool PageHeader::operator==(const PageHeader & rhs) const
   return true;
 }
 
-PageHeader::PageHeader(const PageHeader& other180) {
-  type = other180.type;
-  uncompressed_page_size = other180.uncompressed_page_size;
-  compressed_page_size = other180.compressed_page_size;
-  crc = other180.crc;
-  data_page_header = other180.data_page_header;
-  index_page_header = other180.index_page_header;
-  dictionary_page_header = other180.dictionary_page_header;
-  data_page_header_v2 = other180.data_page_header_v2;
-  __isset = other180.__isset;
+PageHeader::PageHeader(const PageHeader& other104) {
+  type = other104.type;
+  uncompressed_page_size = other104.uncompressed_page_size;
+  compressed_page_size = other104.compressed_page_size;
+  crc = other104.crc;
+  data_page_header = other104.data_page_header;
+  index_page_header = other104.index_page_header;
+  dictionary_page_header = other104.dictionary_page_header;
+  data_page_header_v2 = other104.data_page_header_v2;
+  __isset = other104.__isset;
 }
-PageHeader::PageHeader(PageHeader&& other181) noexcept {
-  type = other181.type;
-  uncompressed_page_size = other181.uncompressed_page_size;
-  compressed_page_size = other181.compressed_page_size;
-  crc = other181.crc;
-  data_page_header = std::move(other181.data_page_header);
-  index_page_header = std::move(other181.index_page_header);
-  dictionary_page_header = std::move(other181.dictionary_page_header);
-  data_page_header_v2 = std::move(other181.data_page_header_v2);
-  __isset = other181.__isset;
-}
-PageHeader& PageHeader::operator=(const PageHeader& other182) {
-  type = other182.type;
-  uncompressed_page_size = other182.uncompressed_page_size;
-  compressed_page_size = other182.compressed_page_size;
-  crc = other182.crc;
-  data_page_header = other182.data_page_header;
-  index_page_header = other182.index_page_header;
-  dictionary_page_header = other182.dictionary_page_header;
-  data_page_header_v2 = other182.data_page_header_v2;
-  __isset = other182.__isset;
-  return *this;
-}
-PageHeader& PageHeader::operator=(PageHeader&& other183) noexcept {
-  type = other183.type;
-  uncompressed_page_size = other183.uncompressed_page_size;
-  compressed_page_size = other183.compressed_page_size;
-  crc = other183.crc;
-  data_page_header = std::move(other183.data_page_header);
-  index_page_header = std::move(other183.index_page_header);
-  dictionary_page_header = std::move(other183.dictionary_page_header);
-  data_page_header_v2 = std::move(other183.data_page_header_v2);
-  __isset = other183.__isset;
+PageHeader& PageHeader::operator=(const PageHeader& other105) {
+  type = other105.type;
+  uncompressed_page_size = other105.uncompressed_page_size;
+  compressed_page_size = other105.compressed_page_size;
+  crc = other105.crc;
+  data_page_header = other105.data_page_header;
+  index_page_header = other105.index_page_header;
+  dictionary_page_header = other105.dictionary_page_header;
+  data_page_header_v2 = other105.data_page_header_v2;
+  __isset = other105.__isset;
   return *this;
 }
 void PageHeader::printTo(std::ostream& out) const {
@@ -3735,26 +3284,15 @@ bool KeyValue::operator==(const KeyValue & rhs) const
   return true;
 }
 
-KeyValue::KeyValue(const KeyValue& other184) {
-  key = other184.key;
-  value = other184.value;
-  __isset = other184.__isset;
+KeyValue::KeyValue(const KeyValue& other106) {
+  key = other106.key;
+  value = other106.value;
+  __isset = other106.__isset;
 }
-KeyValue::KeyValue(KeyValue&& other185) noexcept {
-  key = std::move(other185.key);
-  value = std::move(other185.value);
-  __isset = other185.__isset;
-}
-KeyValue& KeyValue::operator=(const KeyValue& other186) {
-  key = other186.key;
-  value = other186.value;
-  __isset = other186.__isset;
-  return *this;
-}
-KeyValue& KeyValue::operator=(KeyValue&& other187) noexcept {
-  key = std::move(other187.key);
-  value = std::move(other187.value);
-  __isset = other187.__isset;
+KeyValue& KeyValue::operator=(const KeyValue& other107) {
+  key = other107.key;
+  value = other107.value;
+  __isset = other107.__isset;
   return *this;
 }
 void KeyValue::printTo(std::ostream& out) const {
@@ -3811,26 +3349,15 @@ bool SortingColumn::operator==(const SortingColumn & rhs) const
   return true;
 }
 
-SortingColumn::SortingColumn(const SortingColumn& other188) noexcept {
-  column_idx = other188.column_idx;
-  descending = other188.descending;
-  nulls_first = other188.nulls_first;
+SortingColumn::SortingColumn(const SortingColumn& other108) noexcept {
+  column_idx = other108.column_idx;
+  descending = other108.descending;
+  nulls_first = other108.nulls_first;
 }
-SortingColumn::SortingColumn(SortingColumn&& other189) noexcept {
-  column_idx = other189.column_idx;
-  descending = other189.descending;
-  nulls_first = other189.nulls_first;
-}
-SortingColumn& SortingColumn::operator=(const SortingColumn& other190) noexcept {
-  column_idx = other190.column_idx;
-  descending = other190.descending;
-  nulls_first = other190.nulls_first;
-  return *this;
-}
-SortingColumn& SortingColumn::operator=(SortingColumn&& other191) noexcept {
-  column_idx = other191.column_idx;
-  descending = other191.descending;
-  nulls_first = other191.nulls_first;
+SortingColumn& SortingColumn::operator=(const SortingColumn& other109) noexcept {
+  column_idx = other109.column_idx;
+  descending = other109.descending;
+  nulls_first = other109.nulls_first;
   return *this;
 }
 void SortingColumn::printTo(std::ostream& out) const {
@@ -3888,26 +3415,15 @@ bool PageEncodingStats::operator==(const PageEncodingStats & rhs) const
   return true;
 }
 
-PageEncodingStats::PageEncodingStats(const PageEncodingStats& other194) noexcept {
-  page_type = other194.page_type;
-  encoding = other194.encoding;
-  count = other194.count;
+PageEncodingStats::PageEncodingStats(const PageEncodingStats& other112) noexcept {
+  page_type = other112.page_type;
+  encoding = other112.encoding;
+  count = other112.count;
 }
-PageEncodingStats::PageEncodingStats(PageEncodingStats&& other195) noexcept {
-  page_type = other195.page_type;
-  encoding = other195.encoding;
-  count = other195.count;
-}
-PageEncodingStats& PageEncodingStats::operator=(const PageEncodingStats& other196) noexcept {
-  page_type = other196.page_type;
-  encoding = other196.encoding;
-  count = other196.count;
-  return *this;
-}
-PageEncodingStats& PageEncodingStats::operator=(PageEncodingStats&& other197) noexcept {
-  page_type = other197.page_type;
-  encoding = other197.encoding;
-  count = other197.count;
+PageEncodingStats& PageEncodingStats::operator=(const PageEncodingStats& other113) noexcept {
+  page_type = other113.page_type;
+  encoding = other113.encoding;
+  count = other113.count;
   return *this;
 }
 void PageEncodingStats::printTo(std::ostream& out) const {
@@ -4098,86 +3614,45 @@ bool ColumnMetaData::operator==(const ColumnMetaData & rhs) const
   return true;
 }
 
-ColumnMetaData::ColumnMetaData(const ColumnMetaData& other225) {
-  type = other225.type;
-  encodings = other225.encodings;
-  path_in_schema = other225.path_in_schema;
-  codec = other225.codec;
-  num_values = other225.num_values;
-  total_uncompressed_size = other225.total_uncompressed_size;
-  total_compressed_size = other225.total_compressed_size;
-  key_value_metadata = other225.key_value_metadata;
-  data_page_offset = other225.data_page_offset;
-  index_page_offset = other225.index_page_offset;
-  dictionary_page_offset = other225.dictionary_page_offset;
-  statistics = other225.statistics;
-  encoding_stats = other225.encoding_stats;
-  bloom_filter_offset = other225.bloom_filter_offset;
-  bloom_filter_length = other225.bloom_filter_length;
-  size_statistics = other225.size_statistics;
-  geospatial_statistics = other225.geospatial_statistics;
-  __isset = other225.__isset;
+ColumnMetaData::ColumnMetaData(const ColumnMetaData& other141) {
+  type = other141.type;
+  encodings = other141.encodings;
+  path_in_schema = other141.path_in_schema;
+  codec = other141.codec;
+  num_values = other141.num_values;
+  total_uncompressed_size = other141.total_uncompressed_size;
+  total_compressed_size = other141.total_compressed_size;
+  key_value_metadata = other141.key_value_metadata;
+  data_page_offset = other141.data_page_offset;
+  index_page_offset = other141.index_page_offset;
+  dictionary_page_offset = other141.dictionary_page_offset;
+  statistics = other141.statistics;
+  encoding_stats = other141.encoding_stats;
+  bloom_filter_offset = other141.bloom_filter_offset;
+  bloom_filter_length = other141.bloom_filter_length;
+  size_statistics = other141.size_statistics;
+  geospatial_statistics = other141.geospatial_statistics;
+  __isset = other141.__isset;
 }
-ColumnMetaData::ColumnMetaData(ColumnMetaData&& other226) noexcept {
-  type = other226.type;
-  encodings = std::move(other226.encodings);
-  path_in_schema = std::move(other226.path_in_schema);
-  codec = other226.codec;
-  num_values = other226.num_values;
-  total_uncompressed_size = other226.total_uncompressed_size;
-  total_compressed_size = other226.total_compressed_size;
-  key_value_metadata = std::move(other226.key_value_metadata);
-  data_page_offset = other226.data_page_offset;
-  index_page_offset = other226.index_page_offset;
-  dictionary_page_offset = other226.dictionary_page_offset;
-  statistics = std::move(other226.statistics);
-  encoding_stats = std::move(other226.encoding_stats);
-  bloom_filter_offset = other226.bloom_filter_offset;
-  bloom_filter_length = other226.bloom_filter_length;
-  size_statistics = std::move(other226.size_statistics);
-  geospatial_statistics = std::move(other226.geospatial_statistics);
-  __isset = other226.__isset;
-}
-ColumnMetaData& ColumnMetaData::operator=(const ColumnMetaData& other227) {
-  type = other227.type;
-  encodings = other227.encodings;
-  path_in_schema = other227.path_in_schema;
-  codec = other227.codec;
-  num_values = other227.num_values;
-  total_uncompressed_size = other227.total_uncompressed_size;
-  total_compressed_size = other227.total_compressed_size;
-  key_value_metadata = other227.key_value_metadata;
-  data_page_offset = other227.data_page_offset;
-  index_page_offset = other227.index_page_offset;
-  dictionary_page_offset = other227.dictionary_page_offset;
-  statistics = other227.statistics;
-  encoding_stats = other227.encoding_stats;
-  bloom_filter_offset = other227.bloom_filter_offset;
-  bloom_filter_length = other227.bloom_filter_length;
-  size_statistics = other227.size_statistics;
-  geospatial_statistics = other227.geospatial_statistics;
-  __isset = other227.__isset;
-  return *this;
-}
-ColumnMetaData& ColumnMetaData::operator=(ColumnMetaData&& other228) noexcept {
-  type = other228.type;
-  encodings = std::move(other228.encodings);
-  path_in_schema = std::move(other228.path_in_schema);
-  codec = other228.codec;
-  num_values = other228.num_values;
-  total_uncompressed_size = other228.total_uncompressed_size;
-  total_compressed_size = other228.total_compressed_size;
-  key_value_metadata = std::move(other228.key_value_metadata);
-  data_page_offset = other228.data_page_offset;
-  index_page_offset = other228.index_page_offset;
-  dictionary_page_offset = other228.dictionary_page_offset;
-  statistics = std::move(other228.statistics);
-  encoding_stats = std::move(other228.encoding_stats);
-  bloom_filter_offset = other228.bloom_filter_offset;
-  bloom_filter_length = other228.bloom_filter_length;
-  size_statistics = std::move(other228.size_statistics);
-  geospatial_statistics = std::move(other228.geospatial_statistics);
-  __isset = other228.__isset;
+ColumnMetaData& ColumnMetaData::operator=(const ColumnMetaData& other142) {
+  type = other142.type;
+  encodings = other142.encodings;
+  path_in_schema = other142.path_in_schema;
+  codec = other142.codec;
+  num_values = other142.num_values;
+  total_uncompressed_size = other142.total_uncompressed_size;
+  total_compressed_size = other142.total_compressed_size;
+  key_value_metadata = other142.key_value_metadata;
+  data_page_offset = other142.data_page_offset;
+  index_page_offset = other142.index_page_offset;
+  dictionary_page_offset = other142.dictionary_page_offset;
+  statistics = other142.statistics;
+  encoding_stats = other142.encoding_stats;
+  bloom_filter_offset = other142.bloom_filter_offset;
+  bloom_filter_length = other142.bloom_filter_length;
+  size_statistics = other142.size_statistics;
+  geospatial_statistics = other142.geospatial_statistics;
+  __isset = other142.__isset;
   return *this;
 }
 void ColumnMetaData::printTo(std::ostream& out) const {
@@ -4227,18 +3702,11 @@ bool EncryptionWithFooterKey::operator==(const EncryptionWithFooterKey & /* rhs 
   return true;
 }
 
-EncryptionWithFooterKey::EncryptionWithFooterKey(const EncryptionWithFooterKey& other229) noexcept {
-  (void) other229;
+EncryptionWithFooterKey::EncryptionWithFooterKey(const EncryptionWithFooterKey& other143) noexcept {
+  (void) other143;
 }
-EncryptionWithFooterKey::EncryptionWithFooterKey(EncryptionWithFooterKey&& other230) noexcept {
-  (void) other230;
-}
-EncryptionWithFooterKey& EncryptionWithFooterKey::operator=(const EncryptionWithFooterKey& other231) noexcept {
-  (void) other231;
-  return *this;
-}
-EncryptionWithFooterKey& EncryptionWithFooterKey::operator=(EncryptionWithFooterKey&& other232) noexcept {
-  (void) other232;
+EncryptionWithFooterKey& EncryptionWithFooterKey::operator=(const EncryptionWithFooterKey& other144) noexcept {
+  (void) other144;
   return *this;
 }
 void EncryptionWithFooterKey::printTo(std::ostream& out) const {
@@ -4288,26 +3756,15 @@ bool EncryptionWithColumnKey::operator==(const EncryptionWithColumnKey & rhs) co
   return true;
 }
 
-EncryptionWithColumnKey::EncryptionWithColumnKey(const EncryptionWithColumnKey& other239) {
-  path_in_schema = other239.path_in_schema;
-  key_metadata = other239.key_metadata;
-  __isset = other239.__isset;
+EncryptionWithColumnKey::EncryptionWithColumnKey(const EncryptionWithColumnKey& other151) {
+  path_in_schema = other151.path_in_schema;
+  key_metadata = other151.key_metadata;
+  __isset = other151.__isset;
 }
-EncryptionWithColumnKey::EncryptionWithColumnKey(EncryptionWithColumnKey&& other240) noexcept {
-  path_in_schema = std::move(other240.path_in_schema);
-  key_metadata = std::move(other240.key_metadata);
-  __isset = other240.__isset;
-}
-EncryptionWithColumnKey& EncryptionWithColumnKey::operator=(const EncryptionWithColumnKey& other241) {
-  path_in_schema = other241.path_in_schema;
-  key_metadata = other241.key_metadata;
-  __isset = other241.__isset;
-  return *this;
-}
-EncryptionWithColumnKey& EncryptionWithColumnKey::operator=(EncryptionWithColumnKey&& other242) noexcept {
-  path_in_schema = std::move(other242.path_in_schema);
-  key_metadata = std::move(other242.key_metadata);
-  __isset = other242.__isset;
+EncryptionWithColumnKey& EncryptionWithColumnKey::operator=(const EncryptionWithColumnKey& other152) {
+  path_in_schema = other152.path_in_schema;
+  key_metadata = other152.key_metadata;
+  __isset = other152.__isset;
   return *this;
 }
 void EncryptionWithColumnKey::printTo(std::ostream& out) const {
@@ -4361,26 +3818,15 @@ bool ColumnCryptoMetaData::operator==(const ColumnCryptoMetaData & rhs) const
   return true;
 }
 
-ColumnCryptoMetaData::ColumnCryptoMetaData(const ColumnCryptoMetaData& other243) {
-  ENCRYPTION_WITH_FOOTER_KEY = other243.ENCRYPTION_WITH_FOOTER_KEY;
-  ENCRYPTION_WITH_COLUMN_KEY = other243.ENCRYPTION_WITH_COLUMN_KEY;
-  __isset = other243.__isset;
+ColumnCryptoMetaData::ColumnCryptoMetaData(const ColumnCryptoMetaData& other153) {
+  ENCRYPTION_WITH_FOOTER_KEY = other153.ENCRYPTION_WITH_FOOTER_KEY;
+  ENCRYPTION_WITH_COLUMN_KEY = other153.ENCRYPTION_WITH_COLUMN_KEY;
+  __isset = other153.__isset;
 }
-ColumnCryptoMetaData::ColumnCryptoMetaData(ColumnCryptoMetaData&& other244) noexcept {
-  ENCRYPTION_WITH_FOOTER_KEY = std::move(other244.ENCRYPTION_WITH_FOOTER_KEY);
-  ENCRYPTION_WITH_COLUMN_KEY = std::move(other244.ENCRYPTION_WITH_COLUMN_KEY);
-  __isset = other244.__isset;
-}
-ColumnCryptoMetaData& ColumnCryptoMetaData::operator=(const ColumnCryptoMetaData& other245) {
-  ENCRYPTION_WITH_FOOTER_KEY = other245.ENCRYPTION_WITH_FOOTER_KEY;
-  ENCRYPTION_WITH_COLUMN_KEY = other245.ENCRYPTION_WITH_COLUMN_KEY;
-  __isset = other245.__isset;
-  return *this;
-}
-ColumnCryptoMetaData& ColumnCryptoMetaData::operator=(ColumnCryptoMetaData&& other246) noexcept {
-  ENCRYPTION_WITH_FOOTER_KEY = std::move(other246.ENCRYPTION_WITH_FOOTER_KEY);
-  ENCRYPTION_WITH_COLUMN_KEY = std::move(other246.ENCRYPTION_WITH_COLUMN_KEY);
-  __isset = other246.__isset;
+ColumnCryptoMetaData& ColumnCryptoMetaData::operator=(const ColumnCryptoMetaData& other154) {
+  ENCRYPTION_WITH_FOOTER_KEY = other154.ENCRYPTION_WITH_FOOTER_KEY;
+  ENCRYPTION_WITH_COLUMN_KEY = other154.ENCRYPTION_WITH_COLUMN_KEY;
+  __isset = other154.__isset;
   return *this;
 }
 void ColumnCryptoMetaData::printTo(std::ostream& out) const {
@@ -4508,54 +3954,29 @@ bool ColumnChunk::operator==(const ColumnChunk & rhs) const
   return true;
 }
 
-ColumnChunk::ColumnChunk(const ColumnChunk& other247) {
-  file_path = other247.file_path;
-  file_offset = other247.file_offset;
-  meta_data = other247.meta_data;
-  offset_index_offset = other247.offset_index_offset;
-  offset_index_length = other247.offset_index_length;
-  column_index_offset = other247.column_index_offset;
-  column_index_length = other247.column_index_length;
-  crypto_metadata = other247.crypto_metadata;
-  encrypted_column_metadata = other247.encrypted_column_metadata;
-  __isset = other247.__isset;
+ColumnChunk::ColumnChunk(const ColumnChunk& other155) {
+  file_path = other155.file_path;
+  file_offset = other155.file_offset;
+  meta_data = other155.meta_data;
+  offset_index_offset = other155.offset_index_offset;
+  offset_index_length = other155.offset_index_length;
+  column_index_offset = other155.column_index_offset;
+  column_index_length = other155.column_index_length;
+  crypto_metadata = other155.crypto_metadata;
+  encrypted_column_metadata = other155.encrypted_column_metadata;
+  __isset = other155.__isset;
 }
-ColumnChunk::ColumnChunk(ColumnChunk&& other248) noexcept {
-  file_path = std::move(other248.file_path);
-  file_offset = other248.file_offset;
-  meta_data = std::move(other248.meta_data);
-  offset_index_offset = other248.offset_index_offset;
-  offset_index_length = other248.offset_index_length;
-  column_index_offset = other248.column_index_offset;
-  column_index_length = other248.column_index_length;
-  crypto_metadata = std::move(other248.crypto_metadata);
-  encrypted_column_metadata = std::move(other248.encrypted_column_metadata);
-  __isset = other248.__isset;
-}
-ColumnChunk& ColumnChunk::operator=(const ColumnChunk& other249) {
-  file_path = other249.file_path;
-  file_offset = other249.file_offset;
-  meta_data = other249.meta_data;
-  offset_index_offset = other249.offset_index_offset;
-  offset_index_length = other249.offset_index_length;
-  column_index_offset = other249.column_index_offset;
-  column_index_length = other249.column_index_length;
-  crypto_metadata = other249.crypto_metadata;
-  encrypted_column_metadata = other249.encrypted_column_metadata;
-  __isset = other249.__isset;
-  return *this;
-}
-ColumnChunk& ColumnChunk::operator=(ColumnChunk&& other250) noexcept {
-  file_path = std::move(other250.file_path);
-  file_offset = other250.file_offset;
-  meta_data = std::move(other250.meta_data);
-  offset_index_offset = other250.offset_index_offset;
-  offset_index_length = other250.offset_index_length;
-  column_index_offset = other250.column_index_offset;
-  column_index_length = other250.column_index_length;
-  crypto_metadata = std::move(other250.crypto_metadata);
-  encrypted_column_metadata = std::move(other250.encrypted_column_metadata);
-  __isset = other250.__isset;
+ColumnChunk& ColumnChunk::operator=(const ColumnChunk& other156) {
+  file_path = other156.file_path;
+  file_offset = other156.file_offset;
+  meta_data = other156.meta_data;
+  offset_index_offset = other156.offset_index_offset;
+  offset_index_length = other156.offset_index_length;
+  column_index_offset = other156.column_index_offset;
+  column_index_length = other156.column_index_length;
+  crypto_metadata = other156.crypto_metadata;
+  encrypted_column_metadata = other156.encrypted_column_metadata;
+  __isset = other156.__isset;
   return *this;
 }
 void ColumnChunk::printTo(std::ostream& out) const {
@@ -4662,46 +4083,25 @@ bool RowGroup::operator==(const RowGroup & rhs) const
   return true;
 }
 
-RowGroup::RowGroup(const RowGroup& other263) {
-  columns = other263.columns;
-  total_byte_size = other263.total_byte_size;
-  num_rows = other263.num_rows;
-  sorting_columns = other263.sorting_columns;
-  file_offset = other263.file_offset;
-  total_compressed_size = other263.total_compressed_size;
-  ordinal = other263.ordinal;
-  __isset = other263.__isset;
+RowGroup::RowGroup(const RowGroup& other169) {
+  columns = other169.columns;
+  total_byte_size = other169.total_byte_size;
+  num_rows = other169.num_rows;
+  sorting_columns = other169.sorting_columns;
+  file_offset = other169.file_offset;
+  total_compressed_size = other169.total_compressed_size;
+  ordinal = other169.ordinal;
+  __isset = other169.__isset;
 }
-RowGroup::RowGroup(RowGroup&& other264) noexcept {
-  columns = std::move(other264.columns);
-  total_byte_size = other264.total_byte_size;
-  num_rows = other264.num_rows;
-  sorting_columns = std::move(other264.sorting_columns);
-  file_offset = other264.file_offset;
-  total_compressed_size = other264.total_compressed_size;
-  ordinal = other264.ordinal;
-  __isset = other264.__isset;
-}
-RowGroup& RowGroup::operator=(const RowGroup& other265) {
-  columns = other265.columns;
-  total_byte_size = other265.total_byte_size;
-  num_rows = other265.num_rows;
-  sorting_columns = other265.sorting_columns;
-  file_offset = other265.file_offset;
-  total_compressed_size = other265.total_compressed_size;
-  ordinal = other265.ordinal;
-  __isset = other265.__isset;
-  return *this;
-}
-RowGroup& RowGroup::operator=(RowGroup&& other266) noexcept {
-  columns = std::move(other266.columns);
-  total_byte_size = other266.total_byte_size;
-  num_rows = other266.num_rows;
-  sorting_columns = std::move(other266.sorting_columns);
-  file_offset = other266.file_offset;
-  total_compressed_size = other266.total_compressed_size;
-  ordinal = other266.ordinal;
-  __isset = other266.__isset;
+RowGroup& RowGroup::operator=(const RowGroup& other170) {
+  columns = other170.columns;
+  total_byte_size = other170.total_byte_size;
+  num_rows = other170.num_rows;
+  sorting_columns = other170.sorting_columns;
+  file_offset = other170.file_offset;
+  total_compressed_size = other170.total_compressed_size;
+  ordinal = other170.ordinal;
+  __isset = other170.__isset;
   return *this;
 }
 void RowGroup::printTo(std::ostream& out) const {
@@ -4741,18 +4141,11 @@ bool TypeDefinedOrder::operator==(const TypeDefinedOrder & /* rhs */) const
   return true;
 }
 
-TypeDefinedOrder::TypeDefinedOrder(const TypeDefinedOrder& other267) noexcept {
-  (void) other267;
+TypeDefinedOrder::TypeDefinedOrder(const TypeDefinedOrder& other171) noexcept {
+  (void) other171;
 }
-TypeDefinedOrder::TypeDefinedOrder(TypeDefinedOrder&& other268) noexcept {
-  (void) other268;
-}
-TypeDefinedOrder& TypeDefinedOrder::operator=(const TypeDefinedOrder& other269) noexcept {
-  (void) other269;
-  return *this;
-}
-TypeDefinedOrder& TypeDefinedOrder::operator=(TypeDefinedOrder&& other270) noexcept {
-  (void) other270;
+TypeDefinedOrder& TypeDefinedOrder::operator=(const TypeDefinedOrder& other172) noexcept {
+  (void) other172;
   return *this;
 }
 void TypeDefinedOrder::printTo(std::ostream& out) const {
@@ -4794,22 +4187,13 @@ bool ColumnOrder::operator==(const ColumnOrder & rhs) const
   return true;
 }
 
-ColumnOrder::ColumnOrder(const ColumnOrder& other271) noexcept {
-  TYPE_ORDER = other271.TYPE_ORDER;
-  __isset = other271.__isset;
+ColumnOrder::ColumnOrder(const ColumnOrder& other173) noexcept {
+  TYPE_ORDER = other173.TYPE_ORDER;
+  __isset = other173.__isset;
 }
-ColumnOrder::ColumnOrder(ColumnOrder&& other272) noexcept {
-  TYPE_ORDER = std::move(other272.TYPE_ORDER);
-  __isset = other272.__isset;
-}
-ColumnOrder& ColumnOrder::operator=(const ColumnOrder& other273) noexcept {
-  TYPE_ORDER = other273.TYPE_ORDER;
-  __isset = other273.__isset;
-  return *this;
-}
-ColumnOrder& ColumnOrder::operator=(ColumnOrder&& other274) noexcept {
-  TYPE_ORDER = std::move(other274.TYPE_ORDER);
-  __isset = other274.__isset;
+ColumnOrder& ColumnOrder::operator=(const ColumnOrder& other174) noexcept {
+  TYPE_ORDER = other174.TYPE_ORDER;
+  __isset = other174.__isset;
   return *this;
 }
 void ColumnOrder::printTo(std::ostream& out) const {
@@ -4865,26 +4249,15 @@ bool PageLocation::operator==(const PageLocation & rhs) const
   return true;
 }
 
-PageLocation::PageLocation(const PageLocation& other275) noexcept {
-  offset = other275.offset;
-  compressed_page_size = other275.compressed_page_size;
-  first_row_index = other275.first_row_index;
+PageLocation::PageLocation(const PageLocation& other175) noexcept {
+  offset = other175.offset;
+  compressed_page_size = other175.compressed_page_size;
+  first_row_index = other175.first_row_index;
 }
-PageLocation::PageLocation(PageLocation&& other276) noexcept {
-  offset = other276.offset;
-  compressed_page_size = other276.compressed_page_size;
-  first_row_index = other276.first_row_index;
-}
-PageLocation& PageLocation::operator=(const PageLocation& other277) noexcept {
-  offset = other277.offset;
-  compressed_page_size = other277.compressed_page_size;
-  first_row_index = other277.first_row_index;
-  return *this;
-}
-PageLocation& PageLocation::operator=(PageLocation&& other278) noexcept {
-  offset = other278.offset;
-  compressed_page_size = other278.compressed_page_size;
-  first_row_index = other278.first_row_index;
+PageLocation& PageLocation::operator=(const PageLocation& other176) noexcept {
+  offset = other176.offset;
+  compressed_page_size = other176.compressed_page_size;
+  first_row_index = other176.first_row_index;
   return *this;
 }
 void PageLocation::printTo(std::ostream& out) const {
@@ -4936,26 +4309,15 @@ bool OffsetIndex::operator==(const OffsetIndex & rhs) const
   return true;
 }
 
-OffsetIndex::OffsetIndex(const OffsetIndex& other291) {
-  page_locations = other291.page_locations;
-  unencoded_byte_array_data_bytes = other291.unencoded_byte_array_data_bytes;
-  __isset = other291.__isset;
+OffsetIndex::OffsetIndex(const OffsetIndex& other189) {
+  page_locations = other189.page_locations;
+  unencoded_byte_array_data_bytes = other189.unencoded_byte_array_data_bytes;
+  __isset = other189.__isset;
 }
-OffsetIndex::OffsetIndex(OffsetIndex&& other292) noexcept {
-  page_locations = std::move(other292.page_locations);
-  unencoded_byte_array_data_bytes = std::move(other292.unencoded_byte_array_data_bytes);
-  __isset = other292.__isset;
-}
-OffsetIndex& OffsetIndex::operator=(const OffsetIndex& other293) {
-  page_locations = other293.page_locations;
-  unencoded_byte_array_data_bytes = other293.unencoded_byte_array_data_bytes;
-  __isset = other293.__isset;
-  return *this;
-}
-OffsetIndex& OffsetIndex::operator=(OffsetIndex&& other294) noexcept {
-  page_locations = std::move(other294.page_locations);
-  unencoded_byte_array_data_bytes = std::move(other294.unencoded_byte_array_data_bytes);
-  __isset = other294.__isset;
+OffsetIndex& OffsetIndex::operator=(const OffsetIndex& other190) {
+  page_locations = other190.page_locations;
+  unencoded_byte_array_data_bytes = other190.unencoded_byte_array_data_bytes;
+  __isset = other190.__isset;
   return *this;
 }
 void OffsetIndex::printTo(std::ostream& out) const {
@@ -5048,46 +4410,25 @@ bool ColumnIndex::operator==(const ColumnIndex & rhs) const
   return true;
 }
 
-ColumnIndex::ColumnIndex(const ColumnIndex& other332) {
-  null_pages = other332.null_pages;
-  min_values = other332.min_values;
-  max_values = other332.max_values;
-  boundary_order = other332.boundary_order;
-  null_counts = other332.null_counts;
-  repetition_level_histograms = other332.repetition_level_histograms;
-  definition_level_histograms = other332.definition_level_histograms;
-  __isset = other332.__isset;
+ColumnIndex::ColumnIndex(const ColumnIndex& other228) {
+  null_pages = other228.null_pages;
+  min_values = other228.min_values;
+  max_values = other228.max_values;
+  boundary_order = other228.boundary_order;
+  null_counts = other228.null_counts;
+  repetition_level_histograms = other228.repetition_level_histograms;
+  definition_level_histograms = other228.definition_level_histograms;
+  __isset = other228.__isset;
 }
-ColumnIndex::ColumnIndex(ColumnIndex&& other333) noexcept {
-  null_pages = std::move(other333.null_pages);
-  min_values = std::move(other333.min_values);
-  max_values = std::move(other333.max_values);
-  boundary_order = other333.boundary_order;
-  null_counts = std::move(other333.null_counts);
-  repetition_level_histograms = std::move(other333.repetition_level_histograms);
-  definition_level_histograms = std::move(other333.definition_level_histograms);
-  __isset = other333.__isset;
-}
-ColumnIndex& ColumnIndex::operator=(const ColumnIndex& other334) {
-  null_pages = other334.null_pages;
-  min_values = other334.min_values;
-  max_values = other334.max_values;
-  boundary_order = other334.boundary_order;
-  null_counts = other334.null_counts;
-  repetition_level_histograms = other334.repetition_level_histograms;
-  definition_level_histograms = other334.definition_level_histograms;
-  __isset = other334.__isset;
-  return *this;
-}
-ColumnIndex& ColumnIndex::operator=(ColumnIndex&& other335) noexcept {
-  null_pages = std::move(other335.null_pages);
-  min_values = std::move(other335.min_values);
-  max_values = std::move(other335.max_values);
-  boundary_order = other335.boundary_order;
-  null_counts = std::move(other335.null_counts);
-  repetition_level_histograms = std::move(other335.repetition_level_histograms);
-  definition_level_histograms = std::move(other335.definition_level_histograms);
-  __isset = other335.__isset;
+ColumnIndex& ColumnIndex::operator=(const ColumnIndex& other229) {
+  null_pages = other229.null_pages;
+  min_values = other229.min_values;
+  max_values = other229.max_values;
+  boundary_order = other229.boundary_order;
+  null_counts = other229.null_counts;
+  repetition_level_histograms = other229.repetition_level_histograms;
+  definition_level_histograms = other229.definition_level_histograms;
+  __isset = other229.__isset;
   return *this;
 }
 void ColumnIndex::printTo(std::ostream& out) const {
@@ -5159,30 +4500,17 @@ bool AesGcmV1::operator==(const AesGcmV1 & rhs) const
   return true;
 }
 
-AesGcmV1::AesGcmV1(const AesGcmV1& other336) {
-  aad_prefix = other336.aad_prefix;
-  aad_file_unique = other336.aad_file_unique;
-  supply_aad_prefix = other336.supply_aad_prefix;
-  __isset = other336.__isset;
+AesGcmV1::AesGcmV1(const AesGcmV1& other230) {
+  aad_prefix = other230.aad_prefix;
+  aad_file_unique = other230.aad_file_unique;
+  supply_aad_prefix = other230.supply_aad_prefix;
+  __isset = other230.__isset;
 }
-AesGcmV1::AesGcmV1(AesGcmV1&& other337) noexcept {
-  aad_prefix = std::move(other337.aad_prefix);
-  aad_file_unique = std::move(other337.aad_file_unique);
-  supply_aad_prefix = other337.supply_aad_prefix;
-  __isset = other337.__isset;
-}
-AesGcmV1& AesGcmV1::operator=(const AesGcmV1& other338) {
-  aad_prefix = other338.aad_prefix;
-  aad_file_unique = other338.aad_file_unique;
-  supply_aad_prefix = other338.supply_aad_prefix;
-  __isset = other338.__isset;
-  return *this;
-}
-AesGcmV1& AesGcmV1::operator=(AesGcmV1&& other339) noexcept {
-  aad_prefix = std::move(other339.aad_prefix);
-  aad_file_unique = std::move(other339.aad_file_unique);
-  supply_aad_prefix = other339.supply_aad_prefix;
-  __isset = other339.__isset;
+AesGcmV1& AesGcmV1::operator=(const AesGcmV1& other231) {
+  aad_prefix = other231.aad_prefix;
+  aad_file_unique = other231.aad_file_unique;
+  supply_aad_prefix = other231.supply_aad_prefix;
+  __isset = other231.__isset;
   return *this;
 }
 void AesGcmV1::printTo(std::ostream& out) const {
@@ -5250,30 +4578,17 @@ bool AesGcmCtrV1::operator==(const AesGcmCtrV1 & rhs) const
   return true;
 }
 
-AesGcmCtrV1::AesGcmCtrV1(const AesGcmCtrV1& other340) {
-  aad_prefix = other340.aad_prefix;
-  aad_file_unique = other340.aad_file_unique;
-  supply_aad_prefix = other340.supply_aad_prefix;
-  __isset = other340.__isset;
+AesGcmCtrV1::AesGcmCtrV1(const AesGcmCtrV1& other232) {
+  aad_prefix = other232.aad_prefix;
+  aad_file_unique = other232.aad_file_unique;
+  supply_aad_prefix = other232.supply_aad_prefix;
+  __isset = other232.__isset;
 }
-AesGcmCtrV1::AesGcmCtrV1(AesGcmCtrV1&& other341) noexcept {
-  aad_prefix = std::move(other341.aad_prefix);
-  aad_file_unique = std::move(other341.aad_file_unique);
-  supply_aad_prefix = other341.supply_aad_prefix;
-  __isset = other341.__isset;
-}
-AesGcmCtrV1& AesGcmCtrV1::operator=(const AesGcmCtrV1& other342) {
-  aad_prefix = other342.aad_prefix;
-  aad_file_unique = other342.aad_file_unique;
-  supply_aad_prefix = other342.supply_aad_prefix;
-  __isset = other342.__isset;
-  return *this;
-}
-AesGcmCtrV1& AesGcmCtrV1::operator=(AesGcmCtrV1&& other343) noexcept {
-  aad_prefix = std::move(other343.aad_prefix);
-  aad_file_unique = std::move(other343.aad_file_unique);
-  supply_aad_prefix = other343.supply_aad_prefix;
-  __isset = other343.__isset;
+AesGcmCtrV1& AesGcmCtrV1::operator=(const AesGcmCtrV1& other233) {
+  aad_prefix = other233.aad_prefix;
+  aad_file_unique = other233.aad_file_unique;
+  supply_aad_prefix = other233.supply_aad_prefix;
+  __isset = other233.__isset;
   return *this;
 }
 void AesGcmCtrV1::printTo(std::ostream& out) const {
@@ -5282,6 +4597,43 @@ void AesGcmCtrV1::printTo(std::ostream& out) const {
   out << "aad_prefix="; (__isset.aad_prefix ? (out << to_string(aad_prefix)) : (out << "<null>"));
   out << ", " << "aad_file_unique="; (__isset.aad_file_unique ? (out << to_string(aad_file_unique)) : (out << "<null>"));
   out << ", " << "supply_aad_prefix="; (__isset.supply_aad_prefix ? (out << to_string(supply_aad_prefix)) : (out << "<null>"));
+  out << ")";
+}
+
+
+ExternalDBPAV1::~ExternalDBPAV1() noexcept {
+}
+
+ExternalDBPAV1::ExternalDBPAV1() noexcept {
+}
+std::ostream& operator<<(std::ostream& out, const ExternalDBPAV1& obj)
+{
+  obj.printTo(out);
+  return out;
+}
+
+
+void swap(ExternalDBPAV1 &a, ExternalDBPAV1 &b) {
+  using ::std::swap;
+  (void) a;
+  (void) b;
+}
+
+bool ExternalDBPAV1::operator==(const ExternalDBPAV1 & /* rhs */) const
+{
+  return true;
+}
+
+ExternalDBPAV1::ExternalDBPAV1(const ExternalDBPAV1& other234) noexcept {
+  (void) other234;
+}
+ExternalDBPAV1& ExternalDBPAV1::operator=(const ExternalDBPAV1& other235) noexcept {
+  (void) other235;
+  return *this;
+}
+void ExternalDBPAV1::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "ExternalDBPAV1(";
   out << ")";
 }
 
@@ -5301,6 +4653,11 @@ void EncryptionAlgorithm::__set_AES_GCM_CTR_V1(const AesGcmCtrV1& val) {
   this->AES_GCM_CTR_V1 = val;
 __isset.AES_GCM_CTR_V1 = true;
 }
+
+void EncryptionAlgorithm::__set_EXTERNAL_DBPA_V1(const ExternalDBPAV1& val) {
+  this->EXTERNAL_DBPA_V1 = val;
+__isset.EXTERNAL_DBPA_V1 = true;
+}
 std::ostream& operator<<(std::ostream& out, const EncryptionAlgorithm& obj)
 {
   obj.printTo(out);
@@ -5312,6 +4669,7 @@ void swap(EncryptionAlgorithm &a, EncryptionAlgorithm &b) {
   using ::std::swap;
   swap(a.AES_GCM_V1, b.AES_GCM_V1);
   swap(a.AES_GCM_CTR_V1, b.AES_GCM_CTR_V1);
+  swap(a.EXTERNAL_DBPA_V1, b.EXTERNAL_DBPA_V1);
   swap(a.__isset, b.__isset);
 }
 
@@ -5325,29 +4683,24 @@ bool EncryptionAlgorithm::operator==(const EncryptionAlgorithm & rhs) const
     return false;
   else if (__isset.AES_GCM_CTR_V1 && !(AES_GCM_CTR_V1 == rhs.AES_GCM_CTR_V1))
     return false;
+  if (__isset.EXTERNAL_DBPA_V1 != rhs.__isset.EXTERNAL_DBPA_V1)
+    return false;
+  else if (__isset.EXTERNAL_DBPA_V1 && !(EXTERNAL_DBPA_V1 == rhs.EXTERNAL_DBPA_V1))
+    return false;
   return true;
 }
 
-EncryptionAlgorithm::EncryptionAlgorithm(const EncryptionAlgorithm& other344) {
-  AES_GCM_V1 = other344.AES_GCM_V1;
-  AES_GCM_CTR_V1 = other344.AES_GCM_CTR_V1;
-  __isset = other344.__isset;
+EncryptionAlgorithm::EncryptionAlgorithm(const EncryptionAlgorithm& other236) {
+  AES_GCM_V1 = other236.AES_GCM_V1;
+  AES_GCM_CTR_V1 = other236.AES_GCM_CTR_V1;
+  EXTERNAL_DBPA_V1 = other236.EXTERNAL_DBPA_V1;
+  __isset = other236.__isset;
 }
-EncryptionAlgorithm::EncryptionAlgorithm(EncryptionAlgorithm&& other345) noexcept {
-  AES_GCM_V1 = std::move(other345.AES_GCM_V1);
-  AES_GCM_CTR_V1 = std::move(other345.AES_GCM_CTR_V1);
-  __isset = other345.__isset;
-}
-EncryptionAlgorithm& EncryptionAlgorithm::operator=(const EncryptionAlgorithm& other346) {
-  AES_GCM_V1 = other346.AES_GCM_V1;
-  AES_GCM_CTR_V1 = other346.AES_GCM_CTR_V1;
-  __isset = other346.__isset;
-  return *this;
-}
-EncryptionAlgorithm& EncryptionAlgorithm::operator=(EncryptionAlgorithm&& other347) noexcept {
-  AES_GCM_V1 = std::move(other347.AES_GCM_V1);
-  AES_GCM_CTR_V1 = std::move(other347.AES_GCM_CTR_V1);
-  __isset = other347.__isset;
+EncryptionAlgorithm& EncryptionAlgorithm::operator=(const EncryptionAlgorithm& other237) {
+  AES_GCM_V1 = other237.AES_GCM_V1;
+  AES_GCM_CTR_V1 = other237.AES_GCM_CTR_V1;
+  EXTERNAL_DBPA_V1 = other237.EXTERNAL_DBPA_V1;
+  __isset = other237.__isset;
   return *this;
 }
 void EncryptionAlgorithm::printTo(std::ostream& out) const {
@@ -5355,6 +4708,7 @@ void EncryptionAlgorithm::printTo(std::ostream& out) const {
   out << "EncryptionAlgorithm(";
   out << "AES_GCM_V1="; (__isset.AES_GCM_V1 ? (out << to_string(AES_GCM_V1)) : (out << "<null>"));
   out << ", " << "AES_GCM_CTR_V1="; (__isset.AES_GCM_CTR_V1 ? (out << to_string(AES_GCM_CTR_V1)) : (out << "<null>"));
+  out << ", " << "EXTERNAL_DBPA_V1="; (__isset.EXTERNAL_DBPA_V1 ? (out << to_string(EXTERNAL_DBPA_V1)) : (out << "<null>"));
   out << ")";
 }
 
@@ -5463,54 +4817,29 @@ bool FileMetaData::operator==(const FileMetaData & rhs) const
   return true;
 }
 
-FileMetaData::FileMetaData(const FileMetaData& other372) {
-  version = other372.version;
-  schema = other372.schema;
-  num_rows = other372.num_rows;
-  row_groups = other372.row_groups;
-  key_value_metadata = other372.key_value_metadata;
-  created_by = other372.created_by;
-  column_orders = other372.column_orders;
-  encryption_algorithm = other372.encryption_algorithm;
-  footer_signing_key_metadata = other372.footer_signing_key_metadata;
-  __isset = other372.__isset;
+FileMetaData::FileMetaData(const FileMetaData& other262) {
+  version = other262.version;
+  schema = other262.schema;
+  num_rows = other262.num_rows;
+  row_groups = other262.row_groups;
+  key_value_metadata = other262.key_value_metadata;
+  created_by = other262.created_by;
+  column_orders = other262.column_orders;
+  encryption_algorithm = other262.encryption_algorithm;
+  footer_signing_key_metadata = other262.footer_signing_key_metadata;
+  __isset = other262.__isset;
 }
-FileMetaData::FileMetaData(FileMetaData&& other373) noexcept {
-  version = other373.version;
-  schema = std::move(other373.schema);
-  num_rows = other373.num_rows;
-  row_groups = std::move(other373.row_groups);
-  key_value_metadata = std::move(other373.key_value_metadata);
-  created_by = std::move(other373.created_by);
-  column_orders = std::move(other373.column_orders);
-  encryption_algorithm = std::move(other373.encryption_algorithm);
-  footer_signing_key_metadata = std::move(other373.footer_signing_key_metadata);
-  __isset = other373.__isset;
-}
-FileMetaData& FileMetaData::operator=(const FileMetaData& other374) {
-  version = other374.version;
-  schema = other374.schema;
-  num_rows = other374.num_rows;
-  row_groups = other374.row_groups;
-  key_value_metadata = other374.key_value_metadata;
-  created_by = other374.created_by;
-  column_orders = other374.column_orders;
-  encryption_algorithm = other374.encryption_algorithm;
-  footer_signing_key_metadata = other374.footer_signing_key_metadata;
-  __isset = other374.__isset;
-  return *this;
-}
-FileMetaData& FileMetaData::operator=(FileMetaData&& other375) noexcept {
-  version = other375.version;
-  schema = std::move(other375.schema);
-  num_rows = other375.num_rows;
-  row_groups = std::move(other375.row_groups);
-  key_value_metadata = std::move(other375.key_value_metadata);
-  created_by = std::move(other375.created_by);
-  column_orders = std::move(other375.column_orders);
-  encryption_algorithm = std::move(other375.encryption_algorithm);
-  footer_signing_key_metadata = std::move(other375.footer_signing_key_metadata);
-  __isset = other375.__isset;
+FileMetaData& FileMetaData::operator=(const FileMetaData& other263) {
+  version = other263.version;
+  schema = other263.schema;
+  num_rows = other263.num_rows;
+  row_groups = other263.row_groups;
+  key_value_metadata = other263.key_value_metadata;
+  created_by = other263.created_by;
+  column_orders = other263.column_orders;
+  encryption_algorithm = other263.encryption_algorithm;
+  footer_signing_key_metadata = other263.footer_signing_key_metadata;
+  __isset = other263.__isset;
   return *this;
 }
 void FileMetaData::printTo(std::ostream& out) const {
@@ -5569,26 +4898,15 @@ bool FileCryptoMetaData::operator==(const FileCryptoMetaData & rhs) const
   return true;
 }
 
-FileCryptoMetaData::FileCryptoMetaData(const FileCryptoMetaData& other376) {
-  encryption_algorithm = other376.encryption_algorithm;
-  key_metadata = other376.key_metadata;
-  __isset = other376.__isset;
+FileCryptoMetaData::FileCryptoMetaData(const FileCryptoMetaData& other264) {
+  encryption_algorithm = other264.encryption_algorithm;
+  key_metadata = other264.key_metadata;
+  __isset = other264.__isset;
 }
-FileCryptoMetaData::FileCryptoMetaData(FileCryptoMetaData&& other377) noexcept {
-  encryption_algorithm = std::move(other377.encryption_algorithm);
-  key_metadata = std::move(other377.key_metadata);
-  __isset = other377.__isset;
-}
-FileCryptoMetaData& FileCryptoMetaData::operator=(const FileCryptoMetaData& other378) {
-  encryption_algorithm = other378.encryption_algorithm;
-  key_metadata = other378.key_metadata;
-  __isset = other378.__isset;
-  return *this;
-}
-FileCryptoMetaData& FileCryptoMetaData::operator=(FileCryptoMetaData&& other379) noexcept {
-  encryption_algorithm = std::move(other379.encryption_algorithm);
-  key_metadata = std::move(other379.key_metadata);
-  __isset = other379.__isset;
+FileCryptoMetaData& FileCryptoMetaData::operator=(const FileCryptoMetaData& other265) {
+  encryption_algorithm = other265.encryption_algorithm;
+  key_metadata = other265.key_metadata;
+  __isset = other265.__isset;
   return *this;
 }
 void FileCryptoMetaData::printTo(std::ostream& out) const {

--- a/cpp/src/generated/parquet_types.cpp
+++ b/cpp/src/generated/parquet_types.cpp
@@ -715,11 +715,24 @@ SizeStatistics::SizeStatistics(const SizeStatistics& other12) {
   definition_level_histogram = other12.definition_level_histogram;
   __isset = other12.__isset;
 }
-SizeStatistics& SizeStatistics::operator=(const SizeStatistics& other13) {
+SizeStatistics::SizeStatistics(SizeStatistics&& other13) noexcept {
   unencoded_byte_array_data_bytes = other13.unencoded_byte_array_data_bytes;
-  repetition_level_histogram = other13.repetition_level_histogram;
-  definition_level_histogram = other13.definition_level_histogram;
+  repetition_level_histogram = std::move(other13.repetition_level_histogram);
+  definition_level_histogram = std::move(other13.definition_level_histogram);
   __isset = other13.__isset;
+}
+SizeStatistics& SizeStatistics::operator=(const SizeStatistics& other14) {
+  unencoded_byte_array_data_bytes = other14.unencoded_byte_array_data_bytes;
+  repetition_level_histogram = other14.repetition_level_histogram;
+  definition_level_histogram = other14.definition_level_histogram;
+  __isset = other14.__isset;
+  return *this;
+}
+SizeStatistics& SizeStatistics::operator=(SizeStatistics&& other15) noexcept {
+  unencoded_byte_array_data_bytes = other15.unencoded_byte_array_data_bytes;
+  repetition_level_histogram = std::move(other15.repetition_level_histogram);
+  definition_level_histogram = std::move(other15.definition_level_histogram);
+  __isset = other15.__isset;
   return *this;
 }
 void SizeStatistics::printTo(std::ostream& out) const {
@@ -830,27 +843,50 @@ bool BoundingBox::operator==(const BoundingBox & rhs) const
   return true;
 }
 
-BoundingBox::BoundingBox(const BoundingBox& other14) noexcept {
-  xmin = other14.xmin;
-  xmax = other14.xmax;
-  ymin = other14.ymin;
-  ymax = other14.ymax;
-  zmin = other14.zmin;
-  zmax = other14.zmax;
-  mmin = other14.mmin;
-  mmax = other14.mmax;
-  __isset = other14.__isset;
+BoundingBox::BoundingBox(const BoundingBox& other16) noexcept {
+  xmin = other16.xmin;
+  xmax = other16.xmax;
+  ymin = other16.ymin;
+  ymax = other16.ymax;
+  zmin = other16.zmin;
+  zmax = other16.zmax;
+  mmin = other16.mmin;
+  mmax = other16.mmax;
+  __isset = other16.__isset;
 }
-BoundingBox& BoundingBox::operator=(const BoundingBox& other15) noexcept {
-  xmin = other15.xmin;
-  xmax = other15.xmax;
-  ymin = other15.ymin;
-  ymax = other15.ymax;
-  zmin = other15.zmin;
-  zmax = other15.zmax;
-  mmin = other15.mmin;
-  mmax = other15.mmax;
-  __isset = other15.__isset;
+BoundingBox::BoundingBox(BoundingBox&& other17) noexcept {
+  xmin = other17.xmin;
+  xmax = other17.xmax;
+  ymin = other17.ymin;
+  ymax = other17.ymax;
+  zmin = other17.zmin;
+  zmax = other17.zmax;
+  mmin = other17.mmin;
+  mmax = other17.mmax;
+  __isset = other17.__isset;
+}
+BoundingBox& BoundingBox::operator=(const BoundingBox& other18) noexcept {
+  xmin = other18.xmin;
+  xmax = other18.xmax;
+  ymin = other18.ymin;
+  ymax = other18.ymax;
+  zmin = other18.zmin;
+  zmax = other18.zmax;
+  mmin = other18.mmin;
+  mmax = other18.mmax;
+  __isset = other18.__isset;
+  return *this;
+}
+BoundingBox& BoundingBox::operator=(BoundingBox&& other19) noexcept {
+  xmin = other19.xmin;
+  xmax = other19.xmax;
+  ymin = other19.ymin;
+  ymax = other19.ymax;
+  zmin = other19.zmin;
+  zmax = other19.zmax;
+  mmin = other19.mmin;
+  mmax = other19.mmax;
+  __isset = other19.__isset;
   return *this;
 }
 void BoundingBox::printTo(std::ostream& out) const {
@@ -910,15 +946,26 @@ bool GeospatialStatistics::operator==(const GeospatialStatistics & rhs) const
   return true;
 }
 
-GeospatialStatistics::GeospatialStatistics(const GeospatialStatistics& other22) {
-  bbox = other22.bbox;
-  geospatial_types = other22.geospatial_types;
-  __isset = other22.__isset;
+GeospatialStatistics::GeospatialStatistics(const GeospatialStatistics& other26) {
+  bbox = other26.bbox;
+  geospatial_types = other26.geospatial_types;
+  __isset = other26.__isset;
 }
-GeospatialStatistics& GeospatialStatistics::operator=(const GeospatialStatistics& other23) {
-  bbox = other23.bbox;
-  geospatial_types = other23.geospatial_types;
-  __isset = other23.__isset;
+GeospatialStatistics::GeospatialStatistics(GeospatialStatistics&& other27) noexcept {
+  bbox = std::move(other27.bbox);
+  geospatial_types = std::move(other27.geospatial_types);
+  __isset = other27.__isset;
+}
+GeospatialStatistics& GeospatialStatistics::operator=(const GeospatialStatistics& other28) {
+  bbox = other28.bbox;
+  geospatial_types = other28.geospatial_types;
+  __isset = other28.__isset;
+  return *this;
+}
+GeospatialStatistics& GeospatialStatistics::operator=(GeospatialStatistics&& other29) noexcept {
+  bbox = std::move(other29.bbox);
+  geospatial_types = std::move(other29.geospatial_types);
+  __isset = other29.__isset;
   return *this;
 }
 void GeospatialStatistics::printTo(std::ostream& out) const {
@@ -1040,27 +1087,50 @@ bool Statistics::operator==(const Statistics & rhs) const
   return true;
 }
 
-Statistics::Statistics(const Statistics& other24) {
-  max = other24.max;
-  min = other24.min;
-  null_count = other24.null_count;
-  distinct_count = other24.distinct_count;
-  max_value = other24.max_value;
-  min_value = other24.min_value;
-  is_max_value_exact = other24.is_max_value_exact;
-  is_min_value_exact = other24.is_min_value_exact;
-  __isset = other24.__isset;
+Statistics::Statistics(const Statistics& other30) {
+  max = other30.max;
+  min = other30.min;
+  null_count = other30.null_count;
+  distinct_count = other30.distinct_count;
+  max_value = other30.max_value;
+  min_value = other30.min_value;
+  is_max_value_exact = other30.is_max_value_exact;
+  is_min_value_exact = other30.is_min_value_exact;
+  __isset = other30.__isset;
 }
-Statistics& Statistics::operator=(const Statistics& other25) {
-  max = other25.max;
-  min = other25.min;
-  null_count = other25.null_count;
-  distinct_count = other25.distinct_count;
-  max_value = other25.max_value;
-  min_value = other25.min_value;
-  is_max_value_exact = other25.is_max_value_exact;
-  is_min_value_exact = other25.is_min_value_exact;
-  __isset = other25.__isset;
+Statistics::Statistics(Statistics&& other31) noexcept {
+  max = std::move(other31.max);
+  min = std::move(other31.min);
+  null_count = other31.null_count;
+  distinct_count = other31.distinct_count;
+  max_value = std::move(other31.max_value);
+  min_value = std::move(other31.min_value);
+  is_max_value_exact = other31.is_max_value_exact;
+  is_min_value_exact = other31.is_min_value_exact;
+  __isset = other31.__isset;
+}
+Statistics& Statistics::operator=(const Statistics& other32) {
+  max = other32.max;
+  min = other32.min;
+  null_count = other32.null_count;
+  distinct_count = other32.distinct_count;
+  max_value = other32.max_value;
+  min_value = other32.min_value;
+  is_max_value_exact = other32.is_max_value_exact;
+  is_min_value_exact = other32.is_min_value_exact;
+  __isset = other32.__isset;
+  return *this;
+}
+Statistics& Statistics::operator=(Statistics&& other33) noexcept {
+  max = std::move(other33.max);
+  min = std::move(other33.min);
+  null_count = other33.null_count;
+  distinct_count = other33.distinct_count;
+  max_value = std::move(other33.max_value);
+  min_value = std::move(other33.min_value);
+  is_max_value_exact = other33.is_max_value_exact;
+  is_min_value_exact = other33.is_min_value_exact;
+  __isset = other33.__isset;
   return *this;
 }
 void Statistics::printTo(std::ostream& out) const {
@@ -1101,11 +1171,18 @@ bool StringType::operator==(const StringType & /* rhs */) const
   return true;
 }
 
-StringType::StringType(const StringType& other26) noexcept {
-  (void) other26;
+StringType::StringType(const StringType& other34) noexcept {
+  (void) other34;
 }
-StringType& StringType::operator=(const StringType& other27) noexcept {
-  (void) other27;
+StringType::StringType(StringType&& other35) noexcept {
+  (void) other35;
+}
+StringType& StringType::operator=(const StringType& other36) noexcept {
+  (void) other36;
+  return *this;
+}
+StringType& StringType::operator=(StringType&& other37) noexcept {
+  (void) other37;
   return *this;
 }
 void StringType::printTo(std::ostream& out) const {
@@ -1138,11 +1215,18 @@ bool UUIDType::operator==(const UUIDType & /* rhs */) const
   return true;
 }
 
-UUIDType::UUIDType(const UUIDType& other28) noexcept {
-  (void) other28;
+UUIDType::UUIDType(const UUIDType& other38) noexcept {
+  (void) other38;
 }
-UUIDType& UUIDType::operator=(const UUIDType& other29) noexcept {
-  (void) other29;
+UUIDType::UUIDType(UUIDType&& other39) noexcept {
+  (void) other39;
+}
+UUIDType& UUIDType::operator=(const UUIDType& other40) noexcept {
+  (void) other40;
+  return *this;
+}
+UUIDType& UUIDType::operator=(UUIDType&& other41) noexcept {
+  (void) other41;
   return *this;
 }
 void UUIDType::printTo(std::ostream& out) const {
@@ -1175,11 +1259,18 @@ bool MapType::operator==(const MapType & /* rhs */) const
   return true;
 }
 
-MapType::MapType(const MapType& other30) noexcept {
-  (void) other30;
+MapType::MapType(const MapType& other42) noexcept {
+  (void) other42;
 }
-MapType& MapType::operator=(const MapType& other31) noexcept {
-  (void) other31;
+MapType::MapType(MapType&& other43) noexcept {
+  (void) other43;
+}
+MapType& MapType::operator=(const MapType& other44) noexcept {
+  (void) other44;
+  return *this;
+}
+MapType& MapType::operator=(MapType&& other45) noexcept {
+  (void) other45;
   return *this;
 }
 void MapType::printTo(std::ostream& out) const {
@@ -1212,11 +1303,18 @@ bool ListType::operator==(const ListType & /* rhs */) const
   return true;
 }
 
-ListType::ListType(const ListType& other32) noexcept {
-  (void) other32;
+ListType::ListType(const ListType& other46) noexcept {
+  (void) other46;
 }
-ListType& ListType::operator=(const ListType& other33) noexcept {
-  (void) other33;
+ListType::ListType(ListType&& other47) noexcept {
+  (void) other47;
+}
+ListType& ListType::operator=(const ListType& other48) noexcept {
+  (void) other48;
+  return *this;
+}
+ListType& ListType::operator=(ListType&& other49) noexcept {
+  (void) other49;
   return *this;
 }
 void ListType::printTo(std::ostream& out) const {
@@ -1249,11 +1347,18 @@ bool EnumType::operator==(const EnumType & /* rhs */) const
   return true;
 }
 
-EnumType::EnumType(const EnumType& other34) noexcept {
-  (void) other34;
+EnumType::EnumType(const EnumType& other50) noexcept {
+  (void) other50;
 }
-EnumType& EnumType::operator=(const EnumType& other35) noexcept {
-  (void) other35;
+EnumType::EnumType(EnumType&& other51) noexcept {
+  (void) other51;
+}
+EnumType& EnumType::operator=(const EnumType& other52) noexcept {
+  (void) other52;
+  return *this;
+}
+EnumType& EnumType::operator=(EnumType&& other53) noexcept {
+  (void) other53;
   return *this;
 }
 void EnumType::printTo(std::ostream& out) const {
@@ -1286,11 +1391,18 @@ bool DateType::operator==(const DateType & /* rhs */) const
   return true;
 }
 
-DateType::DateType(const DateType& other36) noexcept {
-  (void) other36;
+DateType::DateType(const DateType& other54) noexcept {
+  (void) other54;
 }
-DateType& DateType::operator=(const DateType& other37) noexcept {
-  (void) other37;
+DateType::DateType(DateType&& other55) noexcept {
+  (void) other55;
+}
+DateType& DateType::operator=(const DateType& other56) noexcept {
+  (void) other56;
+  return *this;
+}
+DateType& DateType::operator=(DateType&& other57) noexcept {
+  (void) other57;
   return *this;
 }
 void DateType::printTo(std::ostream& out) const {
@@ -1323,11 +1435,18 @@ bool Float16Type::operator==(const Float16Type & /* rhs */) const
   return true;
 }
 
-Float16Type::Float16Type(const Float16Type& other38) noexcept {
-  (void) other38;
+Float16Type::Float16Type(const Float16Type& other58) noexcept {
+  (void) other58;
 }
-Float16Type& Float16Type::operator=(const Float16Type& other39) noexcept {
-  (void) other39;
+Float16Type::Float16Type(Float16Type&& other59) noexcept {
+  (void) other59;
+}
+Float16Type& Float16Type::operator=(const Float16Type& other60) noexcept {
+  (void) other60;
+  return *this;
+}
+Float16Type& Float16Type::operator=(Float16Type&& other61) noexcept {
+  (void) other61;
   return *this;
 }
 void Float16Type::printTo(std::ostream& out) const {
@@ -1360,11 +1479,18 @@ bool NullType::operator==(const NullType & /* rhs */) const
   return true;
 }
 
-NullType::NullType(const NullType& other40) noexcept {
-  (void) other40;
+NullType::NullType(const NullType& other62) noexcept {
+  (void) other62;
 }
-NullType& NullType::operator=(const NullType& other41) noexcept {
-  (void) other41;
+NullType::NullType(NullType&& other63) noexcept {
+  (void) other63;
+}
+NullType& NullType::operator=(const NullType& other64) noexcept {
+  (void) other64;
+  return *this;
+}
+NullType& NullType::operator=(NullType&& other65) noexcept {
+  (void) other65;
   return *this;
 }
 void NullType::printTo(std::ostream& out) const {
@@ -1411,13 +1537,22 @@ bool DecimalType::operator==(const DecimalType & rhs) const
   return true;
 }
 
-DecimalType::DecimalType(const DecimalType& other42) noexcept {
-  scale = other42.scale;
-  precision = other42.precision;
+DecimalType::DecimalType(const DecimalType& other66) noexcept {
+  scale = other66.scale;
+  precision = other66.precision;
 }
-DecimalType& DecimalType::operator=(const DecimalType& other43) noexcept {
-  scale = other43.scale;
-  precision = other43.precision;
+DecimalType::DecimalType(DecimalType&& other67) noexcept {
+  scale = other67.scale;
+  precision = other67.precision;
+}
+DecimalType& DecimalType::operator=(const DecimalType& other68) noexcept {
+  scale = other68.scale;
+  precision = other68.precision;
+  return *this;
+}
+DecimalType& DecimalType::operator=(DecimalType&& other69) noexcept {
+  scale = other69.scale;
+  precision = other69.precision;
   return *this;
 }
 void DecimalType::printTo(std::ostream& out) const {
@@ -1452,11 +1587,18 @@ bool MilliSeconds::operator==(const MilliSeconds & /* rhs */) const
   return true;
 }
 
-MilliSeconds::MilliSeconds(const MilliSeconds& other44) noexcept {
-  (void) other44;
+MilliSeconds::MilliSeconds(const MilliSeconds& other70) noexcept {
+  (void) other70;
 }
-MilliSeconds& MilliSeconds::operator=(const MilliSeconds& other45) noexcept {
-  (void) other45;
+MilliSeconds::MilliSeconds(MilliSeconds&& other71) noexcept {
+  (void) other71;
+}
+MilliSeconds& MilliSeconds::operator=(const MilliSeconds& other72) noexcept {
+  (void) other72;
+  return *this;
+}
+MilliSeconds& MilliSeconds::operator=(MilliSeconds&& other73) noexcept {
+  (void) other73;
   return *this;
 }
 void MilliSeconds::printTo(std::ostream& out) const {
@@ -1489,11 +1631,18 @@ bool MicroSeconds::operator==(const MicroSeconds & /* rhs */) const
   return true;
 }
 
-MicroSeconds::MicroSeconds(const MicroSeconds& other46) noexcept {
-  (void) other46;
+MicroSeconds::MicroSeconds(const MicroSeconds& other74) noexcept {
+  (void) other74;
 }
-MicroSeconds& MicroSeconds::operator=(const MicroSeconds& other47) noexcept {
-  (void) other47;
+MicroSeconds::MicroSeconds(MicroSeconds&& other75) noexcept {
+  (void) other75;
+}
+MicroSeconds& MicroSeconds::operator=(const MicroSeconds& other76) noexcept {
+  (void) other76;
+  return *this;
+}
+MicroSeconds& MicroSeconds::operator=(MicroSeconds&& other77) noexcept {
+  (void) other77;
   return *this;
 }
 void MicroSeconds::printTo(std::ostream& out) const {
@@ -1526,11 +1675,18 @@ bool NanoSeconds::operator==(const NanoSeconds & /* rhs */) const
   return true;
 }
 
-NanoSeconds::NanoSeconds(const NanoSeconds& other48) noexcept {
-  (void) other48;
+NanoSeconds::NanoSeconds(const NanoSeconds& other78) noexcept {
+  (void) other78;
 }
-NanoSeconds& NanoSeconds::operator=(const NanoSeconds& other49) noexcept {
-  (void) other49;
+NanoSeconds::NanoSeconds(NanoSeconds&& other79) noexcept {
+  (void) other79;
+}
+NanoSeconds& NanoSeconds::operator=(const NanoSeconds& other80) noexcept {
+  (void) other80;
+  return *this;
+}
+NanoSeconds& NanoSeconds::operator=(NanoSeconds&& other81) noexcept {
+  (void) other81;
   return *this;
 }
 void NanoSeconds::printTo(std::ostream& out) const {
@@ -1592,17 +1748,30 @@ bool TimeUnit::operator==(const TimeUnit & rhs) const
   return true;
 }
 
-TimeUnit::TimeUnit(const TimeUnit& other50) noexcept {
-  MILLIS = other50.MILLIS;
-  MICROS = other50.MICROS;
-  NANOS = other50.NANOS;
-  __isset = other50.__isset;
+TimeUnit::TimeUnit(const TimeUnit& other82) noexcept {
+  MILLIS = other82.MILLIS;
+  MICROS = other82.MICROS;
+  NANOS = other82.NANOS;
+  __isset = other82.__isset;
 }
-TimeUnit& TimeUnit::operator=(const TimeUnit& other51) noexcept {
-  MILLIS = other51.MILLIS;
-  MICROS = other51.MICROS;
-  NANOS = other51.NANOS;
-  __isset = other51.__isset;
+TimeUnit::TimeUnit(TimeUnit&& other83) noexcept {
+  MILLIS = std::move(other83.MILLIS);
+  MICROS = std::move(other83.MICROS);
+  NANOS = std::move(other83.NANOS);
+  __isset = other83.__isset;
+}
+TimeUnit& TimeUnit::operator=(const TimeUnit& other84) noexcept {
+  MILLIS = other84.MILLIS;
+  MICROS = other84.MICROS;
+  NANOS = other84.NANOS;
+  __isset = other84.__isset;
+  return *this;
+}
+TimeUnit& TimeUnit::operator=(TimeUnit&& other85) noexcept {
+  MILLIS = std::move(other85.MILLIS);
+  MICROS = std::move(other85.MICROS);
+  NANOS = std::move(other85.NANOS);
+  __isset = other85.__isset;
   return *this;
 }
 void TimeUnit::printTo(std::ostream& out) const {
@@ -1651,13 +1820,22 @@ bool TimestampType::operator==(const TimestampType & rhs) const
   return true;
 }
 
-TimestampType::TimestampType(const TimestampType& other52) noexcept {
-  isAdjustedToUTC = other52.isAdjustedToUTC;
-  unit = other52.unit;
+TimestampType::TimestampType(const TimestampType& other86) noexcept {
+  isAdjustedToUTC = other86.isAdjustedToUTC;
+  unit = other86.unit;
 }
-TimestampType& TimestampType::operator=(const TimestampType& other53) noexcept {
-  isAdjustedToUTC = other53.isAdjustedToUTC;
-  unit = other53.unit;
+TimestampType::TimestampType(TimestampType&& other87) noexcept {
+  isAdjustedToUTC = other87.isAdjustedToUTC;
+  unit = std::move(other87.unit);
+}
+TimestampType& TimestampType::operator=(const TimestampType& other88) noexcept {
+  isAdjustedToUTC = other88.isAdjustedToUTC;
+  unit = other88.unit;
+  return *this;
+}
+TimestampType& TimestampType::operator=(TimestampType&& other89) noexcept {
+  isAdjustedToUTC = other89.isAdjustedToUTC;
+  unit = std::move(other89.unit);
   return *this;
 }
 void TimestampType::printTo(std::ostream& out) const {
@@ -1705,13 +1883,22 @@ bool TimeType::operator==(const TimeType & rhs) const
   return true;
 }
 
-TimeType::TimeType(const TimeType& other54) noexcept {
-  isAdjustedToUTC = other54.isAdjustedToUTC;
-  unit = other54.unit;
+TimeType::TimeType(const TimeType& other90) noexcept {
+  isAdjustedToUTC = other90.isAdjustedToUTC;
+  unit = other90.unit;
 }
-TimeType& TimeType::operator=(const TimeType& other55) noexcept {
-  isAdjustedToUTC = other55.isAdjustedToUTC;
-  unit = other55.unit;
+TimeType::TimeType(TimeType&& other91) noexcept {
+  isAdjustedToUTC = other91.isAdjustedToUTC;
+  unit = std::move(other91.unit);
+}
+TimeType& TimeType::operator=(const TimeType& other92) noexcept {
+  isAdjustedToUTC = other92.isAdjustedToUTC;
+  unit = other92.unit;
+  return *this;
+}
+TimeType& TimeType::operator=(TimeType&& other93) noexcept {
+  isAdjustedToUTC = other93.isAdjustedToUTC;
+  unit = std::move(other93.unit);
   return *this;
 }
 void TimeType::printTo(std::ostream& out) const {
@@ -1760,13 +1947,22 @@ bool IntType::operator==(const IntType & rhs) const
   return true;
 }
 
-IntType::IntType(const IntType& other56) noexcept {
-  bitWidth = other56.bitWidth;
-  isSigned = other56.isSigned;
+IntType::IntType(const IntType& other94) noexcept {
+  bitWidth = other94.bitWidth;
+  isSigned = other94.isSigned;
 }
-IntType& IntType::operator=(const IntType& other57) noexcept {
-  bitWidth = other57.bitWidth;
-  isSigned = other57.isSigned;
+IntType::IntType(IntType&& other95) noexcept {
+  bitWidth = other95.bitWidth;
+  isSigned = other95.isSigned;
+}
+IntType& IntType::operator=(const IntType& other96) noexcept {
+  bitWidth = other96.bitWidth;
+  isSigned = other96.isSigned;
+  return *this;
+}
+IntType& IntType::operator=(IntType&& other97) noexcept {
+  bitWidth = other97.bitWidth;
+  isSigned = other97.isSigned;
   return *this;
 }
 void IntType::printTo(std::ostream& out) const {
@@ -1801,11 +1997,18 @@ bool JsonType::operator==(const JsonType & /* rhs */) const
   return true;
 }
 
-JsonType::JsonType(const JsonType& other58) noexcept {
-  (void) other58;
+JsonType::JsonType(const JsonType& other98) noexcept {
+  (void) other98;
 }
-JsonType& JsonType::operator=(const JsonType& other59) noexcept {
-  (void) other59;
+JsonType::JsonType(JsonType&& other99) noexcept {
+  (void) other99;
+}
+JsonType& JsonType::operator=(const JsonType& other100) noexcept {
+  (void) other100;
+  return *this;
+}
+JsonType& JsonType::operator=(JsonType&& other101) noexcept {
+  (void) other101;
   return *this;
 }
 void JsonType::printTo(std::ostream& out) const {
@@ -1838,11 +2041,18 @@ bool BsonType::operator==(const BsonType & /* rhs */) const
   return true;
 }
 
-BsonType::BsonType(const BsonType& other60) noexcept {
-  (void) other60;
+BsonType::BsonType(const BsonType& other102) noexcept {
+  (void) other102;
 }
-BsonType& BsonType::operator=(const BsonType& other61) noexcept {
-  (void) other61;
+BsonType::BsonType(BsonType&& other103) noexcept {
+  (void) other103;
+}
+BsonType& BsonType::operator=(const BsonType& other104) noexcept {
+  (void) other104;
+  return *this;
+}
+BsonType& BsonType::operator=(BsonType&& other105) noexcept {
+  (void) other105;
   return *this;
 }
 void BsonType::printTo(std::ostream& out) const {
@@ -1885,13 +2095,22 @@ bool VariantType::operator==(const VariantType & rhs) const
   return true;
 }
 
-VariantType::VariantType(const VariantType& other62) noexcept {
-  specification_version = other62.specification_version;
-  __isset = other62.__isset;
+VariantType::VariantType(const VariantType& other106) noexcept {
+  specification_version = other106.specification_version;
+  __isset = other106.__isset;
 }
-VariantType& VariantType::operator=(const VariantType& other63) noexcept {
-  specification_version = other63.specification_version;
-  __isset = other63.__isset;
+VariantType::VariantType(VariantType&& other107) noexcept {
+  specification_version = other107.specification_version;
+  __isset = other107.__isset;
+}
+VariantType& VariantType::operator=(const VariantType& other108) noexcept {
+  specification_version = other108.specification_version;
+  __isset = other108.__isset;
+  return *this;
+}
+VariantType& VariantType::operator=(VariantType&& other109) noexcept {
+  specification_version = other109.specification_version;
+  __isset = other109.__isset;
   return *this;
 }
 void VariantType::printTo(std::ostream& out) const {
@@ -1935,13 +2154,22 @@ bool GeometryType::operator==(const GeometryType & rhs) const
   return true;
 }
 
-GeometryType::GeometryType(const GeometryType& other64) {
-  crs = other64.crs;
-  __isset = other64.__isset;
+GeometryType::GeometryType(const GeometryType& other110) {
+  crs = other110.crs;
+  __isset = other110.__isset;
 }
-GeometryType& GeometryType::operator=(const GeometryType& other65) {
-  crs = other65.crs;
-  __isset = other65.__isset;
+GeometryType::GeometryType(GeometryType&& other111) noexcept {
+  crs = std::move(other111.crs);
+  __isset = other111.__isset;
+}
+GeometryType& GeometryType::operator=(const GeometryType& other112) {
+  crs = other112.crs;
+  __isset = other112.__isset;
+  return *this;
+}
+GeometryType& GeometryType::operator=(GeometryType&& other113) noexcept {
+  crs = std::move(other113.crs);
+  __isset = other113.__isset;
   return *this;
 }
 void GeometryType::printTo(std::ostream& out) const {
@@ -1996,15 +2224,26 @@ bool GeographyType::operator==(const GeographyType & rhs) const
   return true;
 }
 
-GeographyType::GeographyType(const GeographyType& other67) {
-  crs = other67.crs;
-  algorithm = other67.algorithm;
-  __isset = other67.__isset;
+GeographyType::GeographyType(const GeographyType& other115) {
+  crs = other115.crs;
+  algorithm = other115.algorithm;
+  __isset = other115.__isset;
 }
-GeographyType& GeographyType::operator=(const GeographyType& other68) {
-  crs = other68.crs;
-  algorithm = other68.algorithm;
-  __isset = other68.__isset;
+GeographyType::GeographyType(GeographyType&& other116) noexcept {
+  crs = std::move(other116.crs);
+  algorithm = other116.algorithm;
+  __isset = other116.__isset;
+}
+GeographyType& GeographyType::operator=(const GeographyType& other117) {
+  crs = other117.crs;
+  algorithm = other117.algorithm;
+  __isset = other117.__isset;
+  return *this;
+}
+GeographyType& GeographyType::operator=(GeographyType&& other118) noexcept {
+  crs = std::move(other118.crs);
+  algorithm = other118.algorithm;
+  __isset = other118.__isset;
   return *this;
 }
 void GeographyType::printTo(std::ostream& out) const {
@@ -2208,45 +2447,86 @@ bool LogicalType::operator==(const LogicalType & rhs) const
   return true;
 }
 
-LogicalType::LogicalType(const LogicalType& other69) {
-  STRING = other69.STRING;
-  MAP = other69.MAP;
-  LIST = other69.LIST;
-  ENUM = other69.ENUM;
-  DECIMAL = other69.DECIMAL;
-  DATE = other69.DATE;
-  TIME = other69.TIME;
-  TIMESTAMP = other69.TIMESTAMP;
-  INTEGER = other69.INTEGER;
-  UNKNOWN = other69.UNKNOWN;
-  JSON = other69.JSON;
-  BSON = other69.BSON;
-  UUID = other69.UUID;
-  FLOAT16 = other69.FLOAT16;
-  VARIANT = other69.VARIANT;
-  GEOMETRY = other69.GEOMETRY;
-  GEOGRAPHY = other69.GEOGRAPHY;
-  __isset = other69.__isset;
+LogicalType::LogicalType(const LogicalType& other119) {
+  STRING = other119.STRING;
+  MAP = other119.MAP;
+  LIST = other119.LIST;
+  ENUM = other119.ENUM;
+  DECIMAL = other119.DECIMAL;
+  DATE = other119.DATE;
+  TIME = other119.TIME;
+  TIMESTAMP = other119.TIMESTAMP;
+  INTEGER = other119.INTEGER;
+  UNKNOWN = other119.UNKNOWN;
+  JSON = other119.JSON;
+  BSON = other119.BSON;
+  UUID = other119.UUID;
+  FLOAT16 = other119.FLOAT16;
+  VARIANT = other119.VARIANT;
+  GEOMETRY = other119.GEOMETRY;
+  GEOGRAPHY = other119.GEOGRAPHY;
+  __isset = other119.__isset;
 }
-LogicalType& LogicalType::operator=(const LogicalType& other70) {
-  STRING = other70.STRING;
-  MAP = other70.MAP;
-  LIST = other70.LIST;
-  ENUM = other70.ENUM;
-  DECIMAL = other70.DECIMAL;
-  DATE = other70.DATE;
-  TIME = other70.TIME;
-  TIMESTAMP = other70.TIMESTAMP;
-  INTEGER = other70.INTEGER;
-  UNKNOWN = other70.UNKNOWN;
-  JSON = other70.JSON;
-  BSON = other70.BSON;
-  UUID = other70.UUID;
-  FLOAT16 = other70.FLOAT16;
-  VARIANT = other70.VARIANT;
-  GEOMETRY = other70.GEOMETRY;
-  GEOGRAPHY = other70.GEOGRAPHY;
-  __isset = other70.__isset;
+LogicalType::LogicalType(LogicalType&& other120) noexcept {
+  STRING = std::move(other120.STRING);
+  MAP = std::move(other120.MAP);
+  LIST = std::move(other120.LIST);
+  ENUM = std::move(other120.ENUM);
+  DECIMAL = std::move(other120.DECIMAL);
+  DATE = std::move(other120.DATE);
+  TIME = std::move(other120.TIME);
+  TIMESTAMP = std::move(other120.TIMESTAMP);
+  INTEGER = std::move(other120.INTEGER);
+  UNKNOWN = std::move(other120.UNKNOWN);
+  JSON = std::move(other120.JSON);
+  BSON = std::move(other120.BSON);
+  UUID = std::move(other120.UUID);
+  FLOAT16 = std::move(other120.FLOAT16);
+  VARIANT = std::move(other120.VARIANT);
+  GEOMETRY = std::move(other120.GEOMETRY);
+  GEOGRAPHY = std::move(other120.GEOGRAPHY);
+  __isset = other120.__isset;
+}
+LogicalType& LogicalType::operator=(const LogicalType& other121) {
+  STRING = other121.STRING;
+  MAP = other121.MAP;
+  LIST = other121.LIST;
+  ENUM = other121.ENUM;
+  DECIMAL = other121.DECIMAL;
+  DATE = other121.DATE;
+  TIME = other121.TIME;
+  TIMESTAMP = other121.TIMESTAMP;
+  INTEGER = other121.INTEGER;
+  UNKNOWN = other121.UNKNOWN;
+  JSON = other121.JSON;
+  BSON = other121.BSON;
+  UUID = other121.UUID;
+  FLOAT16 = other121.FLOAT16;
+  VARIANT = other121.VARIANT;
+  GEOMETRY = other121.GEOMETRY;
+  GEOGRAPHY = other121.GEOGRAPHY;
+  __isset = other121.__isset;
+  return *this;
+}
+LogicalType& LogicalType::operator=(LogicalType&& other122) noexcept {
+  STRING = std::move(other122.STRING);
+  MAP = std::move(other122.MAP);
+  LIST = std::move(other122.LIST);
+  ENUM = std::move(other122.ENUM);
+  DECIMAL = std::move(other122.DECIMAL);
+  DATE = std::move(other122.DATE);
+  TIME = std::move(other122.TIME);
+  TIMESTAMP = std::move(other122.TIMESTAMP);
+  INTEGER = std::move(other122.INTEGER);
+  UNKNOWN = std::move(other122.UNKNOWN);
+  JSON = std::move(other122.JSON);
+  BSON = std::move(other122.BSON);
+  UUID = std::move(other122.UUID);
+  FLOAT16 = std::move(other122.FLOAT16);
+  VARIANT = std::move(other122.VARIANT);
+  GEOMETRY = std::move(other122.GEOMETRY);
+  GEOGRAPHY = std::move(other122.GEOGRAPHY);
+  __isset = other122.__isset;
   return *this;
 }
 void LogicalType::printTo(std::ostream& out) const {
@@ -2401,31 +2681,58 @@ bool SchemaElement::operator==(const SchemaElement & rhs) const
   return true;
 }
 
-SchemaElement::SchemaElement(const SchemaElement& other74) {
-  type = other74.type;
-  type_length = other74.type_length;
-  repetition_type = other74.repetition_type;
-  name = other74.name;
-  num_children = other74.num_children;
-  converted_type = other74.converted_type;
-  scale = other74.scale;
-  precision = other74.precision;
-  field_id = other74.field_id;
-  logicalType = other74.logicalType;
-  __isset = other74.__isset;
+SchemaElement::SchemaElement(const SchemaElement& other126) {
+  type = other126.type;
+  type_length = other126.type_length;
+  repetition_type = other126.repetition_type;
+  name = other126.name;
+  num_children = other126.num_children;
+  converted_type = other126.converted_type;
+  scale = other126.scale;
+  precision = other126.precision;
+  field_id = other126.field_id;
+  logicalType = other126.logicalType;
+  __isset = other126.__isset;
 }
-SchemaElement& SchemaElement::operator=(const SchemaElement& other75) {
-  type = other75.type;
-  type_length = other75.type_length;
-  repetition_type = other75.repetition_type;
-  name = other75.name;
-  num_children = other75.num_children;
-  converted_type = other75.converted_type;
-  scale = other75.scale;
-  precision = other75.precision;
-  field_id = other75.field_id;
-  logicalType = other75.logicalType;
-  __isset = other75.__isset;
+SchemaElement::SchemaElement(SchemaElement&& other127) noexcept {
+  type = other127.type;
+  type_length = other127.type_length;
+  repetition_type = other127.repetition_type;
+  name = std::move(other127.name);
+  num_children = other127.num_children;
+  converted_type = other127.converted_type;
+  scale = other127.scale;
+  precision = other127.precision;
+  field_id = other127.field_id;
+  logicalType = std::move(other127.logicalType);
+  __isset = other127.__isset;
+}
+SchemaElement& SchemaElement::operator=(const SchemaElement& other128) {
+  type = other128.type;
+  type_length = other128.type_length;
+  repetition_type = other128.repetition_type;
+  name = other128.name;
+  num_children = other128.num_children;
+  converted_type = other128.converted_type;
+  scale = other128.scale;
+  precision = other128.precision;
+  field_id = other128.field_id;
+  logicalType = other128.logicalType;
+  __isset = other128.__isset;
+  return *this;
+}
+SchemaElement& SchemaElement::operator=(SchemaElement&& other129) noexcept {
+  type = other129.type;
+  type_length = other129.type_length;
+  repetition_type = other129.repetition_type;
+  name = std::move(other129.name);
+  num_children = other129.num_children;
+  converted_type = other129.converted_type;
+  scale = other129.scale;
+  precision = other129.precision;
+  field_id = other129.field_id;
+  logicalType = std::move(other129.logicalType);
+  __isset = other129.__isset;
   return *this;
 }
 void SchemaElement::printTo(std::ostream& out) const {
@@ -2509,21 +2816,38 @@ bool DataPageHeader::operator==(const DataPageHeader & rhs) const
   return true;
 }
 
-DataPageHeader::DataPageHeader(const DataPageHeader& other79) {
-  num_values = other79.num_values;
-  encoding = other79.encoding;
-  definition_level_encoding = other79.definition_level_encoding;
-  repetition_level_encoding = other79.repetition_level_encoding;
-  statistics = other79.statistics;
-  __isset = other79.__isset;
+DataPageHeader::DataPageHeader(const DataPageHeader& other133) {
+  num_values = other133.num_values;
+  encoding = other133.encoding;
+  definition_level_encoding = other133.definition_level_encoding;
+  repetition_level_encoding = other133.repetition_level_encoding;
+  statistics = other133.statistics;
+  __isset = other133.__isset;
 }
-DataPageHeader& DataPageHeader::operator=(const DataPageHeader& other80) {
-  num_values = other80.num_values;
-  encoding = other80.encoding;
-  definition_level_encoding = other80.definition_level_encoding;
-  repetition_level_encoding = other80.repetition_level_encoding;
-  statistics = other80.statistics;
-  __isset = other80.__isset;
+DataPageHeader::DataPageHeader(DataPageHeader&& other134) noexcept {
+  num_values = other134.num_values;
+  encoding = other134.encoding;
+  definition_level_encoding = other134.definition_level_encoding;
+  repetition_level_encoding = other134.repetition_level_encoding;
+  statistics = std::move(other134.statistics);
+  __isset = other134.__isset;
+}
+DataPageHeader& DataPageHeader::operator=(const DataPageHeader& other135) {
+  num_values = other135.num_values;
+  encoding = other135.encoding;
+  definition_level_encoding = other135.definition_level_encoding;
+  repetition_level_encoding = other135.repetition_level_encoding;
+  statistics = other135.statistics;
+  __isset = other135.__isset;
+  return *this;
+}
+DataPageHeader& DataPageHeader::operator=(DataPageHeader&& other136) noexcept {
+  num_values = other136.num_values;
+  encoding = other136.encoding;
+  definition_level_encoding = other136.definition_level_encoding;
+  repetition_level_encoding = other136.repetition_level_encoding;
+  statistics = std::move(other136.statistics);
+  __isset = other136.__isset;
   return *this;
 }
 void DataPageHeader::printTo(std::ostream& out) const {
@@ -2561,11 +2885,18 @@ bool IndexPageHeader::operator==(const IndexPageHeader & /* rhs */) const
   return true;
 }
 
-IndexPageHeader::IndexPageHeader(const IndexPageHeader& other81) noexcept {
-  (void) other81;
+IndexPageHeader::IndexPageHeader(const IndexPageHeader& other137) noexcept {
+  (void) other137;
 }
-IndexPageHeader& IndexPageHeader::operator=(const IndexPageHeader& other82) noexcept {
-  (void) other82;
+IndexPageHeader::IndexPageHeader(IndexPageHeader&& other138) noexcept {
+  (void) other138;
+}
+IndexPageHeader& IndexPageHeader::operator=(const IndexPageHeader& other139) noexcept {
+  (void) other139;
+  return *this;
+}
+IndexPageHeader& IndexPageHeader::operator=(IndexPageHeader&& other140) noexcept {
+  (void) other140;
   return *this;
 }
 void IndexPageHeader::printTo(std::ostream& out) const {
@@ -2624,17 +2955,30 @@ bool DictionaryPageHeader::operator==(const DictionaryPageHeader & rhs) const
   return true;
 }
 
-DictionaryPageHeader::DictionaryPageHeader(const DictionaryPageHeader& other84) noexcept {
-  num_values = other84.num_values;
-  encoding = other84.encoding;
-  is_sorted = other84.is_sorted;
-  __isset = other84.__isset;
+DictionaryPageHeader::DictionaryPageHeader(const DictionaryPageHeader& other142) noexcept {
+  num_values = other142.num_values;
+  encoding = other142.encoding;
+  is_sorted = other142.is_sorted;
+  __isset = other142.__isset;
 }
-DictionaryPageHeader& DictionaryPageHeader::operator=(const DictionaryPageHeader& other85) noexcept {
-  num_values = other85.num_values;
-  encoding = other85.encoding;
-  is_sorted = other85.is_sorted;
-  __isset = other85.__isset;
+DictionaryPageHeader::DictionaryPageHeader(DictionaryPageHeader&& other143) noexcept {
+  num_values = other143.num_values;
+  encoding = other143.encoding;
+  is_sorted = other143.is_sorted;
+  __isset = other143.__isset;
+}
+DictionaryPageHeader& DictionaryPageHeader::operator=(const DictionaryPageHeader& other144) noexcept {
+  num_values = other144.num_values;
+  encoding = other144.encoding;
+  is_sorted = other144.is_sorted;
+  __isset = other144.__isset;
+  return *this;
+}
+DictionaryPageHeader& DictionaryPageHeader::operator=(DictionaryPageHeader&& other145) noexcept {
+  num_values = other145.num_values;
+  encoding = other145.encoding;
+  is_sorted = other145.is_sorted;
+  __isset = other145.__isset;
   return *this;
 }
 void DictionaryPageHeader::printTo(std::ostream& out) const {
@@ -2738,27 +3082,50 @@ bool DataPageHeaderV2::operator==(const DataPageHeaderV2 & rhs) const
   return true;
 }
 
-DataPageHeaderV2::DataPageHeaderV2(const DataPageHeaderV2& other87) {
-  num_values = other87.num_values;
-  num_nulls = other87.num_nulls;
-  num_rows = other87.num_rows;
-  encoding = other87.encoding;
-  definition_levels_byte_length = other87.definition_levels_byte_length;
-  repetition_levels_byte_length = other87.repetition_levels_byte_length;
-  is_compressed = other87.is_compressed;
-  statistics = other87.statistics;
-  __isset = other87.__isset;
+DataPageHeaderV2::DataPageHeaderV2(const DataPageHeaderV2& other147) {
+  num_values = other147.num_values;
+  num_nulls = other147.num_nulls;
+  num_rows = other147.num_rows;
+  encoding = other147.encoding;
+  definition_levels_byte_length = other147.definition_levels_byte_length;
+  repetition_levels_byte_length = other147.repetition_levels_byte_length;
+  is_compressed = other147.is_compressed;
+  statistics = other147.statistics;
+  __isset = other147.__isset;
 }
-DataPageHeaderV2& DataPageHeaderV2::operator=(const DataPageHeaderV2& other88) {
-  num_values = other88.num_values;
-  num_nulls = other88.num_nulls;
-  num_rows = other88.num_rows;
-  encoding = other88.encoding;
-  definition_levels_byte_length = other88.definition_levels_byte_length;
-  repetition_levels_byte_length = other88.repetition_levels_byte_length;
-  is_compressed = other88.is_compressed;
-  statistics = other88.statistics;
-  __isset = other88.__isset;
+DataPageHeaderV2::DataPageHeaderV2(DataPageHeaderV2&& other148) noexcept {
+  num_values = other148.num_values;
+  num_nulls = other148.num_nulls;
+  num_rows = other148.num_rows;
+  encoding = other148.encoding;
+  definition_levels_byte_length = other148.definition_levels_byte_length;
+  repetition_levels_byte_length = other148.repetition_levels_byte_length;
+  is_compressed = other148.is_compressed;
+  statistics = std::move(other148.statistics);
+  __isset = other148.__isset;
+}
+DataPageHeaderV2& DataPageHeaderV2::operator=(const DataPageHeaderV2& other149) {
+  num_values = other149.num_values;
+  num_nulls = other149.num_nulls;
+  num_rows = other149.num_rows;
+  encoding = other149.encoding;
+  definition_levels_byte_length = other149.definition_levels_byte_length;
+  repetition_levels_byte_length = other149.repetition_levels_byte_length;
+  is_compressed = other149.is_compressed;
+  statistics = other149.statistics;
+  __isset = other149.__isset;
+  return *this;
+}
+DataPageHeaderV2& DataPageHeaderV2::operator=(DataPageHeaderV2&& other150) noexcept {
+  num_values = other150.num_values;
+  num_nulls = other150.num_nulls;
+  num_rows = other150.num_rows;
+  encoding = other150.encoding;
+  definition_levels_byte_length = other150.definition_levels_byte_length;
+  repetition_levels_byte_length = other150.repetition_levels_byte_length;
+  is_compressed = other150.is_compressed;
+  statistics = std::move(other150.statistics);
+  __isset = other150.__isset;
   return *this;
 }
 void DataPageHeaderV2::printTo(std::ostream& out) const {
@@ -2799,11 +3166,18 @@ bool SplitBlockAlgorithm::operator==(const SplitBlockAlgorithm & /* rhs */) cons
   return true;
 }
 
-SplitBlockAlgorithm::SplitBlockAlgorithm(const SplitBlockAlgorithm& other89) noexcept {
-  (void) other89;
+SplitBlockAlgorithm::SplitBlockAlgorithm(const SplitBlockAlgorithm& other151) noexcept {
+  (void) other151;
 }
-SplitBlockAlgorithm& SplitBlockAlgorithm::operator=(const SplitBlockAlgorithm& other90) noexcept {
-  (void) other90;
+SplitBlockAlgorithm::SplitBlockAlgorithm(SplitBlockAlgorithm&& other152) noexcept {
+  (void) other152;
+}
+SplitBlockAlgorithm& SplitBlockAlgorithm::operator=(const SplitBlockAlgorithm& other153) noexcept {
+  (void) other153;
+  return *this;
+}
+SplitBlockAlgorithm& SplitBlockAlgorithm::operator=(SplitBlockAlgorithm&& other154) noexcept {
+  (void) other154;
   return *this;
 }
 void SplitBlockAlgorithm::printTo(std::ostream& out) const {
@@ -2845,13 +3219,22 @@ bool BloomFilterAlgorithm::operator==(const BloomFilterAlgorithm & rhs) const
   return true;
 }
 
-BloomFilterAlgorithm::BloomFilterAlgorithm(const BloomFilterAlgorithm& other91) noexcept {
-  BLOCK = other91.BLOCK;
-  __isset = other91.__isset;
+BloomFilterAlgorithm::BloomFilterAlgorithm(const BloomFilterAlgorithm& other155) noexcept {
+  BLOCK = other155.BLOCK;
+  __isset = other155.__isset;
 }
-BloomFilterAlgorithm& BloomFilterAlgorithm::operator=(const BloomFilterAlgorithm& other92) noexcept {
-  BLOCK = other92.BLOCK;
-  __isset = other92.__isset;
+BloomFilterAlgorithm::BloomFilterAlgorithm(BloomFilterAlgorithm&& other156) noexcept {
+  BLOCK = std::move(other156.BLOCK);
+  __isset = other156.__isset;
+}
+BloomFilterAlgorithm& BloomFilterAlgorithm::operator=(const BloomFilterAlgorithm& other157) noexcept {
+  BLOCK = other157.BLOCK;
+  __isset = other157.__isset;
+  return *this;
+}
+BloomFilterAlgorithm& BloomFilterAlgorithm::operator=(BloomFilterAlgorithm&& other158) noexcept {
+  BLOCK = std::move(other158.BLOCK);
+  __isset = other158.__isset;
   return *this;
 }
 void BloomFilterAlgorithm::printTo(std::ostream& out) const {
@@ -2885,11 +3268,18 @@ bool XxHash::operator==(const XxHash & /* rhs */) const
   return true;
 }
 
-XxHash::XxHash(const XxHash& other93) noexcept {
-  (void) other93;
+XxHash::XxHash(const XxHash& other159) noexcept {
+  (void) other159;
 }
-XxHash& XxHash::operator=(const XxHash& other94) noexcept {
-  (void) other94;
+XxHash::XxHash(XxHash&& other160) noexcept {
+  (void) other160;
+}
+XxHash& XxHash::operator=(const XxHash& other161) noexcept {
+  (void) other161;
+  return *this;
+}
+XxHash& XxHash::operator=(XxHash&& other162) noexcept {
+  (void) other162;
   return *this;
 }
 void XxHash::printTo(std::ostream& out) const {
@@ -2931,13 +3321,22 @@ bool BloomFilterHash::operator==(const BloomFilterHash & rhs) const
   return true;
 }
 
-BloomFilterHash::BloomFilterHash(const BloomFilterHash& other95) noexcept {
-  XXHASH = other95.XXHASH;
-  __isset = other95.__isset;
+BloomFilterHash::BloomFilterHash(const BloomFilterHash& other163) noexcept {
+  XXHASH = other163.XXHASH;
+  __isset = other163.__isset;
 }
-BloomFilterHash& BloomFilterHash::operator=(const BloomFilterHash& other96) noexcept {
-  XXHASH = other96.XXHASH;
-  __isset = other96.__isset;
+BloomFilterHash::BloomFilterHash(BloomFilterHash&& other164) noexcept {
+  XXHASH = std::move(other164.XXHASH);
+  __isset = other164.__isset;
+}
+BloomFilterHash& BloomFilterHash::operator=(const BloomFilterHash& other165) noexcept {
+  XXHASH = other165.XXHASH;
+  __isset = other165.__isset;
+  return *this;
+}
+BloomFilterHash& BloomFilterHash::operator=(BloomFilterHash&& other166) noexcept {
+  XXHASH = std::move(other166.XXHASH);
+  __isset = other166.__isset;
   return *this;
 }
 void BloomFilterHash::printTo(std::ostream& out) const {
@@ -2971,11 +3370,18 @@ bool Uncompressed::operator==(const Uncompressed & /* rhs */) const
   return true;
 }
 
-Uncompressed::Uncompressed(const Uncompressed& other97) noexcept {
-  (void) other97;
+Uncompressed::Uncompressed(const Uncompressed& other167) noexcept {
+  (void) other167;
 }
-Uncompressed& Uncompressed::operator=(const Uncompressed& other98) noexcept {
-  (void) other98;
+Uncompressed::Uncompressed(Uncompressed&& other168) noexcept {
+  (void) other168;
+}
+Uncompressed& Uncompressed::operator=(const Uncompressed& other169) noexcept {
+  (void) other169;
+  return *this;
+}
+Uncompressed& Uncompressed::operator=(Uncompressed&& other170) noexcept {
+  (void) other170;
   return *this;
 }
 void Uncompressed::printTo(std::ostream& out) const {
@@ -3017,13 +3423,22 @@ bool BloomFilterCompression::operator==(const BloomFilterCompression & rhs) cons
   return true;
 }
 
-BloomFilterCompression::BloomFilterCompression(const BloomFilterCompression& other99) noexcept {
-  UNCOMPRESSED = other99.UNCOMPRESSED;
-  __isset = other99.__isset;
+BloomFilterCompression::BloomFilterCompression(const BloomFilterCompression& other171) noexcept {
+  UNCOMPRESSED = other171.UNCOMPRESSED;
+  __isset = other171.__isset;
 }
-BloomFilterCompression& BloomFilterCompression::operator=(const BloomFilterCompression& other100) noexcept {
-  UNCOMPRESSED = other100.UNCOMPRESSED;
-  __isset = other100.__isset;
+BloomFilterCompression::BloomFilterCompression(BloomFilterCompression&& other172) noexcept {
+  UNCOMPRESSED = std::move(other172.UNCOMPRESSED);
+  __isset = other172.__isset;
+}
+BloomFilterCompression& BloomFilterCompression::operator=(const BloomFilterCompression& other173) noexcept {
+  UNCOMPRESSED = other173.UNCOMPRESSED;
+  __isset = other173.__isset;
+  return *this;
+}
+BloomFilterCompression& BloomFilterCompression::operator=(BloomFilterCompression&& other174) noexcept {
+  UNCOMPRESSED = std::move(other174.UNCOMPRESSED);
+  __isset = other174.__isset;
   return *this;
 }
 void BloomFilterCompression::printTo(std::ostream& out) const {
@@ -3084,17 +3499,30 @@ bool BloomFilterHeader::operator==(const BloomFilterHeader & rhs) const
   return true;
 }
 
-BloomFilterHeader::BloomFilterHeader(const BloomFilterHeader& other101) noexcept {
-  numBytes = other101.numBytes;
-  algorithm = other101.algorithm;
-  hash = other101.hash;
-  compression = other101.compression;
+BloomFilterHeader::BloomFilterHeader(const BloomFilterHeader& other175) noexcept {
+  numBytes = other175.numBytes;
+  algorithm = other175.algorithm;
+  hash = other175.hash;
+  compression = other175.compression;
 }
-BloomFilterHeader& BloomFilterHeader::operator=(const BloomFilterHeader& other102) noexcept {
-  numBytes = other102.numBytes;
-  algorithm = other102.algorithm;
-  hash = other102.hash;
-  compression = other102.compression;
+BloomFilterHeader::BloomFilterHeader(BloomFilterHeader&& other176) noexcept {
+  numBytes = other176.numBytes;
+  algorithm = std::move(other176.algorithm);
+  hash = std::move(other176.hash);
+  compression = std::move(other176.compression);
+}
+BloomFilterHeader& BloomFilterHeader::operator=(const BloomFilterHeader& other177) noexcept {
+  numBytes = other177.numBytes;
+  algorithm = other177.algorithm;
+  hash = other177.hash;
+  compression = other177.compression;
+  return *this;
+}
+BloomFilterHeader& BloomFilterHeader::operator=(BloomFilterHeader&& other178) noexcept {
+  numBytes = other178.numBytes;
+  algorithm = std::move(other178.algorithm);
+  hash = std::move(other178.hash);
+  compression = std::move(other178.compression);
   return *this;
 }
 void BloomFilterHeader::printTo(std::ostream& out) const {
@@ -3205,27 +3633,50 @@ bool PageHeader::operator==(const PageHeader & rhs) const
   return true;
 }
 
-PageHeader::PageHeader(const PageHeader& other104) {
-  type = other104.type;
-  uncompressed_page_size = other104.uncompressed_page_size;
-  compressed_page_size = other104.compressed_page_size;
-  crc = other104.crc;
-  data_page_header = other104.data_page_header;
-  index_page_header = other104.index_page_header;
-  dictionary_page_header = other104.dictionary_page_header;
-  data_page_header_v2 = other104.data_page_header_v2;
-  __isset = other104.__isset;
+PageHeader::PageHeader(const PageHeader& other180) {
+  type = other180.type;
+  uncompressed_page_size = other180.uncompressed_page_size;
+  compressed_page_size = other180.compressed_page_size;
+  crc = other180.crc;
+  data_page_header = other180.data_page_header;
+  index_page_header = other180.index_page_header;
+  dictionary_page_header = other180.dictionary_page_header;
+  data_page_header_v2 = other180.data_page_header_v2;
+  __isset = other180.__isset;
 }
-PageHeader& PageHeader::operator=(const PageHeader& other105) {
-  type = other105.type;
-  uncompressed_page_size = other105.uncompressed_page_size;
-  compressed_page_size = other105.compressed_page_size;
-  crc = other105.crc;
-  data_page_header = other105.data_page_header;
-  index_page_header = other105.index_page_header;
-  dictionary_page_header = other105.dictionary_page_header;
-  data_page_header_v2 = other105.data_page_header_v2;
-  __isset = other105.__isset;
+PageHeader::PageHeader(PageHeader&& other181) noexcept {
+  type = other181.type;
+  uncompressed_page_size = other181.uncompressed_page_size;
+  compressed_page_size = other181.compressed_page_size;
+  crc = other181.crc;
+  data_page_header = std::move(other181.data_page_header);
+  index_page_header = std::move(other181.index_page_header);
+  dictionary_page_header = std::move(other181.dictionary_page_header);
+  data_page_header_v2 = std::move(other181.data_page_header_v2);
+  __isset = other181.__isset;
+}
+PageHeader& PageHeader::operator=(const PageHeader& other182) {
+  type = other182.type;
+  uncompressed_page_size = other182.uncompressed_page_size;
+  compressed_page_size = other182.compressed_page_size;
+  crc = other182.crc;
+  data_page_header = other182.data_page_header;
+  index_page_header = other182.index_page_header;
+  dictionary_page_header = other182.dictionary_page_header;
+  data_page_header_v2 = other182.data_page_header_v2;
+  __isset = other182.__isset;
+  return *this;
+}
+PageHeader& PageHeader::operator=(PageHeader&& other183) noexcept {
+  type = other183.type;
+  uncompressed_page_size = other183.uncompressed_page_size;
+  compressed_page_size = other183.compressed_page_size;
+  crc = other183.crc;
+  data_page_header = std::move(other183.data_page_header);
+  index_page_header = std::move(other183.index_page_header);
+  dictionary_page_header = std::move(other183.dictionary_page_header);
+  data_page_header_v2 = std::move(other183.data_page_header_v2);
+  __isset = other183.__isset;
   return *this;
 }
 void PageHeader::printTo(std::ostream& out) const {
@@ -3284,15 +3735,26 @@ bool KeyValue::operator==(const KeyValue & rhs) const
   return true;
 }
 
-KeyValue::KeyValue(const KeyValue& other106) {
-  key = other106.key;
-  value = other106.value;
-  __isset = other106.__isset;
+KeyValue::KeyValue(const KeyValue& other184) {
+  key = other184.key;
+  value = other184.value;
+  __isset = other184.__isset;
 }
-KeyValue& KeyValue::operator=(const KeyValue& other107) {
-  key = other107.key;
-  value = other107.value;
-  __isset = other107.__isset;
+KeyValue::KeyValue(KeyValue&& other185) noexcept {
+  key = std::move(other185.key);
+  value = std::move(other185.value);
+  __isset = other185.__isset;
+}
+KeyValue& KeyValue::operator=(const KeyValue& other186) {
+  key = other186.key;
+  value = other186.value;
+  __isset = other186.__isset;
+  return *this;
+}
+KeyValue& KeyValue::operator=(KeyValue&& other187) noexcept {
+  key = std::move(other187.key);
+  value = std::move(other187.value);
+  __isset = other187.__isset;
   return *this;
 }
 void KeyValue::printTo(std::ostream& out) const {
@@ -3349,15 +3811,26 @@ bool SortingColumn::operator==(const SortingColumn & rhs) const
   return true;
 }
 
-SortingColumn::SortingColumn(const SortingColumn& other108) noexcept {
-  column_idx = other108.column_idx;
-  descending = other108.descending;
-  nulls_first = other108.nulls_first;
+SortingColumn::SortingColumn(const SortingColumn& other188) noexcept {
+  column_idx = other188.column_idx;
+  descending = other188.descending;
+  nulls_first = other188.nulls_first;
 }
-SortingColumn& SortingColumn::operator=(const SortingColumn& other109) noexcept {
-  column_idx = other109.column_idx;
-  descending = other109.descending;
-  nulls_first = other109.nulls_first;
+SortingColumn::SortingColumn(SortingColumn&& other189) noexcept {
+  column_idx = other189.column_idx;
+  descending = other189.descending;
+  nulls_first = other189.nulls_first;
+}
+SortingColumn& SortingColumn::operator=(const SortingColumn& other190) noexcept {
+  column_idx = other190.column_idx;
+  descending = other190.descending;
+  nulls_first = other190.nulls_first;
+  return *this;
+}
+SortingColumn& SortingColumn::operator=(SortingColumn&& other191) noexcept {
+  column_idx = other191.column_idx;
+  descending = other191.descending;
+  nulls_first = other191.nulls_first;
   return *this;
 }
 void SortingColumn::printTo(std::ostream& out) const {
@@ -3415,15 +3888,26 @@ bool PageEncodingStats::operator==(const PageEncodingStats & rhs) const
   return true;
 }
 
-PageEncodingStats::PageEncodingStats(const PageEncodingStats& other112) noexcept {
-  page_type = other112.page_type;
-  encoding = other112.encoding;
-  count = other112.count;
+PageEncodingStats::PageEncodingStats(const PageEncodingStats& other194) noexcept {
+  page_type = other194.page_type;
+  encoding = other194.encoding;
+  count = other194.count;
 }
-PageEncodingStats& PageEncodingStats::operator=(const PageEncodingStats& other113) noexcept {
-  page_type = other113.page_type;
-  encoding = other113.encoding;
-  count = other113.count;
+PageEncodingStats::PageEncodingStats(PageEncodingStats&& other195) noexcept {
+  page_type = other195.page_type;
+  encoding = other195.encoding;
+  count = other195.count;
+}
+PageEncodingStats& PageEncodingStats::operator=(const PageEncodingStats& other196) noexcept {
+  page_type = other196.page_type;
+  encoding = other196.encoding;
+  count = other196.count;
+  return *this;
+}
+PageEncodingStats& PageEncodingStats::operator=(PageEncodingStats&& other197) noexcept {
+  page_type = other197.page_type;
+  encoding = other197.encoding;
+  count = other197.count;
   return *this;
 }
 void PageEncodingStats::printTo(std::ostream& out) const {
@@ -3614,45 +4098,86 @@ bool ColumnMetaData::operator==(const ColumnMetaData & rhs) const
   return true;
 }
 
-ColumnMetaData::ColumnMetaData(const ColumnMetaData& other141) {
-  type = other141.type;
-  encodings = other141.encodings;
-  path_in_schema = other141.path_in_schema;
-  codec = other141.codec;
-  num_values = other141.num_values;
-  total_uncompressed_size = other141.total_uncompressed_size;
-  total_compressed_size = other141.total_compressed_size;
-  key_value_metadata = other141.key_value_metadata;
-  data_page_offset = other141.data_page_offset;
-  index_page_offset = other141.index_page_offset;
-  dictionary_page_offset = other141.dictionary_page_offset;
-  statistics = other141.statistics;
-  encoding_stats = other141.encoding_stats;
-  bloom_filter_offset = other141.bloom_filter_offset;
-  bloom_filter_length = other141.bloom_filter_length;
-  size_statistics = other141.size_statistics;
-  geospatial_statistics = other141.geospatial_statistics;
-  __isset = other141.__isset;
+ColumnMetaData::ColumnMetaData(const ColumnMetaData& other225) {
+  type = other225.type;
+  encodings = other225.encodings;
+  path_in_schema = other225.path_in_schema;
+  codec = other225.codec;
+  num_values = other225.num_values;
+  total_uncompressed_size = other225.total_uncompressed_size;
+  total_compressed_size = other225.total_compressed_size;
+  key_value_metadata = other225.key_value_metadata;
+  data_page_offset = other225.data_page_offset;
+  index_page_offset = other225.index_page_offset;
+  dictionary_page_offset = other225.dictionary_page_offset;
+  statistics = other225.statistics;
+  encoding_stats = other225.encoding_stats;
+  bloom_filter_offset = other225.bloom_filter_offset;
+  bloom_filter_length = other225.bloom_filter_length;
+  size_statistics = other225.size_statistics;
+  geospatial_statistics = other225.geospatial_statistics;
+  __isset = other225.__isset;
 }
-ColumnMetaData& ColumnMetaData::operator=(const ColumnMetaData& other142) {
-  type = other142.type;
-  encodings = other142.encodings;
-  path_in_schema = other142.path_in_schema;
-  codec = other142.codec;
-  num_values = other142.num_values;
-  total_uncompressed_size = other142.total_uncompressed_size;
-  total_compressed_size = other142.total_compressed_size;
-  key_value_metadata = other142.key_value_metadata;
-  data_page_offset = other142.data_page_offset;
-  index_page_offset = other142.index_page_offset;
-  dictionary_page_offset = other142.dictionary_page_offset;
-  statistics = other142.statistics;
-  encoding_stats = other142.encoding_stats;
-  bloom_filter_offset = other142.bloom_filter_offset;
-  bloom_filter_length = other142.bloom_filter_length;
-  size_statistics = other142.size_statistics;
-  geospatial_statistics = other142.geospatial_statistics;
-  __isset = other142.__isset;
+ColumnMetaData::ColumnMetaData(ColumnMetaData&& other226) noexcept {
+  type = other226.type;
+  encodings = std::move(other226.encodings);
+  path_in_schema = std::move(other226.path_in_schema);
+  codec = other226.codec;
+  num_values = other226.num_values;
+  total_uncompressed_size = other226.total_uncompressed_size;
+  total_compressed_size = other226.total_compressed_size;
+  key_value_metadata = std::move(other226.key_value_metadata);
+  data_page_offset = other226.data_page_offset;
+  index_page_offset = other226.index_page_offset;
+  dictionary_page_offset = other226.dictionary_page_offset;
+  statistics = std::move(other226.statistics);
+  encoding_stats = std::move(other226.encoding_stats);
+  bloom_filter_offset = other226.bloom_filter_offset;
+  bloom_filter_length = other226.bloom_filter_length;
+  size_statistics = std::move(other226.size_statistics);
+  geospatial_statistics = std::move(other226.geospatial_statistics);
+  __isset = other226.__isset;
+}
+ColumnMetaData& ColumnMetaData::operator=(const ColumnMetaData& other227) {
+  type = other227.type;
+  encodings = other227.encodings;
+  path_in_schema = other227.path_in_schema;
+  codec = other227.codec;
+  num_values = other227.num_values;
+  total_uncompressed_size = other227.total_uncompressed_size;
+  total_compressed_size = other227.total_compressed_size;
+  key_value_metadata = other227.key_value_metadata;
+  data_page_offset = other227.data_page_offset;
+  index_page_offset = other227.index_page_offset;
+  dictionary_page_offset = other227.dictionary_page_offset;
+  statistics = other227.statistics;
+  encoding_stats = other227.encoding_stats;
+  bloom_filter_offset = other227.bloom_filter_offset;
+  bloom_filter_length = other227.bloom_filter_length;
+  size_statistics = other227.size_statistics;
+  geospatial_statistics = other227.geospatial_statistics;
+  __isset = other227.__isset;
+  return *this;
+}
+ColumnMetaData& ColumnMetaData::operator=(ColumnMetaData&& other228) noexcept {
+  type = other228.type;
+  encodings = std::move(other228.encodings);
+  path_in_schema = std::move(other228.path_in_schema);
+  codec = other228.codec;
+  num_values = other228.num_values;
+  total_uncompressed_size = other228.total_uncompressed_size;
+  total_compressed_size = other228.total_compressed_size;
+  key_value_metadata = std::move(other228.key_value_metadata);
+  data_page_offset = other228.data_page_offset;
+  index_page_offset = other228.index_page_offset;
+  dictionary_page_offset = other228.dictionary_page_offset;
+  statistics = std::move(other228.statistics);
+  encoding_stats = std::move(other228.encoding_stats);
+  bloom_filter_offset = other228.bloom_filter_offset;
+  bloom_filter_length = other228.bloom_filter_length;
+  size_statistics = std::move(other228.size_statistics);
+  geospatial_statistics = std::move(other228.geospatial_statistics);
+  __isset = other228.__isset;
   return *this;
 }
 void ColumnMetaData::printTo(std::ostream& out) const {
@@ -3702,11 +4227,18 @@ bool EncryptionWithFooterKey::operator==(const EncryptionWithFooterKey & /* rhs 
   return true;
 }
 
-EncryptionWithFooterKey::EncryptionWithFooterKey(const EncryptionWithFooterKey& other143) noexcept {
-  (void) other143;
+EncryptionWithFooterKey::EncryptionWithFooterKey(const EncryptionWithFooterKey& other229) noexcept {
+  (void) other229;
 }
-EncryptionWithFooterKey& EncryptionWithFooterKey::operator=(const EncryptionWithFooterKey& other144) noexcept {
-  (void) other144;
+EncryptionWithFooterKey::EncryptionWithFooterKey(EncryptionWithFooterKey&& other230) noexcept {
+  (void) other230;
+}
+EncryptionWithFooterKey& EncryptionWithFooterKey::operator=(const EncryptionWithFooterKey& other231) noexcept {
+  (void) other231;
+  return *this;
+}
+EncryptionWithFooterKey& EncryptionWithFooterKey::operator=(EncryptionWithFooterKey&& other232) noexcept {
+  (void) other232;
   return *this;
 }
 void EncryptionWithFooterKey::printTo(std::ostream& out) const {
@@ -3756,15 +4288,26 @@ bool EncryptionWithColumnKey::operator==(const EncryptionWithColumnKey & rhs) co
   return true;
 }
 
-EncryptionWithColumnKey::EncryptionWithColumnKey(const EncryptionWithColumnKey& other151) {
-  path_in_schema = other151.path_in_schema;
-  key_metadata = other151.key_metadata;
-  __isset = other151.__isset;
+EncryptionWithColumnKey::EncryptionWithColumnKey(const EncryptionWithColumnKey& other239) {
+  path_in_schema = other239.path_in_schema;
+  key_metadata = other239.key_metadata;
+  __isset = other239.__isset;
 }
-EncryptionWithColumnKey& EncryptionWithColumnKey::operator=(const EncryptionWithColumnKey& other152) {
-  path_in_schema = other152.path_in_schema;
-  key_metadata = other152.key_metadata;
-  __isset = other152.__isset;
+EncryptionWithColumnKey::EncryptionWithColumnKey(EncryptionWithColumnKey&& other240) noexcept {
+  path_in_schema = std::move(other240.path_in_schema);
+  key_metadata = std::move(other240.key_metadata);
+  __isset = other240.__isset;
+}
+EncryptionWithColumnKey& EncryptionWithColumnKey::operator=(const EncryptionWithColumnKey& other241) {
+  path_in_schema = other241.path_in_schema;
+  key_metadata = other241.key_metadata;
+  __isset = other241.__isset;
+  return *this;
+}
+EncryptionWithColumnKey& EncryptionWithColumnKey::operator=(EncryptionWithColumnKey&& other242) noexcept {
+  path_in_schema = std::move(other242.path_in_schema);
+  key_metadata = std::move(other242.key_metadata);
+  __isset = other242.__isset;
   return *this;
 }
 void EncryptionWithColumnKey::printTo(std::ostream& out) const {
@@ -3818,15 +4361,26 @@ bool ColumnCryptoMetaData::operator==(const ColumnCryptoMetaData & rhs) const
   return true;
 }
 
-ColumnCryptoMetaData::ColumnCryptoMetaData(const ColumnCryptoMetaData& other153) {
-  ENCRYPTION_WITH_FOOTER_KEY = other153.ENCRYPTION_WITH_FOOTER_KEY;
-  ENCRYPTION_WITH_COLUMN_KEY = other153.ENCRYPTION_WITH_COLUMN_KEY;
-  __isset = other153.__isset;
+ColumnCryptoMetaData::ColumnCryptoMetaData(const ColumnCryptoMetaData& other243) {
+  ENCRYPTION_WITH_FOOTER_KEY = other243.ENCRYPTION_WITH_FOOTER_KEY;
+  ENCRYPTION_WITH_COLUMN_KEY = other243.ENCRYPTION_WITH_COLUMN_KEY;
+  __isset = other243.__isset;
 }
-ColumnCryptoMetaData& ColumnCryptoMetaData::operator=(const ColumnCryptoMetaData& other154) {
-  ENCRYPTION_WITH_FOOTER_KEY = other154.ENCRYPTION_WITH_FOOTER_KEY;
-  ENCRYPTION_WITH_COLUMN_KEY = other154.ENCRYPTION_WITH_COLUMN_KEY;
-  __isset = other154.__isset;
+ColumnCryptoMetaData::ColumnCryptoMetaData(ColumnCryptoMetaData&& other244) noexcept {
+  ENCRYPTION_WITH_FOOTER_KEY = std::move(other244.ENCRYPTION_WITH_FOOTER_KEY);
+  ENCRYPTION_WITH_COLUMN_KEY = std::move(other244.ENCRYPTION_WITH_COLUMN_KEY);
+  __isset = other244.__isset;
+}
+ColumnCryptoMetaData& ColumnCryptoMetaData::operator=(const ColumnCryptoMetaData& other245) {
+  ENCRYPTION_WITH_FOOTER_KEY = other245.ENCRYPTION_WITH_FOOTER_KEY;
+  ENCRYPTION_WITH_COLUMN_KEY = other245.ENCRYPTION_WITH_COLUMN_KEY;
+  __isset = other245.__isset;
+  return *this;
+}
+ColumnCryptoMetaData& ColumnCryptoMetaData::operator=(ColumnCryptoMetaData&& other246) noexcept {
+  ENCRYPTION_WITH_FOOTER_KEY = std::move(other246.ENCRYPTION_WITH_FOOTER_KEY);
+  ENCRYPTION_WITH_COLUMN_KEY = std::move(other246.ENCRYPTION_WITH_COLUMN_KEY);
+  __isset = other246.__isset;
   return *this;
 }
 void ColumnCryptoMetaData::printTo(std::ostream& out) const {
@@ -3954,29 +4508,54 @@ bool ColumnChunk::operator==(const ColumnChunk & rhs) const
   return true;
 }
 
-ColumnChunk::ColumnChunk(const ColumnChunk& other155) {
-  file_path = other155.file_path;
-  file_offset = other155.file_offset;
-  meta_data = other155.meta_data;
-  offset_index_offset = other155.offset_index_offset;
-  offset_index_length = other155.offset_index_length;
-  column_index_offset = other155.column_index_offset;
-  column_index_length = other155.column_index_length;
-  crypto_metadata = other155.crypto_metadata;
-  encrypted_column_metadata = other155.encrypted_column_metadata;
-  __isset = other155.__isset;
+ColumnChunk::ColumnChunk(const ColumnChunk& other247) {
+  file_path = other247.file_path;
+  file_offset = other247.file_offset;
+  meta_data = other247.meta_data;
+  offset_index_offset = other247.offset_index_offset;
+  offset_index_length = other247.offset_index_length;
+  column_index_offset = other247.column_index_offset;
+  column_index_length = other247.column_index_length;
+  crypto_metadata = other247.crypto_metadata;
+  encrypted_column_metadata = other247.encrypted_column_metadata;
+  __isset = other247.__isset;
 }
-ColumnChunk& ColumnChunk::operator=(const ColumnChunk& other156) {
-  file_path = other156.file_path;
-  file_offset = other156.file_offset;
-  meta_data = other156.meta_data;
-  offset_index_offset = other156.offset_index_offset;
-  offset_index_length = other156.offset_index_length;
-  column_index_offset = other156.column_index_offset;
-  column_index_length = other156.column_index_length;
-  crypto_metadata = other156.crypto_metadata;
-  encrypted_column_metadata = other156.encrypted_column_metadata;
-  __isset = other156.__isset;
+ColumnChunk::ColumnChunk(ColumnChunk&& other248) noexcept {
+  file_path = std::move(other248.file_path);
+  file_offset = other248.file_offset;
+  meta_data = std::move(other248.meta_data);
+  offset_index_offset = other248.offset_index_offset;
+  offset_index_length = other248.offset_index_length;
+  column_index_offset = other248.column_index_offset;
+  column_index_length = other248.column_index_length;
+  crypto_metadata = std::move(other248.crypto_metadata);
+  encrypted_column_metadata = std::move(other248.encrypted_column_metadata);
+  __isset = other248.__isset;
+}
+ColumnChunk& ColumnChunk::operator=(const ColumnChunk& other249) {
+  file_path = other249.file_path;
+  file_offset = other249.file_offset;
+  meta_data = other249.meta_data;
+  offset_index_offset = other249.offset_index_offset;
+  offset_index_length = other249.offset_index_length;
+  column_index_offset = other249.column_index_offset;
+  column_index_length = other249.column_index_length;
+  crypto_metadata = other249.crypto_metadata;
+  encrypted_column_metadata = other249.encrypted_column_metadata;
+  __isset = other249.__isset;
+  return *this;
+}
+ColumnChunk& ColumnChunk::operator=(ColumnChunk&& other250) noexcept {
+  file_path = std::move(other250.file_path);
+  file_offset = other250.file_offset;
+  meta_data = std::move(other250.meta_data);
+  offset_index_offset = other250.offset_index_offset;
+  offset_index_length = other250.offset_index_length;
+  column_index_offset = other250.column_index_offset;
+  column_index_length = other250.column_index_length;
+  crypto_metadata = std::move(other250.crypto_metadata);
+  encrypted_column_metadata = std::move(other250.encrypted_column_metadata);
+  __isset = other250.__isset;
   return *this;
 }
 void ColumnChunk::printTo(std::ostream& out) const {
@@ -4083,25 +4662,46 @@ bool RowGroup::operator==(const RowGroup & rhs) const
   return true;
 }
 
-RowGroup::RowGroup(const RowGroup& other169) {
-  columns = other169.columns;
-  total_byte_size = other169.total_byte_size;
-  num_rows = other169.num_rows;
-  sorting_columns = other169.sorting_columns;
-  file_offset = other169.file_offset;
-  total_compressed_size = other169.total_compressed_size;
-  ordinal = other169.ordinal;
-  __isset = other169.__isset;
+RowGroup::RowGroup(const RowGroup& other263) {
+  columns = other263.columns;
+  total_byte_size = other263.total_byte_size;
+  num_rows = other263.num_rows;
+  sorting_columns = other263.sorting_columns;
+  file_offset = other263.file_offset;
+  total_compressed_size = other263.total_compressed_size;
+  ordinal = other263.ordinal;
+  __isset = other263.__isset;
 }
-RowGroup& RowGroup::operator=(const RowGroup& other170) {
-  columns = other170.columns;
-  total_byte_size = other170.total_byte_size;
-  num_rows = other170.num_rows;
-  sorting_columns = other170.sorting_columns;
-  file_offset = other170.file_offset;
-  total_compressed_size = other170.total_compressed_size;
-  ordinal = other170.ordinal;
-  __isset = other170.__isset;
+RowGroup::RowGroup(RowGroup&& other264) noexcept {
+  columns = std::move(other264.columns);
+  total_byte_size = other264.total_byte_size;
+  num_rows = other264.num_rows;
+  sorting_columns = std::move(other264.sorting_columns);
+  file_offset = other264.file_offset;
+  total_compressed_size = other264.total_compressed_size;
+  ordinal = other264.ordinal;
+  __isset = other264.__isset;
+}
+RowGroup& RowGroup::operator=(const RowGroup& other265) {
+  columns = other265.columns;
+  total_byte_size = other265.total_byte_size;
+  num_rows = other265.num_rows;
+  sorting_columns = other265.sorting_columns;
+  file_offset = other265.file_offset;
+  total_compressed_size = other265.total_compressed_size;
+  ordinal = other265.ordinal;
+  __isset = other265.__isset;
+  return *this;
+}
+RowGroup& RowGroup::operator=(RowGroup&& other266) noexcept {
+  columns = std::move(other266.columns);
+  total_byte_size = other266.total_byte_size;
+  num_rows = other266.num_rows;
+  sorting_columns = std::move(other266.sorting_columns);
+  file_offset = other266.file_offset;
+  total_compressed_size = other266.total_compressed_size;
+  ordinal = other266.ordinal;
+  __isset = other266.__isset;
   return *this;
 }
 void RowGroup::printTo(std::ostream& out) const {
@@ -4141,11 +4741,18 @@ bool TypeDefinedOrder::operator==(const TypeDefinedOrder & /* rhs */) const
   return true;
 }
 
-TypeDefinedOrder::TypeDefinedOrder(const TypeDefinedOrder& other171) noexcept {
-  (void) other171;
+TypeDefinedOrder::TypeDefinedOrder(const TypeDefinedOrder& other267) noexcept {
+  (void) other267;
 }
-TypeDefinedOrder& TypeDefinedOrder::operator=(const TypeDefinedOrder& other172) noexcept {
-  (void) other172;
+TypeDefinedOrder::TypeDefinedOrder(TypeDefinedOrder&& other268) noexcept {
+  (void) other268;
+}
+TypeDefinedOrder& TypeDefinedOrder::operator=(const TypeDefinedOrder& other269) noexcept {
+  (void) other269;
+  return *this;
+}
+TypeDefinedOrder& TypeDefinedOrder::operator=(TypeDefinedOrder&& other270) noexcept {
+  (void) other270;
   return *this;
 }
 void TypeDefinedOrder::printTo(std::ostream& out) const {
@@ -4187,13 +4794,22 @@ bool ColumnOrder::operator==(const ColumnOrder & rhs) const
   return true;
 }
 
-ColumnOrder::ColumnOrder(const ColumnOrder& other173) noexcept {
-  TYPE_ORDER = other173.TYPE_ORDER;
-  __isset = other173.__isset;
+ColumnOrder::ColumnOrder(const ColumnOrder& other271) noexcept {
+  TYPE_ORDER = other271.TYPE_ORDER;
+  __isset = other271.__isset;
 }
-ColumnOrder& ColumnOrder::operator=(const ColumnOrder& other174) noexcept {
-  TYPE_ORDER = other174.TYPE_ORDER;
-  __isset = other174.__isset;
+ColumnOrder::ColumnOrder(ColumnOrder&& other272) noexcept {
+  TYPE_ORDER = std::move(other272.TYPE_ORDER);
+  __isset = other272.__isset;
+}
+ColumnOrder& ColumnOrder::operator=(const ColumnOrder& other273) noexcept {
+  TYPE_ORDER = other273.TYPE_ORDER;
+  __isset = other273.__isset;
+  return *this;
+}
+ColumnOrder& ColumnOrder::operator=(ColumnOrder&& other274) noexcept {
+  TYPE_ORDER = std::move(other274.TYPE_ORDER);
+  __isset = other274.__isset;
   return *this;
 }
 void ColumnOrder::printTo(std::ostream& out) const {
@@ -4249,15 +4865,26 @@ bool PageLocation::operator==(const PageLocation & rhs) const
   return true;
 }
 
-PageLocation::PageLocation(const PageLocation& other175) noexcept {
-  offset = other175.offset;
-  compressed_page_size = other175.compressed_page_size;
-  first_row_index = other175.first_row_index;
+PageLocation::PageLocation(const PageLocation& other275) noexcept {
+  offset = other275.offset;
+  compressed_page_size = other275.compressed_page_size;
+  first_row_index = other275.first_row_index;
 }
-PageLocation& PageLocation::operator=(const PageLocation& other176) noexcept {
-  offset = other176.offset;
-  compressed_page_size = other176.compressed_page_size;
-  first_row_index = other176.first_row_index;
+PageLocation::PageLocation(PageLocation&& other276) noexcept {
+  offset = other276.offset;
+  compressed_page_size = other276.compressed_page_size;
+  first_row_index = other276.first_row_index;
+}
+PageLocation& PageLocation::operator=(const PageLocation& other277) noexcept {
+  offset = other277.offset;
+  compressed_page_size = other277.compressed_page_size;
+  first_row_index = other277.first_row_index;
+  return *this;
+}
+PageLocation& PageLocation::operator=(PageLocation&& other278) noexcept {
+  offset = other278.offset;
+  compressed_page_size = other278.compressed_page_size;
+  first_row_index = other278.first_row_index;
   return *this;
 }
 void PageLocation::printTo(std::ostream& out) const {
@@ -4309,15 +4936,26 @@ bool OffsetIndex::operator==(const OffsetIndex & rhs) const
   return true;
 }
 
-OffsetIndex::OffsetIndex(const OffsetIndex& other189) {
-  page_locations = other189.page_locations;
-  unencoded_byte_array_data_bytes = other189.unencoded_byte_array_data_bytes;
-  __isset = other189.__isset;
+OffsetIndex::OffsetIndex(const OffsetIndex& other291) {
+  page_locations = other291.page_locations;
+  unencoded_byte_array_data_bytes = other291.unencoded_byte_array_data_bytes;
+  __isset = other291.__isset;
 }
-OffsetIndex& OffsetIndex::operator=(const OffsetIndex& other190) {
-  page_locations = other190.page_locations;
-  unencoded_byte_array_data_bytes = other190.unencoded_byte_array_data_bytes;
-  __isset = other190.__isset;
+OffsetIndex::OffsetIndex(OffsetIndex&& other292) noexcept {
+  page_locations = std::move(other292.page_locations);
+  unencoded_byte_array_data_bytes = std::move(other292.unencoded_byte_array_data_bytes);
+  __isset = other292.__isset;
+}
+OffsetIndex& OffsetIndex::operator=(const OffsetIndex& other293) {
+  page_locations = other293.page_locations;
+  unencoded_byte_array_data_bytes = other293.unencoded_byte_array_data_bytes;
+  __isset = other293.__isset;
+  return *this;
+}
+OffsetIndex& OffsetIndex::operator=(OffsetIndex&& other294) noexcept {
+  page_locations = std::move(other294.page_locations);
+  unencoded_byte_array_data_bytes = std::move(other294.unencoded_byte_array_data_bytes);
+  __isset = other294.__isset;
   return *this;
 }
 void OffsetIndex::printTo(std::ostream& out) const {
@@ -4410,25 +5048,46 @@ bool ColumnIndex::operator==(const ColumnIndex & rhs) const
   return true;
 }
 
-ColumnIndex::ColumnIndex(const ColumnIndex& other228) {
-  null_pages = other228.null_pages;
-  min_values = other228.min_values;
-  max_values = other228.max_values;
-  boundary_order = other228.boundary_order;
-  null_counts = other228.null_counts;
-  repetition_level_histograms = other228.repetition_level_histograms;
-  definition_level_histograms = other228.definition_level_histograms;
-  __isset = other228.__isset;
+ColumnIndex::ColumnIndex(const ColumnIndex& other332) {
+  null_pages = other332.null_pages;
+  min_values = other332.min_values;
+  max_values = other332.max_values;
+  boundary_order = other332.boundary_order;
+  null_counts = other332.null_counts;
+  repetition_level_histograms = other332.repetition_level_histograms;
+  definition_level_histograms = other332.definition_level_histograms;
+  __isset = other332.__isset;
 }
-ColumnIndex& ColumnIndex::operator=(const ColumnIndex& other229) {
-  null_pages = other229.null_pages;
-  min_values = other229.min_values;
-  max_values = other229.max_values;
-  boundary_order = other229.boundary_order;
-  null_counts = other229.null_counts;
-  repetition_level_histograms = other229.repetition_level_histograms;
-  definition_level_histograms = other229.definition_level_histograms;
-  __isset = other229.__isset;
+ColumnIndex::ColumnIndex(ColumnIndex&& other333) noexcept {
+  null_pages = std::move(other333.null_pages);
+  min_values = std::move(other333.min_values);
+  max_values = std::move(other333.max_values);
+  boundary_order = other333.boundary_order;
+  null_counts = std::move(other333.null_counts);
+  repetition_level_histograms = std::move(other333.repetition_level_histograms);
+  definition_level_histograms = std::move(other333.definition_level_histograms);
+  __isset = other333.__isset;
+}
+ColumnIndex& ColumnIndex::operator=(const ColumnIndex& other334) {
+  null_pages = other334.null_pages;
+  min_values = other334.min_values;
+  max_values = other334.max_values;
+  boundary_order = other334.boundary_order;
+  null_counts = other334.null_counts;
+  repetition_level_histograms = other334.repetition_level_histograms;
+  definition_level_histograms = other334.definition_level_histograms;
+  __isset = other334.__isset;
+  return *this;
+}
+ColumnIndex& ColumnIndex::operator=(ColumnIndex&& other335) noexcept {
+  null_pages = std::move(other335.null_pages);
+  min_values = std::move(other335.min_values);
+  max_values = std::move(other335.max_values);
+  boundary_order = other335.boundary_order;
+  null_counts = std::move(other335.null_counts);
+  repetition_level_histograms = std::move(other335.repetition_level_histograms);
+  definition_level_histograms = std::move(other335.definition_level_histograms);
+  __isset = other335.__isset;
   return *this;
 }
 void ColumnIndex::printTo(std::ostream& out) const {
@@ -4500,17 +5159,30 @@ bool AesGcmV1::operator==(const AesGcmV1 & rhs) const
   return true;
 }
 
-AesGcmV1::AesGcmV1(const AesGcmV1& other230) {
-  aad_prefix = other230.aad_prefix;
-  aad_file_unique = other230.aad_file_unique;
-  supply_aad_prefix = other230.supply_aad_prefix;
-  __isset = other230.__isset;
+AesGcmV1::AesGcmV1(const AesGcmV1& other336) {
+  aad_prefix = other336.aad_prefix;
+  aad_file_unique = other336.aad_file_unique;
+  supply_aad_prefix = other336.supply_aad_prefix;
+  __isset = other336.__isset;
 }
-AesGcmV1& AesGcmV1::operator=(const AesGcmV1& other231) {
-  aad_prefix = other231.aad_prefix;
-  aad_file_unique = other231.aad_file_unique;
-  supply_aad_prefix = other231.supply_aad_prefix;
-  __isset = other231.__isset;
+AesGcmV1::AesGcmV1(AesGcmV1&& other337) noexcept {
+  aad_prefix = std::move(other337.aad_prefix);
+  aad_file_unique = std::move(other337.aad_file_unique);
+  supply_aad_prefix = other337.supply_aad_prefix;
+  __isset = other337.__isset;
+}
+AesGcmV1& AesGcmV1::operator=(const AesGcmV1& other338) {
+  aad_prefix = other338.aad_prefix;
+  aad_file_unique = other338.aad_file_unique;
+  supply_aad_prefix = other338.supply_aad_prefix;
+  __isset = other338.__isset;
+  return *this;
+}
+AesGcmV1& AesGcmV1::operator=(AesGcmV1&& other339) noexcept {
+  aad_prefix = std::move(other339.aad_prefix);
+  aad_file_unique = std::move(other339.aad_file_unique);
+  supply_aad_prefix = other339.supply_aad_prefix;
+  __isset = other339.__isset;
   return *this;
 }
 void AesGcmV1::printTo(std::ostream& out) const {
@@ -4578,17 +5250,30 @@ bool AesGcmCtrV1::operator==(const AesGcmCtrV1 & rhs) const
   return true;
 }
 
-AesGcmCtrV1::AesGcmCtrV1(const AesGcmCtrV1& other232) {
-  aad_prefix = other232.aad_prefix;
-  aad_file_unique = other232.aad_file_unique;
-  supply_aad_prefix = other232.supply_aad_prefix;
-  __isset = other232.__isset;
+AesGcmCtrV1::AesGcmCtrV1(const AesGcmCtrV1& other340) {
+  aad_prefix = other340.aad_prefix;
+  aad_file_unique = other340.aad_file_unique;
+  supply_aad_prefix = other340.supply_aad_prefix;
+  __isset = other340.__isset;
 }
-AesGcmCtrV1& AesGcmCtrV1::operator=(const AesGcmCtrV1& other233) {
-  aad_prefix = other233.aad_prefix;
-  aad_file_unique = other233.aad_file_unique;
-  supply_aad_prefix = other233.supply_aad_prefix;
-  __isset = other233.__isset;
+AesGcmCtrV1::AesGcmCtrV1(AesGcmCtrV1&& other341) noexcept {
+  aad_prefix = std::move(other341.aad_prefix);
+  aad_file_unique = std::move(other341.aad_file_unique);
+  supply_aad_prefix = other341.supply_aad_prefix;
+  __isset = other341.__isset;
+}
+AesGcmCtrV1& AesGcmCtrV1::operator=(const AesGcmCtrV1& other342) {
+  aad_prefix = other342.aad_prefix;
+  aad_file_unique = other342.aad_file_unique;
+  supply_aad_prefix = other342.supply_aad_prefix;
+  __isset = other342.__isset;
+  return *this;
+}
+AesGcmCtrV1& AesGcmCtrV1::operator=(AesGcmCtrV1&& other343) noexcept {
+  aad_prefix = std::move(other343.aad_prefix);
+  aad_file_unique = std::move(other343.aad_file_unique);
+  supply_aad_prefix = other343.supply_aad_prefix;
+  __isset = other343.__isset;
   return *this;
 }
 void AesGcmCtrV1::printTo(std::ostream& out) const {
@@ -4624,11 +5309,18 @@ bool ExternalDBPAV1::operator==(const ExternalDBPAV1 & /* rhs */) const
   return true;
 }
 
-ExternalDBPAV1::ExternalDBPAV1(const ExternalDBPAV1& other234) noexcept {
-  (void) other234;
+ExternalDBPAV1::ExternalDBPAV1(const ExternalDBPAV1& other344) noexcept {
+  (void) other344;
 }
-ExternalDBPAV1& ExternalDBPAV1::operator=(const ExternalDBPAV1& other235) noexcept {
-  (void) other235;
+ExternalDBPAV1::ExternalDBPAV1(ExternalDBPAV1&& other345) noexcept {
+  (void) other345;
+}
+ExternalDBPAV1& ExternalDBPAV1::operator=(const ExternalDBPAV1& other346) noexcept {
+  (void) other346;
+  return *this;
+}
+ExternalDBPAV1& ExternalDBPAV1::operator=(ExternalDBPAV1&& other347) noexcept {
+  (void) other347;
   return *this;
 }
 void ExternalDBPAV1::printTo(std::ostream& out) const {
@@ -4690,17 +5382,30 @@ bool EncryptionAlgorithm::operator==(const EncryptionAlgorithm & rhs) const
   return true;
 }
 
-EncryptionAlgorithm::EncryptionAlgorithm(const EncryptionAlgorithm& other236) {
-  AES_GCM_V1 = other236.AES_GCM_V1;
-  AES_GCM_CTR_V1 = other236.AES_GCM_CTR_V1;
-  EXTERNAL_DBPA_V1 = other236.EXTERNAL_DBPA_V1;
-  __isset = other236.__isset;
+EncryptionAlgorithm::EncryptionAlgorithm(const EncryptionAlgorithm& other348) {
+  AES_GCM_V1 = other348.AES_GCM_V1;
+  AES_GCM_CTR_V1 = other348.AES_GCM_CTR_V1;
+  EXTERNAL_DBPA_V1 = other348.EXTERNAL_DBPA_V1;
+  __isset = other348.__isset;
 }
-EncryptionAlgorithm& EncryptionAlgorithm::operator=(const EncryptionAlgorithm& other237) {
-  AES_GCM_V1 = other237.AES_GCM_V1;
-  AES_GCM_CTR_V1 = other237.AES_GCM_CTR_V1;
-  EXTERNAL_DBPA_V1 = other237.EXTERNAL_DBPA_V1;
-  __isset = other237.__isset;
+EncryptionAlgorithm::EncryptionAlgorithm(EncryptionAlgorithm&& other349) noexcept {
+  AES_GCM_V1 = std::move(other349.AES_GCM_V1);
+  AES_GCM_CTR_V1 = std::move(other349.AES_GCM_CTR_V1);
+  EXTERNAL_DBPA_V1 = std::move(other349.EXTERNAL_DBPA_V1);
+  __isset = other349.__isset;
+}
+EncryptionAlgorithm& EncryptionAlgorithm::operator=(const EncryptionAlgorithm& other350) {
+  AES_GCM_V1 = other350.AES_GCM_V1;
+  AES_GCM_CTR_V1 = other350.AES_GCM_CTR_V1;
+  EXTERNAL_DBPA_V1 = other350.EXTERNAL_DBPA_V1;
+  __isset = other350.__isset;
+  return *this;
+}
+EncryptionAlgorithm& EncryptionAlgorithm::operator=(EncryptionAlgorithm&& other351) noexcept {
+  AES_GCM_V1 = std::move(other351.AES_GCM_V1);
+  AES_GCM_CTR_V1 = std::move(other351.AES_GCM_CTR_V1);
+  EXTERNAL_DBPA_V1 = std::move(other351.EXTERNAL_DBPA_V1);
+  __isset = other351.__isset;
   return *this;
 }
 void EncryptionAlgorithm::printTo(std::ostream& out) const {
@@ -4817,29 +5522,54 @@ bool FileMetaData::operator==(const FileMetaData & rhs) const
   return true;
 }
 
-FileMetaData::FileMetaData(const FileMetaData& other262) {
-  version = other262.version;
-  schema = other262.schema;
-  num_rows = other262.num_rows;
-  row_groups = other262.row_groups;
-  key_value_metadata = other262.key_value_metadata;
-  created_by = other262.created_by;
-  column_orders = other262.column_orders;
-  encryption_algorithm = other262.encryption_algorithm;
-  footer_signing_key_metadata = other262.footer_signing_key_metadata;
-  __isset = other262.__isset;
+FileMetaData::FileMetaData(const FileMetaData& other376) {
+  version = other376.version;
+  schema = other376.schema;
+  num_rows = other376.num_rows;
+  row_groups = other376.row_groups;
+  key_value_metadata = other376.key_value_metadata;
+  created_by = other376.created_by;
+  column_orders = other376.column_orders;
+  encryption_algorithm = other376.encryption_algorithm;
+  footer_signing_key_metadata = other376.footer_signing_key_metadata;
+  __isset = other376.__isset;
 }
-FileMetaData& FileMetaData::operator=(const FileMetaData& other263) {
-  version = other263.version;
-  schema = other263.schema;
-  num_rows = other263.num_rows;
-  row_groups = other263.row_groups;
-  key_value_metadata = other263.key_value_metadata;
-  created_by = other263.created_by;
-  column_orders = other263.column_orders;
-  encryption_algorithm = other263.encryption_algorithm;
-  footer_signing_key_metadata = other263.footer_signing_key_metadata;
-  __isset = other263.__isset;
+FileMetaData::FileMetaData(FileMetaData&& other377) noexcept {
+  version = other377.version;
+  schema = std::move(other377.schema);
+  num_rows = other377.num_rows;
+  row_groups = std::move(other377.row_groups);
+  key_value_metadata = std::move(other377.key_value_metadata);
+  created_by = std::move(other377.created_by);
+  column_orders = std::move(other377.column_orders);
+  encryption_algorithm = std::move(other377.encryption_algorithm);
+  footer_signing_key_metadata = std::move(other377.footer_signing_key_metadata);
+  __isset = other377.__isset;
+}
+FileMetaData& FileMetaData::operator=(const FileMetaData& other378) {
+  version = other378.version;
+  schema = other378.schema;
+  num_rows = other378.num_rows;
+  row_groups = other378.row_groups;
+  key_value_metadata = other378.key_value_metadata;
+  created_by = other378.created_by;
+  column_orders = other378.column_orders;
+  encryption_algorithm = other378.encryption_algorithm;
+  footer_signing_key_metadata = other378.footer_signing_key_metadata;
+  __isset = other378.__isset;
+  return *this;
+}
+FileMetaData& FileMetaData::operator=(FileMetaData&& other379) noexcept {
+  version = other379.version;
+  schema = std::move(other379.schema);
+  num_rows = other379.num_rows;
+  row_groups = std::move(other379.row_groups);
+  key_value_metadata = std::move(other379.key_value_metadata);
+  created_by = std::move(other379.created_by);
+  column_orders = std::move(other379.column_orders);
+  encryption_algorithm = std::move(other379.encryption_algorithm);
+  footer_signing_key_metadata = std::move(other379.footer_signing_key_metadata);
+  __isset = other379.__isset;
   return *this;
 }
 void FileMetaData::printTo(std::ostream& out) const {
@@ -4898,15 +5628,26 @@ bool FileCryptoMetaData::operator==(const FileCryptoMetaData & rhs) const
   return true;
 }
 
-FileCryptoMetaData::FileCryptoMetaData(const FileCryptoMetaData& other264) {
-  encryption_algorithm = other264.encryption_algorithm;
-  key_metadata = other264.key_metadata;
-  __isset = other264.__isset;
+FileCryptoMetaData::FileCryptoMetaData(const FileCryptoMetaData& other380) {
+  encryption_algorithm = other380.encryption_algorithm;
+  key_metadata = other380.key_metadata;
+  __isset = other380.__isset;
 }
-FileCryptoMetaData& FileCryptoMetaData::operator=(const FileCryptoMetaData& other265) {
-  encryption_algorithm = other265.encryption_algorithm;
-  key_metadata = other265.key_metadata;
-  __isset = other265.__isset;
+FileCryptoMetaData::FileCryptoMetaData(FileCryptoMetaData&& other381) noexcept {
+  encryption_algorithm = std::move(other381.encryption_algorithm);
+  key_metadata = std::move(other381.key_metadata);
+  __isset = other381.__isset;
+}
+FileCryptoMetaData& FileCryptoMetaData::operator=(const FileCryptoMetaData& other382) {
+  encryption_algorithm = other382.encryption_algorithm;
+  key_metadata = other382.key_metadata;
+  __isset = other382.__isset;
+  return *this;
+}
+FileCryptoMetaData& FileCryptoMetaData::operator=(FileCryptoMetaData&& other383) noexcept {
+  encryption_algorithm = std::move(other383.encryption_algorithm);
+  key_metadata = std::move(other383.key_metadata);
+  __isset = other383.__isset;
   return *this;
 }
 void FileCryptoMetaData::printTo(std::ostream& out) const {

--- a/cpp/src/generated/parquet_types.h
+++ b/cpp/src/generated/parquet_types.h
@@ -504,7 +504,9 @@ class SizeStatistics {
  public:
 
   SizeStatistics(const SizeStatistics&);
+  SizeStatistics(SizeStatistics&&) noexcept;
   SizeStatistics& operator=(const SizeStatistics&);
+  SizeStatistics& operator=(SizeStatistics&&) noexcept;
   SizeStatistics() noexcept;
 
   virtual ~SizeStatistics() noexcept;
@@ -589,7 +591,9 @@ class BoundingBox {
  public:
 
   BoundingBox(const BoundingBox&) noexcept;
+  BoundingBox(BoundingBox&&) noexcept;
   BoundingBox& operator=(const BoundingBox&) noexcept;
+  BoundingBox& operator=(BoundingBox&&) noexcept;
   BoundingBox() noexcept;
 
   virtual ~BoundingBox() noexcept;
@@ -652,7 +656,9 @@ class GeospatialStatistics {
  public:
 
   GeospatialStatistics(const GeospatialStatistics&);
+  GeospatialStatistics(GeospatialStatistics&&) noexcept;
   GeospatialStatistics& operator=(const GeospatialStatistics&);
+  GeospatialStatistics& operator=(GeospatialStatistics&&) noexcept;
   GeospatialStatistics() noexcept;
 
   virtual ~GeospatialStatistics() noexcept;
@@ -710,7 +716,9 @@ class Statistics {
  public:
 
   Statistics(const Statistics&);
+  Statistics(Statistics&&) noexcept;
   Statistics& operator=(const Statistics&);
+  Statistics& operator=(Statistics&&) noexcept;
   Statistics() noexcept;
 
   virtual ~Statistics() noexcept;
@@ -810,7 +818,9 @@ class StringType {
  public:
 
   StringType(const StringType&) noexcept;
+  StringType(StringType&&) noexcept;
   StringType& operator=(const StringType&) noexcept;
+  StringType& operator=(StringType&&) noexcept;
   StringType() noexcept;
 
   virtual ~StringType() noexcept;
@@ -839,7 +849,9 @@ class UUIDType {
  public:
 
   UUIDType(const UUIDType&) noexcept;
+  UUIDType(UUIDType&&) noexcept;
   UUIDType& operator=(const UUIDType&) noexcept;
+  UUIDType& operator=(UUIDType&&) noexcept;
   UUIDType() noexcept;
 
   virtual ~UUIDType() noexcept;
@@ -868,7 +880,9 @@ class MapType {
  public:
 
   MapType(const MapType&) noexcept;
+  MapType(MapType&&) noexcept;
   MapType& operator=(const MapType&) noexcept;
+  MapType& operator=(MapType&&) noexcept;
   MapType() noexcept;
 
   virtual ~MapType() noexcept;
@@ -897,7 +911,9 @@ class ListType {
  public:
 
   ListType(const ListType&) noexcept;
+  ListType(ListType&&) noexcept;
   ListType& operator=(const ListType&) noexcept;
+  ListType& operator=(ListType&&) noexcept;
   ListType() noexcept;
 
   virtual ~ListType() noexcept;
@@ -926,7 +942,9 @@ class EnumType {
  public:
 
   EnumType(const EnumType&) noexcept;
+  EnumType(EnumType&&) noexcept;
   EnumType& operator=(const EnumType&) noexcept;
+  EnumType& operator=(EnumType&&) noexcept;
   EnumType() noexcept;
 
   virtual ~EnumType() noexcept;
@@ -955,7 +973,9 @@ class DateType {
  public:
 
   DateType(const DateType&) noexcept;
+  DateType(DateType&&) noexcept;
   DateType& operator=(const DateType&) noexcept;
+  DateType& operator=(DateType&&) noexcept;
   DateType() noexcept;
 
   virtual ~DateType() noexcept;
@@ -984,7 +1004,9 @@ class Float16Type {
  public:
 
   Float16Type(const Float16Type&) noexcept;
+  Float16Type(Float16Type&&) noexcept;
   Float16Type& operator=(const Float16Type&) noexcept;
+  Float16Type& operator=(Float16Type&&) noexcept;
   Float16Type() noexcept;
 
   virtual ~Float16Type() noexcept;
@@ -1020,7 +1042,9 @@ class NullType {
  public:
 
   NullType(const NullType&) noexcept;
+  NullType(NullType&&) noexcept;
   NullType& operator=(const NullType&) noexcept;
+  NullType& operator=(NullType&&) noexcept;
   NullType() noexcept;
 
   virtual ~NullType() noexcept;
@@ -1060,7 +1084,9 @@ class DecimalType {
  public:
 
   DecimalType(const DecimalType&) noexcept;
+  DecimalType(DecimalType&&) noexcept;
   DecimalType& operator=(const DecimalType&) noexcept;
+  DecimalType& operator=(DecimalType&&) noexcept;
   DecimalType() noexcept;
 
   virtual ~DecimalType() noexcept;
@@ -1098,7 +1124,9 @@ class MilliSeconds {
  public:
 
   MilliSeconds(const MilliSeconds&) noexcept;
+  MilliSeconds(MilliSeconds&&) noexcept;
   MilliSeconds& operator=(const MilliSeconds&) noexcept;
+  MilliSeconds& operator=(MilliSeconds&&) noexcept;
   MilliSeconds() noexcept;
 
   virtual ~MilliSeconds() noexcept;
@@ -1127,7 +1155,9 @@ class MicroSeconds {
  public:
 
   MicroSeconds(const MicroSeconds&) noexcept;
+  MicroSeconds(MicroSeconds&&) noexcept;
   MicroSeconds& operator=(const MicroSeconds&) noexcept;
+  MicroSeconds& operator=(MicroSeconds&&) noexcept;
   MicroSeconds() noexcept;
 
   virtual ~MicroSeconds() noexcept;
@@ -1156,7 +1186,9 @@ class NanoSeconds {
  public:
 
   NanoSeconds(const NanoSeconds&) noexcept;
+  NanoSeconds(NanoSeconds&&) noexcept;
   NanoSeconds& operator=(const NanoSeconds&) noexcept;
+  NanoSeconds& operator=(NanoSeconds&&) noexcept;
   NanoSeconds() noexcept;
 
   virtual ~NanoSeconds() noexcept;
@@ -1191,7 +1223,9 @@ class TimeUnit {
  public:
 
   TimeUnit(const TimeUnit&) noexcept;
+  TimeUnit(TimeUnit&&) noexcept;
   TimeUnit& operator=(const TimeUnit&) noexcept;
+  TimeUnit& operator=(TimeUnit&&) noexcept;
   TimeUnit() noexcept;
 
   virtual ~TimeUnit() noexcept;
@@ -1236,7 +1270,9 @@ class TimestampType {
  public:
 
   TimestampType(const TimestampType&) noexcept;
+  TimestampType(TimestampType&&) noexcept;
   TimestampType& operator=(const TimestampType&) noexcept;
+  TimestampType& operator=(TimestampType&&) noexcept;
   TimestampType() noexcept;
 
   virtual ~TimestampType() noexcept;
@@ -1276,7 +1312,9 @@ class TimeType {
  public:
 
   TimeType(const TimeType&) noexcept;
+  TimeType(TimeType&&) noexcept;
   TimeType& operator=(const TimeType&) noexcept;
+  TimeType& operator=(TimeType&&) noexcept;
   TimeType() noexcept;
 
   virtual ~TimeType() noexcept;
@@ -1318,7 +1356,9 @@ class IntType {
  public:
 
   IntType(const IntType&) noexcept;
+  IntType(IntType&&) noexcept;
   IntType& operator=(const IntType&) noexcept;
+  IntType& operator=(IntType&&) noexcept;
   IntType() noexcept;
 
   virtual ~IntType() noexcept;
@@ -1358,7 +1398,9 @@ class JsonType {
  public:
 
   JsonType(const JsonType&) noexcept;
+  JsonType(JsonType&&) noexcept;
   JsonType& operator=(const JsonType&) noexcept;
+  JsonType& operator=(JsonType&&) noexcept;
   JsonType() noexcept;
 
   virtual ~JsonType() noexcept;
@@ -1392,7 +1434,9 @@ class BsonType {
  public:
 
   BsonType(const BsonType&) noexcept;
+  BsonType(BsonType&&) noexcept;
   BsonType& operator=(const BsonType&) noexcept;
+  BsonType& operator=(BsonType&&) noexcept;
   BsonType() noexcept;
 
   virtual ~BsonType() noexcept;
@@ -1428,7 +1472,9 @@ class VariantType {
  public:
 
   VariantType(const VariantType&) noexcept;
+  VariantType(VariantType&&) noexcept;
   VariantType& operator=(const VariantType&) noexcept;
+  VariantType& operator=(VariantType&&) noexcept;
   VariantType() noexcept;
 
   virtual ~VariantType() noexcept;
@@ -1480,7 +1526,9 @@ class GeometryType {
  public:
 
   GeometryType(const GeometryType&);
+  GeometryType(GeometryType&&) noexcept;
   GeometryType& operator=(const GeometryType&);
+  GeometryType& operator=(GeometryType&&) noexcept;
   GeometryType() noexcept;
 
   virtual ~GeometryType() noexcept;
@@ -1536,7 +1584,9 @@ class GeographyType {
  public:
 
   GeographyType(const GeographyType&);
+  GeographyType(GeographyType&&) noexcept;
   GeographyType& operator=(const GeographyType&);
+  GeographyType& operator=(GeographyType&&) noexcept;
   GeographyType() noexcept;
 
   virtual ~GeographyType() noexcept;
@@ -1604,7 +1654,9 @@ class LogicalType {
  public:
 
   LogicalType(const LogicalType&);
+  LogicalType(LogicalType&&) noexcept;
   LogicalType& operator=(const LogicalType&);
+  LogicalType& operator=(LogicalType&&) noexcept;
   LogicalType() noexcept;
 
   virtual ~LogicalType() noexcept;
@@ -1704,7 +1756,9 @@ class SchemaElement {
  public:
 
   SchemaElement(const SchemaElement&);
+  SchemaElement(SchemaElement&&) noexcept;
   SchemaElement& operator=(const SchemaElement&);
+  SchemaElement& operator=(SchemaElement&&) noexcept;
   SchemaElement() noexcept;
 
   virtual ~SchemaElement() noexcept;
@@ -1822,7 +1876,9 @@ class DataPageHeader {
  public:
 
   DataPageHeader(const DataPageHeader&);
+  DataPageHeader(DataPageHeader&&) noexcept;
   DataPageHeader& operator=(const DataPageHeader&);
+  DataPageHeader& operator=(DataPageHeader&&) noexcept;
   DataPageHeader() noexcept;
 
   virtual ~DataPageHeader() noexcept;
@@ -1894,7 +1950,9 @@ class IndexPageHeader {
  public:
 
   IndexPageHeader(const IndexPageHeader&) noexcept;
+  IndexPageHeader(IndexPageHeader&&) noexcept;
   IndexPageHeader& operator=(const IndexPageHeader&) noexcept;
+  IndexPageHeader& operator=(IndexPageHeader&&) noexcept;
   IndexPageHeader() noexcept;
 
   virtual ~IndexPageHeader() noexcept;
@@ -1933,7 +1991,9 @@ class DictionaryPageHeader {
  public:
 
   DictionaryPageHeader(const DictionaryPageHeader&) noexcept;
+  DictionaryPageHeader(DictionaryPageHeader&&) noexcept;
   DictionaryPageHeader& operator=(const DictionaryPageHeader&) noexcept;
+  DictionaryPageHeader& operator=(DictionaryPageHeader&&) noexcept;
   DictionaryPageHeader() noexcept;
 
   virtual ~DictionaryPageHeader() noexcept;
@@ -1995,7 +2055,9 @@ class DataPageHeaderV2 {
  public:
 
   DataPageHeaderV2(const DataPageHeaderV2&);
+  DataPageHeaderV2(DataPageHeaderV2&&) noexcept;
   DataPageHeaderV2& operator=(const DataPageHeaderV2&);
+  DataPageHeaderV2& operator=(DataPageHeaderV2&&) noexcept;
   DataPageHeaderV2() noexcept;
 
   virtual ~DataPageHeaderV2() noexcept;
@@ -2087,7 +2149,9 @@ class SplitBlockAlgorithm {
  public:
 
   SplitBlockAlgorithm(const SplitBlockAlgorithm&) noexcept;
+  SplitBlockAlgorithm(SplitBlockAlgorithm&&) noexcept;
   SplitBlockAlgorithm& operator=(const SplitBlockAlgorithm&) noexcept;
+  SplitBlockAlgorithm& operator=(SplitBlockAlgorithm&&) noexcept;
   SplitBlockAlgorithm() noexcept;
 
   virtual ~SplitBlockAlgorithm() noexcept;
@@ -2123,7 +2187,9 @@ class BloomFilterAlgorithm {
  public:
 
   BloomFilterAlgorithm(const BloomFilterAlgorithm&) noexcept;
+  BloomFilterAlgorithm(BloomFilterAlgorithm&&) noexcept;
   BloomFilterAlgorithm& operator=(const BloomFilterAlgorithm&) noexcept;
+  BloomFilterAlgorithm& operator=(BloomFilterAlgorithm&&) noexcept;
   BloomFilterAlgorithm() noexcept;
 
   virtual ~BloomFilterAlgorithm() noexcept;
@@ -2165,7 +2231,9 @@ class XxHash {
  public:
 
   XxHash(const XxHash&) noexcept;
+  XxHash(XxHash&&) noexcept;
   XxHash& operator=(const XxHash&) noexcept;
+  XxHash& operator=(XxHash&&) noexcept;
   XxHash() noexcept;
 
   virtual ~XxHash() noexcept;
@@ -2203,7 +2271,9 @@ class BloomFilterHash {
  public:
 
   BloomFilterHash(const BloomFilterHash&) noexcept;
+  BloomFilterHash(BloomFilterHash&&) noexcept;
   BloomFilterHash& operator=(const BloomFilterHash&) noexcept;
+  BloomFilterHash& operator=(BloomFilterHash&&) noexcept;
   BloomFilterHash() noexcept;
 
   virtual ~BloomFilterHash() noexcept;
@@ -2244,7 +2314,9 @@ class Uncompressed {
  public:
 
   Uncompressed(const Uncompressed&) noexcept;
+  Uncompressed(Uncompressed&&) noexcept;
   Uncompressed& operator=(const Uncompressed&) noexcept;
+  Uncompressed& operator=(Uncompressed&&) noexcept;
   Uncompressed() noexcept;
 
   virtual ~Uncompressed() noexcept;
@@ -2277,7 +2349,9 @@ class BloomFilterCompression {
  public:
 
   BloomFilterCompression(const BloomFilterCompression&) noexcept;
+  BloomFilterCompression(BloomFilterCompression&&) noexcept;
   BloomFilterCompression& operator=(const BloomFilterCompression&) noexcept;
+  BloomFilterCompression& operator=(BloomFilterCompression&&) noexcept;
   BloomFilterCompression() noexcept;
 
   virtual ~BloomFilterCompression() noexcept;
@@ -2316,7 +2390,9 @@ class BloomFilterHeader {
  public:
 
   BloomFilterHeader(const BloomFilterHeader&) noexcept;
+  BloomFilterHeader(BloomFilterHeader&&) noexcept;
   BloomFilterHeader& operator=(const BloomFilterHeader&) noexcept;
+  BloomFilterHeader& operator=(BloomFilterHeader&&) noexcept;
   BloomFilterHeader() noexcept;
 
   virtual ~BloomFilterHeader() noexcept;
@@ -2377,7 +2453,9 @@ class PageHeader {
  public:
 
   PageHeader(const PageHeader&);
+  PageHeader(PageHeader&&) noexcept;
   PageHeader& operator=(const PageHeader&);
+  PageHeader& operator=(PageHeader&&) noexcept;
   PageHeader() noexcept;
 
   virtual ~PageHeader() noexcept;
@@ -2468,7 +2546,9 @@ class KeyValue {
  public:
 
   KeyValue(const KeyValue&);
+  KeyValue(KeyValue&&) noexcept;
   KeyValue& operator=(const KeyValue&);
+  KeyValue& operator=(KeyValue&&) noexcept;
   KeyValue() noexcept;
 
   virtual ~KeyValue() noexcept;
@@ -2508,7 +2588,9 @@ class SortingColumn {
  public:
 
   SortingColumn(const SortingColumn&) noexcept;
+  SortingColumn(SortingColumn&&) noexcept;
   SortingColumn& operator=(const SortingColumn&) noexcept;
+  SortingColumn& operator=(SortingColumn&&) noexcept;
   SortingColumn() noexcept;
 
   virtual ~SortingColumn() noexcept;
@@ -2559,7 +2641,9 @@ class PageEncodingStats {
  public:
 
   PageEncodingStats(const PageEncodingStats&) noexcept;
+  PageEncodingStats(PageEncodingStats&&) noexcept;
   PageEncodingStats& operator=(const PageEncodingStats&) noexcept;
+  PageEncodingStats& operator=(PageEncodingStats&&) noexcept;
   PageEncodingStats() noexcept;
 
   virtual ~PageEncodingStats() noexcept;
@@ -2625,7 +2709,9 @@ class ColumnMetaData {
  public:
 
   ColumnMetaData(const ColumnMetaData&);
+  ColumnMetaData(ColumnMetaData&&) noexcept;
   ColumnMetaData& operator=(const ColumnMetaData&);
+  ColumnMetaData& operator=(ColumnMetaData&&) noexcept;
   ColumnMetaData() noexcept;
 
   virtual ~ColumnMetaData() noexcept;
@@ -2773,7 +2859,9 @@ class EncryptionWithFooterKey {
  public:
 
   EncryptionWithFooterKey(const EncryptionWithFooterKey&) noexcept;
+  EncryptionWithFooterKey(EncryptionWithFooterKey&&) noexcept;
   EncryptionWithFooterKey& operator=(const EncryptionWithFooterKey&) noexcept;
+  EncryptionWithFooterKey& operator=(EncryptionWithFooterKey&&) noexcept;
   EncryptionWithFooterKey() noexcept;
 
   virtual ~EncryptionWithFooterKey() noexcept;
@@ -2806,7 +2894,9 @@ class EncryptionWithColumnKey {
  public:
 
   EncryptionWithColumnKey(const EncryptionWithColumnKey&);
+  EncryptionWithColumnKey(EncryptionWithColumnKey&&) noexcept;
   EncryptionWithColumnKey& operator=(const EncryptionWithColumnKey&);
+  EncryptionWithColumnKey& operator=(EncryptionWithColumnKey&&) noexcept;
   EncryptionWithColumnKey() noexcept;
 
   virtual ~EncryptionWithColumnKey() noexcept;
@@ -2854,7 +2944,9 @@ class ColumnCryptoMetaData {
  public:
 
   ColumnCryptoMetaData(const ColumnCryptoMetaData&);
+  ColumnCryptoMetaData(ColumnCryptoMetaData&&) noexcept;
   ColumnCryptoMetaData& operator=(const ColumnCryptoMetaData&);
+  ColumnCryptoMetaData& operator=(ColumnCryptoMetaData&&) noexcept;
   ColumnCryptoMetaData() noexcept;
 
   virtual ~ColumnCryptoMetaData() noexcept;
@@ -2902,7 +2994,9 @@ class ColumnChunk {
  public:
 
   ColumnChunk(const ColumnChunk&);
+  ColumnChunk(ColumnChunk&&) noexcept;
   ColumnChunk& operator=(const ColumnChunk&);
+  ColumnChunk& operator=(ColumnChunk&&) noexcept;
   ColumnChunk() noexcept;
 
   virtual ~ColumnChunk() noexcept;
@@ -3007,7 +3101,9 @@ class RowGroup {
  public:
 
   RowGroup(const RowGroup&);
+  RowGroup(RowGroup&&) noexcept;
   RowGroup& operator=(const RowGroup&);
+  RowGroup& operator=(RowGroup&&) noexcept;
   RowGroup() noexcept;
 
   virtual ~RowGroup() noexcept;
@@ -3088,7 +3184,9 @@ class TypeDefinedOrder {
  public:
 
   TypeDefinedOrder(const TypeDefinedOrder&) noexcept;
+  TypeDefinedOrder(TypeDefinedOrder&&) noexcept;
   TypeDefinedOrder& operator=(const TypeDefinedOrder&) noexcept;
+  TypeDefinedOrder& operator=(TypeDefinedOrder&&) noexcept;
   TypeDefinedOrder() noexcept;
 
   virtual ~TypeDefinedOrder() noexcept;
@@ -3133,7 +3231,9 @@ class ColumnOrder {
  public:
 
   ColumnOrder(const ColumnOrder&) noexcept;
+  ColumnOrder(ColumnOrder&&) noexcept;
   ColumnOrder& operator=(const ColumnOrder&) noexcept;
+  ColumnOrder& operator=(ColumnOrder&&) noexcept;
   ColumnOrder() noexcept;
 
   virtual ~ColumnOrder() noexcept;
@@ -3220,7 +3320,9 @@ class PageLocation {
  public:
 
   PageLocation(const PageLocation&) noexcept;
+  PageLocation(PageLocation&&) noexcept;
   PageLocation& operator=(const PageLocation&) noexcept;
+  PageLocation& operator=(PageLocation&&) noexcept;
   PageLocation() noexcept;
 
   virtual ~PageLocation() noexcept;
@@ -3281,7 +3383,9 @@ class OffsetIndex {
  public:
 
   OffsetIndex(const OffsetIndex&);
+  OffsetIndex(OffsetIndex&&) noexcept;
   OffsetIndex& operator=(const OffsetIndex&);
+  OffsetIndex& operator=(OffsetIndex&&) noexcept;
   OffsetIndex() noexcept;
 
   virtual ~OffsetIndex() noexcept;
@@ -3344,7 +3448,9 @@ class ColumnIndex {
  public:
 
   ColumnIndex(const ColumnIndex&);
+  ColumnIndex(ColumnIndex&&) noexcept;
   ColumnIndex& operator=(const ColumnIndex&);
+  ColumnIndex& operator=(ColumnIndex&&) noexcept;
   ColumnIndex() noexcept;
 
   virtual ~ColumnIndex() noexcept;
@@ -3454,7 +3560,9 @@ class AesGcmV1 {
  public:
 
   AesGcmV1(const AesGcmV1&);
+  AesGcmV1(AesGcmV1&&) noexcept;
   AesGcmV1& operator=(const AesGcmV1&);
+  AesGcmV1& operator=(AesGcmV1&&) noexcept;
   AesGcmV1() noexcept;
 
   virtual ~AesGcmV1() noexcept;
@@ -3510,7 +3618,9 @@ class AesGcmCtrV1 {
  public:
 
   AesGcmCtrV1(const AesGcmCtrV1&);
+  AesGcmCtrV1(AesGcmCtrV1&&) noexcept;
   AesGcmCtrV1& operator=(const AesGcmCtrV1&);
+  AesGcmCtrV1& operator=(AesGcmCtrV1&&) noexcept;
   AesGcmCtrV1() noexcept;
 
   virtual ~AesGcmCtrV1() noexcept;
@@ -3560,7 +3670,9 @@ class ExternalDBPAV1 {
  public:
 
   ExternalDBPAV1(const ExternalDBPAV1&) noexcept;
+  ExternalDBPAV1(ExternalDBPAV1&&) noexcept;
   ExternalDBPAV1& operator=(const ExternalDBPAV1&) noexcept;
+  ExternalDBPAV1& operator=(ExternalDBPAV1&&) noexcept;
   ExternalDBPAV1() noexcept;
 
   virtual ~ExternalDBPAV1() noexcept;
@@ -3595,7 +3707,9 @@ class EncryptionAlgorithm {
  public:
 
   EncryptionAlgorithm(const EncryptionAlgorithm&);
+  EncryptionAlgorithm(EncryptionAlgorithm&&) noexcept;
   EncryptionAlgorithm& operator=(const EncryptionAlgorithm&);
+  EncryptionAlgorithm& operator=(EncryptionAlgorithm&&) noexcept;
   EncryptionAlgorithm() noexcept;
 
   virtual ~EncryptionAlgorithm() noexcept;
@@ -3646,7 +3760,9 @@ class FileMetaData {
  public:
 
   FileMetaData(const FileMetaData&);
+  FileMetaData(FileMetaData&&) noexcept;
   FileMetaData& operator=(const FileMetaData&);
+  FileMetaData& operator=(FileMetaData&&) noexcept;
   FileMetaData() noexcept;
 
   virtual ~FileMetaData() noexcept;
@@ -3762,7 +3878,9 @@ class FileCryptoMetaData {
  public:
 
   FileCryptoMetaData(const FileCryptoMetaData&);
+  FileCryptoMetaData(FileCryptoMetaData&&) noexcept;
   FileCryptoMetaData& operator=(const FileCryptoMetaData&);
+  FileCryptoMetaData& operator=(FileCryptoMetaData&&) noexcept;
   FileCryptoMetaData() noexcept;
 
   virtual ~FileCryptoMetaData() noexcept;

--- a/cpp/src/generated/parquet_types.h
+++ b/cpp/src/generated/parquet_types.h
@@ -477,6 +477,8 @@ class AesGcmV1;
 
 class AesGcmCtrV1;
 
+class ExternalDBPAV1;
+
 class EncryptionAlgorithm;
 
 class FileMetaData;
@@ -502,9 +504,7 @@ class SizeStatistics {
  public:
 
   SizeStatistics(const SizeStatistics&);
-  SizeStatistics(SizeStatistics&&) noexcept;
   SizeStatistics& operator=(const SizeStatistics&);
-  SizeStatistics& operator=(SizeStatistics&&) noexcept;
   SizeStatistics() noexcept;
 
   virtual ~SizeStatistics() noexcept;
@@ -589,9 +589,7 @@ class BoundingBox {
  public:
 
   BoundingBox(const BoundingBox&) noexcept;
-  BoundingBox(BoundingBox&&) noexcept;
   BoundingBox& operator=(const BoundingBox&) noexcept;
-  BoundingBox& operator=(BoundingBox&&) noexcept;
   BoundingBox() noexcept;
 
   virtual ~BoundingBox() noexcept;
@@ -654,9 +652,7 @@ class GeospatialStatistics {
  public:
 
   GeospatialStatistics(const GeospatialStatistics&);
-  GeospatialStatistics(GeospatialStatistics&&) noexcept;
   GeospatialStatistics& operator=(const GeospatialStatistics&);
-  GeospatialStatistics& operator=(GeospatialStatistics&&) noexcept;
   GeospatialStatistics() noexcept;
 
   virtual ~GeospatialStatistics() noexcept;
@@ -714,9 +710,7 @@ class Statistics {
  public:
 
   Statistics(const Statistics&);
-  Statistics(Statistics&&) noexcept;
   Statistics& operator=(const Statistics&);
-  Statistics& operator=(Statistics&&) noexcept;
   Statistics() noexcept;
 
   virtual ~Statistics() noexcept;
@@ -816,9 +810,7 @@ class StringType {
  public:
 
   StringType(const StringType&) noexcept;
-  StringType(StringType&&) noexcept;
   StringType& operator=(const StringType&) noexcept;
-  StringType& operator=(StringType&&) noexcept;
   StringType() noexcept;
 
   virtual ~StringType() noexcept;
@@ -847,9 +839,7 @@ class UUIDType {
  public:
 
   UUIDType(const UUIDType&) noexcept;
-  UUIDType(UUIDType&&) noexcept;
   UUIDType& operator=(const UUIDType&) noexcept;
-  UUIDType& operator=(UUIDType&&) noexcept;
   UUIDType() noexcept;
 
   virtual ~UUIDType() noexcept;
@@ -878,9 +868,7 @@ class MapType {
  public:
 
   MapType(const MapType&) noexcept;
-  MapType(MapType&&) noexcept;
   MapType& operator=(const MapType&) noexcept;
-  MapType& operator=(MapType&&) noexcept;
   MapType() noexcept;
 
   virtual ~MapType() noexcept;
@@ -909,9 +897,7 @@ class ListType {
  public:
 
   ListType(const ListType&) noexcept;
-  ListType(ListType&&) noexcept;
   ListType& operator=(const ListType&) noexcept;
-  ListType& operator=(ListType&&) noexcept;
   ListType() noexcept;
 
   virtual ~ListType() noexcept;
@@ -940,9 +926,7 @@ class EnumType {
  public:
 
   EnumType(const EnumType&) noexcept;
-  EnumType(EnumType&&) noexcept;
   EnumType& operator=(const EnumType&) noexcept;
-  EnumType& operator=(EnumType&&) noexcept;
   EnumType() noexcept;
 
   virtual ~EnumType() noexcept;
@@ -971,9 +955,7 @@ class DateType {
  public:
 
   DateType(const DateType&) noexcept;
-  DateType(DateType&&) noexcept;
   DateType& operator=(const DateType&) noexcept;
-  DateType& operator=(DateType&&) noexcept;
   DateType() noexcept;
 
   virtual ~DateType() noexcept;
@@ -1002,9 +984,7 @@ class Float16Type {
  public:
 
   Float16Type(const Float16Type&) noexcept;
-  Float16Type(Float16Type&&) noexcept;
   Float16Type& operator=(const Float16Type&) noexcept;
-  Float16Type& operator=(Float16Type&&) noexcept;
   Float16Type() noexcept;
 
   virtual ~Float16Type() noexcept;
@@ -1040,9 +1020,7 @@ class NullType {
  public:
 
   NullType(const NullType&) noexcept;
-  NullType(NullType&&) noexcept;
   NullType& operator=(const NullType&) noexcept;
-  NullType& operator=(NullType&&) noexcept;
   NullType() noexcept;
 
   virtual ~NullType() noexcept;
@@ -1082,9 +1060,7 @@ class DecimalType {
  public:
 
   DecimalType(const DecimalType&) noexcept;
-  DecimalType(DecimalType&&) noexcept;
   DecimalType& operator=(const DecimalType&) noexcept;
-  DecimalType& operator=(DecimalType&&) noexcept;
   DecimalType() noexcept;
 
   virtual ~DecimalType() noexcept;
@@ -1122,9 +1098,7 @@ class MilliSeconds {
  public:
 
   MilliSeconds(const MilliSeconds&) noexcept;
-  MilliSeconds(MilliSeconds&&) noexcept;
   MilliSeconds& operator=(const MilliSeconds&) noexcept;
-  MilliSeconds& operator=(MilliSeconds&&) noexcept;
   MilliSeconds() noexcept;
 
   virtual ~MilliSeconds() noexcept;
@@ -1153,9 +1127,7 @@ class MicroSeconds {
  public:
 
   MicroSeconds(const MicroSeconds&) noexcept;
-  MicroSeconds(MicroSeconds&&) noexcept;
   MicroSeconds& operator=(const MicroSeconds&) noexcept;
-  MicroSeconds& operator=(MicroSeconds&&) noexcept;
   MicroSeconds() noexcept;
 
   virtual ~MicroSeconds() noexcept;
@@ -1184,9 +1156,7 @@ class NanoSeconds {
  public:
 
   NanoSeconds(const NanoSeconds&) noexcept;
-  NanoSeconds(NanoSeconds&&) noexcept;
   NanoSeconds& operator=(const NanoSeconds&) noexcept;
-  NanoSeconds& operator=(NanoSeconds&&) noexcept;
   NanoSeconds() noexcept;
 
   virtual ~NanoSeconds() noexcept;
@@ -1221,9 +1191,7 @@ class TimeUnit {
  public:
 
   TimeUnit(const TimeUnit&) noexcept;
-  TimeUnit(TimeUnit&&) noexcept;
   TimeUnit& operator=(const TimeUnit&) noexcept;
-  TimeUnit& operator=(TimeUnit&&) noexcept;
   TimeUnit() noexcept;
 
   virtual ~TimeUnit() noexcept;
@@ -1268,9 +1236,7 @@ class TimestampType {
  public:
 
   TimestampType(const TimestampType&) noexcept;
-  TimestampType(TimestampType&&) noexcept;
   TimestampType& operator=(const TimestampType&) noexcept;
-  TimestampType& operator=(TimestampType&&) noexcept;
   TimestampType() noexcept;
 
   virtual ~TimestampType() noexcept;
@@ -1310,9 +1276,7 @@ class TimeType {
  public:
 
   TimeType(const TimeType&) noexcept;
-  TimeType(TimeType&&) noexcept;
   TimeType& operator=(const TimeType&) noexcept;
-  TimeType& operator=(TimeType&&) noexcept;
   TimeType() noexcept;
 
   virtual ~TimeType() noexcept;
@@ -1354,9 +1318,7 @@ class IntType {
  public:
 
   IntType(const IntType&) noexcept;
-  IntType(IntType&&) noexcept;
   IntType& operator=(const IntType&) noexcept;
-  IntType& operator=(IntType&&) noexcept;
   IntType() noexcept;
 
   virtual ~IntType() noexcept;
@@ -1396,9 +1358,7 @@ class JsonType {
  public:
 
   JsonType(const JsonType&) noexcept;
-  JsonType(JsonType&&) noexcept;
   JsonType& operator=(const JsonType&) noexcept;
-  JsonType& operator=(JsonType&&) noexcept;
   JsonType() noexcept;
 
   virtual ~JsonType() noexcept;
@@ -1432,9 +1392,7 @@ class BsonType {
  public:
 
   BsonType(const BsonType&) noexcept;
-  BsonType(BsonType&&) noexcept;
   BsonType& operator=(const BsonType&) noexcept;
-  BsonType& operator=(BsonType&&) noexcept;
   BsonType() noexcept;
 
   virtual ~BsonType() noexcept;
@@ -1470,9 +1428,7 @@ class VariantType {
  public:
 
   VariantType(const VariantType&) noexcept;
-  VariantType(VariantType&&) noexcept;
   VariantType& operator=(const VariantType&) noexcept;
-  VariantType& operator=(VariantType&&) noexcept;
   VariantType() noexcept;
 
   virtual ~VariantType() noexcept;
@@ -1524,9 +1480,7 @@ class GeometryType {
  public:
 
   GeometryType(const GeometryType&);
-  GeometryType(GeometryType&&) noexcept;
   GeometryType& operator=(const GeometryType&);
-  GeometryType& operator=(GeometryType&&) noexcept;
   GeometryType() noexcept;
 
   virtual ~GeometryType() noexcept;
@@ -1582,9 +1536,7 @@ class GeographyType {
  public:
 
   GeographyType(const GeographyType&);
-  GeographyType(GeographyType&&) noexcept;
   GeographyType& operator=(const GeographyType&);
-  GeographyType& operator=(GeographyType&&) noexcept;
   GeographyType() noexcept;
 
   virtual ~GeographyType() noexcept;
@@ -1652,9 +1604,7 @@ class LogicalType {
  public:
 
   LogicalType(const LogicalType&);
-  LogicalType(LogicalType&&) noexcept;
   LogicalType& operator=(const LogicalType&);
-  LogicalType& operator=(LogicalType&&) noexcept;
   LogicalType() noexcept;
 
   virtual ~LogicalType() noexcept;
@@ -1754,9 +1704,7 @@ class SchemaElement {
  public:
 
   SchemaElement(const SchemaElement&);
-  SchemaElement(SchemaElement&&) noexcept;
   SchemaElement& operator=(const SchemaElement&);
-  SchemaElement& operator=(SchemaElement&&) noexcept;
   SchemaElement() noexcept;
 
   virtual ~SchemaElement() noexcept;
@@ -1874,9 +1822,7 @@ class DataPageHeader {
  public:
 
   DataPageHeader(const DataPageHeader&);
-  DataPageHeader(DataPageHeader&&) noexcept;
   DataPageHeader& operator=(const DataPageHeader&);
-  DataPageHeader& operator=(DataPageHeader&&) noexcept;
   DataPageHeader() noexcept;
 
   virtual ~DataPageHeader() noexcept;
@@ -1948,9 +1894,7 @@ class IndexPageHeader {
  public:
 
   IndexPageHeader(const IndexPageHeader&) noexcept;
-  IndexPageHeader(IndexPageHeader&&) noexcept;
   IndexPageHeader& operator=(const IndexPageHeader&) noexcept;
-  IndexPageHeader& operator=(IndexPageHeader&&) noexcept;
   IndexPageHeader() noexcept;
 
   virtual ~IndexPageHeader() noexcept;
@@ -1989,9 +1933,7 @@ class DictionaryPageHeader {
  public:
 
   DictionaryPageHeader(const DictionaryPageHeader&) noexcept;
-  DictionaryPageHeader(DictionaryPageHeader&&) noexcept;
   DictionaryPageHeader& operator=(const DictionaryPageHeader&) noexcept;
-  DictionaryPageHeader& operator=(DictionaryPageHeader&&) noexcept;
   DictionaryPageHeader() noexcept;
 
   virtual ~DictionaryPageHeader() noexcept;
@@ -2053,9 +1995,7 @@ class DataPageHeaderV2 {
  public:
 
   DataPageHeaderV2(const DataPageHeaderV2&);
-  DataPageHeaderV2(DataPageHeaderV2&&) noexcept;
   DataPageHeaderV2& operator=(const DataPageHeaderV2&);
-  DataPageHeaderV2& operator=(DataPageHeaderV2&&) noexcept;
   DataPageHeaderV2() noexcept;
 
   virtual ~DataPageHeaderV2() noexcept;
@@ -2147,9 +2087,7 @@ class SplitBlockAlgorithm {
  public:
 
   SplitBlockAlgorithm(const SplitBlockAlgorithm&) noexcept;
-  SplitBlockAlgorithm(SplitBlockAlgorithm&&) noexcept;
   SplitBlockAlgorithm& operator=(const SplitBlockAlgorithm&) noexcept;
-  SplitBlockAlgorithm& operator=(SplitBlockAlgorithm&&) noexcept;
   SplitBlockAlgorithm() noexcept;
 
   virtual ~SplitBlockAlgorithm() noexcept;
@@ -2185,9 +2123,7 @@ class BloomFilterAlgorithm {
  public:
 
   BloomFilterAlgorithm(const BloomFilterAlgorithm&) noexcept;
-  BloomFilterAlgorithm(BloomFilterAlgorithm&&) noexcept;
   BloomFilterAlgorithm& operator=(const BloomFilterAlgorithm&) noexcept;
-  BloomFilterAlgorithm& operator=(BloomFilterAlgorithm&&) noexcept;
   BloomFilterAlgorithm() noexcept;
 
   virtual ~BloomFilterAlgorithm() noexcept;
@@ -2229,9 +2165,7 @@ class XxHash {
  public:
 
   XxHash(const XxHash&) noexcept;
-  XxHash(XxHash&&) noexcept;
   XxHash& operator=(const XxHash&) noexcept;
-  XxHash& operator=(XxHash&&) noexcept;
   XxHash() noexcept;
 
   virtual ~XxHash() noexcept;
@@ -2269,9 +2203,7 @@ class BloomFilterHash {
  public:
 
   BloomFilterHash(const BloomFilterHash&) noexcept;
-  BloomFilterHash(BloomFilterHash&&) noexcept;
   BloomFilterHash& operator=(const BloomFilterHash&) noexcept;
-  BloomFilterHash& operator=(BloomFilterHash&&) noexcept;
   BloomFilterHash() noexcept;
 
   virtual ~BloomFilterHash() noexcept;
@@ -2312,9 +2244,7 @@ class Uncompressed {
  public:
 
   Uncompressed(const Uncompressed&) noexcept;
-  Uncompressed(Uncompressed&&) noexcept;
   Uncompressed& operator=(const Uncompressed&) noexcept;
-  Uncompressed& operator=(Uncompressed&&) noexcept;
   Uncompressed() noexcept;
 
   virtual ~Uncompressed() noexcept;
@@ -2347,9 +2277,7 @@ class BloomFilterCompression {
  public:
 
   BloomFilterCompression(const BloomFilterCompression&) noexcept;
-  BloomFilterCompression(BloomFilterCompression&&) noexcept;
   BloomFilterCompression& operator=(const BloomFilterCompression&) noexcept;
-  BloomFilterCompression& operator=(BloomFilterCompression&&) noexcept;
   BloomFilterCompression() noexcept;
 
   virtual ~BloomFilterCompression() noexcept;
@@ -2388,9 +2316,7 @@ class BloomFilterHeader {
  public:
 
   BloomFilterHeader(const BloomFilterHeader&) noexcept;
-  BloomFilterHeader(BloomFilterHeader&&) noexcept;
   BloomFilterHeader& operator=(const BloomFilterHeader&) noexcept;
-  BloomFilterHeader& operator=(BloomFilterHeader&&) noexcept;
   BloomFilterHeader() noexcept;
 
   virtual ~BloomFilterHeader() noexcept;
@@ -2451,9 +2377,7 @@ class PageHeader {
  public:
 
   PageHeader(const PageHeader&);
-  PageHeader(PageHeader&&) noexcept;
   PageHeader& operator=(const PageHeader&);
-  PageHeader& operator=(PageHeader&&) noexcept;
   PageHeader() noexcept;
 
   virtual ~PageHeader() noexcept;
@@ -2544,9 +2468,7 @@ class KeyValue {
  public:
 
   KeyValue(const KeyValue&);
-  KeyValue(KeyValue&&) noexcept;
   KeyValue& operator=(const KeyValue&);
-  KeyValue& operator=(KeyValue&&) noexcept;
   KeyValue() noexcept;
 
   virtual ~KeyValue() noexcept;
@@ -2586,9 +2508,7 @@ class SortingColumn {
  public:
 
   SortingColumn(const SortingColumn&) noexcept;
-  SortingColumn(SortingColumn&&) noexcept;
   SortingColumn& operator=(const SortingColumn&) noexcept;
-  SortingColumn& operator=(SortingColumn&&) noexcept;
   SortingColumn() noexcept;
 
   virtual ~SortingColumn() noexcept;
@@ -2639,9 +2559,7 @@ class PageEncodingStats {
  public:
 
   PageEncodingStats(const PageEncodingStats&) noexcept;
-  PageEncodingStats(PageEncodingStats&&) noexcept;
   PageEncodingStats& operator=(const PageEncodingStats&) noexcept;
-  PageEncodingStats& operator=(PageEncodingStats&&) noexcept;
   PageEncodingStats() noexcept;
 
   virtual ~PageEncodingStats() noexcept;
@@ -2707,9 +2625,7 @@ class ColumnMetaData {
  public:
 
   ColumnMetaData(const ColumnMetaData&);
-  ColumnMetaData(ColumnMetaData&&) noexcept;
   ColumnMetaData& operator=(const ColumnMetaData&);
-  ColumnMetaData& operator=(ColumnMetaData&&) noexcept;
   ColumnMetaData() noexcept;
 
   virtual ~ColumnMetaData() noexcept;
@@ -2857,9 +2773,7 @@ class EncryptionWithFooterKey {
  public:
 
   EncryptionWithFooterKey(const EncryptionWithFooterKey&) noexcept;
-  EncryptionWithFooterKey(EncryptionWithFooterKey&&) noexcept;
   EncryptionWithFooterKey& operator=(const EncryptionWithFooterKey&) noexcept;
-  EncryptionWithFooterKey& operator=(EncryptionWithFooterKey&&) noexcept;
   EncryptionWithFooterKey() noexcept;
 
   virtual ~EncryptionWithFooterKey() noexcept;
@@ -2892,9 +2806,7 @@ class EncryptionWithColumnKey {
  public:
 
   EncryptionWithColumnKey(const EncryptionWithColumnKey&);
-  EncryptionWithColumnKey(EncryptionWithColumnKey&&) noexcept;
   EncryptionWithColumnKey& operator=(const EncryptionWithColumnKey&);
-  EncryptionWithColumnKey& operator=(EncryptionWithColumnKey&&) noexcept;
   EncryptionWithColumnKey() noexcept;
 
   virtual ~EncryptionWithColumnKey() noexcept;
@@ -2942,9 +2854,7 @@ class ColumnCryptoMetaData {
  public:
 
   ColumnCryptoMetaData(const ColumnCryptoMetaData&);
-  ColumnCryptoMetaData(ColumnCryptoMetaData&&) noexcept;
   ColumnCryptoMetaData& operator=(const ColumnCryptoMetaData&);
-  ColumnCryptoMetaData& operator=(ColumnCryptoMetaData&&) noexcept;
   ColumnCryptoMetaData() noexcept;
 
   virtual ~ColumnCryptoMetaData() noexcept;
@@ -2992,9 +2902,7 @@ class ColumnChunk {
  public:
 
   ColumnChunk(const ColumnChunk&);
-  ColumnChunk(ColumnChunk&&) noexcept;
   ColumnChunk& operator=(const ColumnChunk&);
-  ColumnChunk& operator=(ColumnChunk&&) noexcept;
   ColumnChunk() noexcept;
 
   virtual ~ColumnChunk() noexcept;
@@ -3099,9 +3007,7 @@ class RowGroup {
  public:
 
   RowGroup(const RowGroup&);
-  RowGroup(RowGroup&&) noexcept;
   RowGroup& operator=(const RowGroup&);
-  RowGroup& operator=(RowGroup&&) noexcept;
   RowGroup() noexcept;
 
   virtual ~RowGroup() noexcept;
@@ -3182,9 +3088,7 @@ class TypeDefinedOrder {
  public:
 
   TypeDefinedOrder(const TypeDefinedOrder&) noexcept;
-  TypeDefinedOrder(TypeDefinedOrder&&) noexcept;
   TypeDefinedOrder& operator=(const TypeDefinedOrder&) noexcept;
-  TypeDefinedOrder& operator=(TypeDefinedOrder&&) noexcept;
   TypeDefinedOrder() noexcept;
 
   virtual ~TypeDefinedOrder() noexcept;
@@ -3229,9 +3133,7 @@ class ColumnOrder {
  public:
 
   ColumnOrder(const ColumnOrder&) noexcept;
-  ColumnOrder(ColumnOrder&&) noexcept;
   ColumnOrder& operator=(const ColumnOrder&) noexcept;
-  ColumnOrder& operator=(ColumnOrder&&) noexcept;
   ColumnOrder() noexcept;
 
   virtual ~ColumnOrder() noexcept;
@@ -3318,9 +3220,7 @@ class PageLocation {
  public:
 
   PageLocation(const PageLocation&) noexcept;
-  PageLocation(PageLocation&&) noexcept;
   PageLocation& operator=(const PageLocation&) noexcept;
-  PageLocation& operator=(PageLocation&&) noexcept;
   PageLocation() noexcept;
 
   virtual ~PageLocation() noexcept;
@@ -3381,9 +3281,7 @@ class OffsetIndex {
  public:
 
   OffsetIndex(const OffsetIndex&);
-  OffsetIndex(OffsetIndex&&) noexcept;
   OffsetIndex& operator=(const OffsetIndex&);
-  OffsetIndex& operator=(OffsetIndex&&) noexcept;
   OffsetIndex() noexcept;
 
   virtual ~OffsetIndex() noexcept;
@@ -3446,9 +3344,7 @@ class ColumnIndex {
  public:
 
   ColumnIndex(const ColumnIndex&);
-  ColumnIndex(ColumnIndex&&) noexcept;
   ColumnIndex& operator=(const ColumnIndex&);
-  ColumnIndex& operator=(ColumnIndex&&) noexcept;
   ColumnIndex() noexcept;
 
   virtual ~ColumnIndex() noexcept;
@@ -3558,9 +3454,7 @@ class AesGcmV1 {
  public:
 
   AesGcmV1(const AesGcmV1&);
-  AesGcmV1(AesGcmV1&&) noexcept;
   AesGcmV1& operator=(const AesGcmV1&);
-  AesGcmV1& operator=(AesGcmV1&&) noexcept;
   AesGcmV1() noexcept;
 
   virtual ~AesGcmV1() noexcept;
@@ -3616,9 +3510,7 @@ class AesGcmCtrV1 {
  public:
 
   AesGcmCtrV1(const AesGcmCtrV1&);
-  AesGcmCtrV1(AesGcmCtrV1&&) noexcept;
   AesGcmCtrV1& operator=(const AesGcmCtrV1&);
-  AesGcmCtrV1& operator=(AesGcmCtrV1&&) noexcept;
   AesGcmCtrV1() noexcept;
 
   virtual ~AesGcmCtrV1() noexcept;
@@ -3663,30 +3555,61 @@ void swap(AesGcmCtrV1 &a, AesGcmCtrV1 &b);
 
 std::ostream& operator<<(std::ostream& out, const AesGcmCtrV1& obj);
 
+
+class ExternalDBPAV1 {
+ public:
+
+  ExternalDBPAV1(const ExternalDBPAV1&) noexcept;
+  ExternalDBPAV1& operator=(const ExternalDBPAV1&) noexcept;
+  ExternalDBPAV1() noexcept;
+
+  virtual ~ExternalDBPAV1() noexcept;
+
+  bool operator == (const ExternalDBPAV1 & /* rhs */) const;
+  bool operator != (const ExternalDBPAV1 &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const ExternalDBPAV1 & ) const;
+
+  template <class Protocol_>
+  uint32_t read(Protocol_* iprot);
+  template <class Protocol_>
+  uint32_t write(Protocol_* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
+};
+
+void swap(ExternalDBPAV1 &a, ExternalDBPAV1 &b);
+
+std::ostream& operator<<(std::ostream& out, const ExternalDBPAV1& obj);
+
 typedef struct _EncryptionAlgorithm__isset {
-  _EncryptionAlgorithm__isset() : AES_GCM_V1(false), AES_GCM_CTR_V1(false) {}
+  _EncryptionAlgorithm__isset() : AES_GCM_V1(false), AES_GCM_CTR_V1(false), EXTERNAL_DBPA_V1(false) {}
   bool AES_GCM_V1 :1;
   bool AES_GCM_CTR_V1 :1;
+  bool EXTERNAL_DBPA_V1 :1;
 } _EncryptionAlgorithm__isset;
 
 class EncryptionAlgorithm {
  public:
 
   EncryptionAlgorithm(const EncryptionAlgorithm&);
-  EncryptionAlgorithm(EncryptionAlgorithm&&) noexcept;
   EncryptionAlgorithm& operator=(const EncryptionAlgorithm&);
-  EncryptionAlgorithm& operator=(EncryptionAlgorithm&&) noexcept;
   EncryptionAlgorithm() noexcept;
 
   virtual ~EncryptionAlgorithm() noexcept;
   AesGcmV1 AES_GCM_V1;
   AesGcmCtrV1 AES_GCM_CTR_V1;
+  ExternalDBPAV1 EXTERNAL_DBPA_V1;
 
   _EncryptionAlgorithm__isset __isset;
 
   void __set_AES_GCM_V1(const AesGcmV1& val);
 
   void __set_AES_GCM_CTR_V1(const AesGcmCtrV1& val);
+
+  void __set_EXTERNAL_DBPA_V1(const ExternalDBPAV1& val);
 
   bool operator == (const EncryptionAlgorithm & rhs) const;
   bool operator != (const EncryptionAlgorithm &rhs) const {
@@ -3723,9 +3646,7 @@ class FileMetaData {
  public:
 
   FileMetaData(const FileMetaData&);
-  FileMetaData(FileMetaData&&) noexcept;
   FileMetaData& operator=(const FileMetaData&);
-  FileMetaData& operator=(FileMetaData&&) noexcept;
   FileMetaData() noexcept;
 
   virtual ~FileMetaData() noexcept;
@@ -3841,9 +3762,7 @@ class FileCryptoMetaData {
  public:
 
   FileCryptoMetaData(const FileCryptoMetaData&);
-  FileCryptoMetaData(FileCryptoMetaData&&) noexcept;
   FileCryptoMetaData& operator=(const FileCryptoMetaData&);
-  FileCryptoMetaData& operator=(FileCryptoMetaData&&) noexcept;
   FileCryptoMetaData() noexcept;
 
   virtual ~FileCryptoMetaData() noexcept;

--- a/cpp/src/generated/parquet_types.tcc
+++ b/cpp/src/generated/parquet_types.tcc
@@ -326,14 +326,14 @@ uint32_t GeospatialStatistics::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->geospatial_types.clear();
-            uint32_t _size16;
-            ::apache::thrift::protocol::TType _etype19;
-            xfer += iprot->readListBegin(_etype19, _size16);
-            this->geospatial_types.resize(_size16);
-            uint32_t _i20;
-            for (_i20 = 0; _i20 < _size16; ++_i20)
+            uint32_t _size20;
+            ::apache::thrift::protocol::TType _etype23;
+            xfer += iprot->readListBegin(_etype23, _size20);
+            this->geospatial_types.resize(_size20);
+            uint32_t _i24;
+            for (_i24 = 0; _i24 < _size20; ++_i24)
             {
-              xfer += iprot->readI32(this->geospatial_types[_i20]);
+              xfer += iprot->readI32(this->geospatial_types[_i24]);
             }
             xfer += iprot->readListEnd();
           }
@@ -369,10 +369,10 @@ uint32_t GeospatialStatistics::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("geospatial_types", ::apache::thrift::protocol::T_LIST, 2);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I32, static_cast<uint32_t>(this->geospatial_types.size()));
-      std::vector<int32_t> ::const_iterator _iter21;
-      for (_iter21 = this->geospatial_types.begin(); _iter21 != this->geospatial_types.end(); ++_iter21)
+      std::vector<int32_t> ::const_iterator _iter25;
+      for (_iter25 = this->geospatial_types.begin(); _iter25 != this->geospatial_types.end(); ++_iter25)
       {
-        xfer += oprot->writeI32((*_iter21));
+        xfer += oprot->writeI32((*_iter25));
       }
       xfer += oprot->writeListEnd();
     }
@@ -1584,9 +1584,9 @@ uint32_t GeographyType::read(Protocol_* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast66;
-          xfer += iprot->readI32(ecast66);
-          this->algorithm = static_cast<EdgeInterpolationAlgorithm::type>(ecast66);
+          int32_t ecast114;
+          xfer += iprot->readI32(ecast114);
+          this->algorithm = static_cast<EdgeInterpolationAlgorithm::type>(ecast114);
           this->__isset.algorithm = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -1916,9 +1916,9 @@ uint32_t SchemaElement::read(Protocol_* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast71;
-          xfer += iprot->readI32(ecast71);
-          this->type = static_cast<Type::type>(ecast71);
+          int32_t ecast123;
+          xfer += iprot->readI32(ecast123);
+          this->type = static_cast<Type::type>(ecast123);
           this->__isset.type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -1934,9 +1934,9 @@ uint32_t SchemaElement::read(Protocol_* iprot) {
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast72;
-          xfer += iprot->readI32(ecast72);
-          this->repetition_type = static_cast<FieldRepetitionType::type>(ecast72);
+          int32_t ecast124;
+          xfer += iprot->readI32(ecast124);
+          this->repetition_type = static_cast<FieldRepetitionType::type>(ecast124);
           this->__isset.repetition_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -1960,9 +1960,9 @@ uint32_t SchemaElement::read(Protocol_* iprot) {
         break;
       case 6:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast73;
-          xfer += iprot->readI32(ecast73);
-          this->converted_type = static_cast<ConvertedType::type>(ecast73);
+          int32_t ecast125;
+          xfer += iprot->readI32(ecast125);
+          this->converted_type = static_cast<ConvertedType::type>(ecast125);
           this->__isset.converted_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2110,9 +2110,9 @@ uint32_t DataPageHeader::read(Protocol_* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast76;
-          xfer += iprot->readI32(ecast76);
-          this->encoding = static_cast<Encoding::type>(ecast76);
+          int32_t ecast130;
+          xfer += iprot->readI32(ecast130);
+          this->encoding = static_cast<Encoding::type>(ecast130);
           isset_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2120,9 +2120,9 @@ uint32_t DataPageHeader::read(Protocol_* iprot) {
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast77;
-          xfer += iprot->readI32(ecast77);
-          this->definition_level_encoding = static_cast<Encoding::type>(ecast77);
+          int32_t ecast131;
+          xfer += iprot->readI32(ecast131);
+          this->definition_level_encoding = static_cast<Encoding::type>(ecast131);
           isset_definition_level_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2130,9 +2130,9 @@ uint32_t DataPageHeader::read(Protocol_* iprot) {
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast78;
-          xfer += iprot->readI32(ecast78);
-          this->repetition_level_encoding = static_cast<Encoding::type>(ecast78);
+          int32_t ecast132;
+          xfer += iprot->readI32(ecast132);
+          this->repetition_level_encoding = static_cast<Encoding::type>(ecast132);
           isset_repetition_level_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2272,9 +2272,9 @@ uint32_t DictionaryPageHeader::read(Protocol_* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast83;
-          xfer += iprot->readI32(ecast83);
-          this->encoding = static_cast<Encoding::type>(ecast83);
+          int32_t ecast141;
+          xfer += iprot->readI32(ecast141);
+          this->encoding = static_cast<Encoding::type>(ecast141);
           isset_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2382,9 +2382,9 @@ uint32_t DataPageHeaderV2::read(Protocol_* iprot) {
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast86;
-          xfer += iprot->readI32(ecast86);
-          this->encoding = static_cast<Encoding::type>(ecast86);
+          int32_t ecast146;
+          xfer += iprot->readI32(ecast146);
+          this->encoding = static_cast<Encoding::type>(ecast146);
           isset_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2917,9 +2917,9 @@ uint32_t PageHeader::read(Protocol_* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast103;
-          xfer += iprot->readI32(ecast103);
-          this->type = static_cast<PageType::type>(ecast103);
+          int32_t ecast179;
+          xfer += iprot->readI32(ecast179);
+          this->type = static_cast<PageType::type>(ecast179);
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3237,9 +3237,9 @@ uint32_t PageEncodingStats::read(Protocol_* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast110;
-          xfer += iprot->readI32(ecast110);
-          this->page_type = static_cast<PageType::type>(ecast110);
+          int32_t ecast192;
+          xfer += iprot->readI32(ecast192);
+          this->page_type = static_cast<PageType::type>(ecast192);
           isset_page_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3247,9 +3247,9 @@ uint32_t PageEncodingStats::read(Protocol_* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast111;
-          xfer += iprot->readI32(ecast111);
-          this->encoding = static_cast<Encoding::type>(ecast111);
+          int32_t ecast193;
+          xfer += iprot->readI32(ecast193);
+          this->encoding = static_cast<Encoding::type>(ecast193);
           isset_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3336,9 +3336,9 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast114;
-          xfer += iprot->readI32(ecast114);
-          this->type = static_cast<Type::type>(ecast114);
+          int32_t ecast198;
+          xfer += iprot->readI32(ecast198);
+          this->type = static_cast<Type::type>(ecast198);
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3348,16 +3348,16 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->encodings.clear();
-            uint32_t _size115;
-            ::apache::thrift::protocol::TType _etype118;
-            xfer += iprot->readListBegin(_etype118, _size115);
-            this->encodings.resize(_size115);
-            uint32_t _i119;
-            for (_i119 = 0; _i119 < _size115; ++_i119)
+            uint32_t _size199;
+            ::apache::thrift::protocol::TType _etype202;
+            xfer += iprot->readListBegin(_etype202, _size199);
+            this->encodings.resize(_size199);
+            uint32_t _i203;
+            for (_i203 = 0; _i203 < _size199; ++_i203)
             {
-              int32_t ecast120;
-              xfer += iprot->readI32(ecast120);
-              this->encodings[_i119] = static_cast<Encoding::type>(ecast120);
+              int32_t ecast204;
+              xfer += iprot->readI32(ecast204);
+              this->encodings[_i203] = static_cast<Encoding::type>(ecast204);
             }
             xfer += iprot->readListEnd();
           }
@@ -3370,14 +3370,14 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->path_in_schema.clear();
-            uint32_t _size121;
-            ::apache::thrift::protocol::TType _etype124;
-            xfer += iprot->readListBegin(_etype124, _size121);
-            this->path_in_schema.resize(_size121);
-            uint32_t _i125;
-            for (_i125 = 0; _i125 < _size121; ++_i125)
+            uint32_t _size205;
+            ::apache::thrift::protocol::TType _etype208;
+            xfer += iprot->readListBegin(_etype208, _size205);
+            this->path_in_schema.resize(_size205);
+            uint32_t _i209;
+            for (_i209 = 0; _i209 < _size205; ++_i209)
             {
-              xfer += iprot->readString(this->path_in_schema[_i125]);
+              xfer += iprot->readString(this->path_in_schema[_i209]);
             }
             xfer += iprot->readListEnd();
           }
@@ -3388,9 +3388,9 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast126;
-          xfer += iprot->readI32(ecast126);
-          this->codec = static_cast<CompressionCodec::type>(ecast126);
+          int32_t ecast210;
+          xfer += iprot->readI32(ecast210);
+          this->codec = static_cast<CompressionCodec::type>(ecast210);
           isset_codec = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3424,14 +3424,14 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->key_value_metadata.clear();
-            uint32_t _size127;
-            ::apache::thrift::protocol::TType _etype130;
-            xfer += iprot->readListBegin(_etype130, _size127);
-            this->key_value_metadata.resize(_size127);
-            uint32_t _i131;
-            for (_i131 = 0; _i131 < _size127; ++_i131)
+            uint32_t _size211;
+            ::apache::thrift::protocol::TType _etype214;
+            xfer += iprot->readListBegin(_etype214, _size211);
+            this->key_value_metadata.resize(_size211);
+            uint32_t _i215;
+            for (_i215 = 0; _i215 < _size211; ++_i215)
             {
-              xfer += this->key_value_metadata[_i131].read(iprot);
+              xfer += this->key_value_metadata[_i215].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -3476,14 +3476,14 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->encoding_stats.clear();
-            uint32_t _size132;
-            ::apache::thrift::protocol::TType _etype135;
-            xfer += iprot->readListBegin(_etype135, _size132);
-            this->encoding_stats.resize(_size132);
-            uint32_t _i136;
-            for (_i136 = 0; _i136 < _size132; ++_i136)
+            uint32_t _size216;
+            ::apache::thrift::protocol::TType _etype219;
+            xfer += iprot->readListBegin(_etype219, _size216);
+            this->encoding_stats.resize(_size216);
+            uint32_t _i220;
+            for (_i220 = 0; _i220 < _size216; ++_i220)
             {
-              xfer += this->encoding_stats[_i136].read(iprot);
+              xfer += this->encoding_stats[_i220].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -3565,10 +3565,10 @@ uint32_t ColumnMetaData::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("encodings", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I32, static_cast<uint32_t>(this->encodings.size()));
-    std::vector<Encoding::type> ::const_iterator _iter137;
-    for (_iter137 = this->encodings.begin(); _iter137 != this->encodings.end(); ++_iter137)
+    std::vector<Encoding::type> ::const_iterator _iter221;
+    for (_iter221 = this->encodings.begin(); _iter221 != this->encodings.end(); ++_iter221)
     {
-      xfer += oprot->writeI32(static_cast<int32_t>((*_iter137)));
+      xfer += oprot->writeI32(static_cast<int32_t>((*_iter221)));
     }
     xfer += oprot->writeListEnd();
   }
@@ -3577,10 +3577,10 @@ uint32_t ColumnMetaData::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("path_in_schema", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->path_in_schema.size()));
-    std::vector<std::string> ::const_iterator _iter138;
-    for (_iter138 = this->path_in_schema.begin(); _iter138 != this->path_in_schema.end(); ++_iter138)
+    std::vector<std::string> ::const_iterator _iter222;
+    for (_iter222 = this->path_in_schema.begin(); _iter222 != this->path_in_schema.end(); ++_iter222)
     {
-      xfer += oprot->writeString((*_iter138));
+      xfer += oprot->writeString((*_iter222));
     }
     xfer += oprot->writeListEnd();
   }
@@ -3606,10 +3606,10 @@ uint32_t ColumnMetaData::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("key_value_metadata", ::apache::thrift::protocol::T_LIST, 8);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->key_value_metadata.size()));
-      std::vector<KeyValue> ::const_iterator _iter139;
-      for (_iter139 = this->key_value_metadata.begin(); _iter139 != this->key_value_metadata.end(); ++_iter139)
+      std::vector<KeyValue> ::const_iterator _iter223;
+      for (_iter223 = this->key_value_metadata.begin(); _iter223 != this->key_value_metadata.end(); ++_iter223)
       {
-        xfer += (*_iter139).write(oprot);
+        xfer += (*_iter223).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -3638,10 +3638,10 @@ uint32_t ColumnMetaData::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("encoding_stats", ::apache::thrift::protocol::T_LIST, 13);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->encoding_stats.size()));
-      std::vector<PageEncodingStats> ::const_iterator _iter140;
-      for (_iter140 = this->encoding_stats.begin(); _iter140 != this->encoding_stats.end(); ++_iter140)
+      std::vector<PageEncodingStats> ::const_iterator _iter224;
+      for (_iter224 = this->encoding_stats.begin(); _iter224 != this->encoding_stats.end(); ++_iter224)
       {
-        xfer += (*_iter140).write(oprot);
+        xfer += (*_iter224).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -3739,14 +3739,14 @@ uint32_t EncryptionWithColumnKey::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->path_in_schema.clear();
-            uint32_t _size145;
-            ::apache::thrift::protocol::TType _etype148;
-            xfer += iprot->readListBegin(_etype148, _size145);
-            this->path_in_schema.resize(_size145);
-            uint32_t _i149;
-            for (_i149 = 0; _i149 < _size145; ++_i149)
+            uint32_t _size233;
+            ::apache::thrift::protocol::TType _etype236;
+            xfer += iprot->readListBegin(_etype236, _size233);
+            this->path_in_schema.resize(_size233);
+            uint32_t _i237;
+            for (_i237 = 0; _i237 < _size233; ++_i237)
             {
-              xfer += iprot->readString(this->path_in_schema[_i149]);
+              xfer += iprot->readString(this->path_in_schema[_i237]);
             }
             xfer += iprot->readListEnd();
           }
@@ -3786,10 +3786,10 @@ uint32_t EncryptionWithColumnKey::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("path_in_schema", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->path_in_schema.size()));
-    std::vector<std::string> ::const_iterator _iter150;
-    for (_iter150 = this->path_in_schema.begin(); _iter150 != this->path_in_schema.end(); ++_iter150)
+    std::vector<std::string> ::const_iterator _iter238;
+    for (_iter238 = this->path_in_schema.begin(); _iter238 != this->path_in_schema.end(); ++_iter238)
     {
-      xfer += oprot->writeString((*_iter150));
+      xfer += oprot->writeString((*_iter238));
     }
     xfer += oprot->writeListEnd();
   }
@@ -4069,14 +4069,14 @@ uint32_t RowGroup::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->columns.clear();
-            uint32_t _size157;
-            ::apache::thrift::protocol::TType _etype160;
-            xfer += iprot->readListBegin(_etype160, _size157);
-            this->columns.resize(_size157);
-            uint32_t _i161;
-            for (_i161 = 0; _i161 < _size157; ++_i161)
+            uint32_t _size251;
+            ::apache::thrift::protocol::TType _etype254;
+            xfer += iprot->readListBegin(_etype254, _size251);
+            this->columns.resize(_size251);
+            uint32_t _i255;
+            for (_i255 = 0; _i255 < _size251; ++_i255)
             {
-              xfer += this->columns[_i161].read(iprot);
+              xfer += this->columns[_i255].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -4105,14 +4105,14 @@ uint32_t RowGroup::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->sorting_columns.clear();
-            uint32_t _size162;
-            ::apache::thrift::protocol::TType _etype165;
-            xfer += iprot->readListBegin(_etype165, _size162);
-            this->sorting_columns.resize(_size162);
-            uint32_t _i166;
-            for (_i166 = 0; _i166 < _size162; ++_i166)
+            uint32_t _size256;
+            ::apache::thrift::protocol::TType _etype259;
+            xfer += iprot->readListBegin(_etype259, _size256);
+            this->sorting_columns.resize(_size256);
+            uint32_t _i260;
+            for (_i260 = 0; _i260 < _size256; ++_i260)
             {
-              xfer += this->sorting_columns[_i166].read(iprot);
+              xfer += this->sorting_columns[_i260].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -4172,10 +4172,10 @@ uint32_t RowGroup::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("columns", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->columns.size()));
-    std::vector<ColumnChunk> ::const_iterator _iter167;
-    for (_iter167 = this->columns.begin(); _iter167 != this->columns.end(); ++_iter167)
+    std::vector<ColumnChunk> ::const_iterator _iter261;
+    for (_iter261 = this->columns.begin(); _iter261 != this->columns.end(); ++_iter261)
     {
-      xfer += (*_iter167).write(oprot);
+      xfer += (*_iter261).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -4193,10 +4193,10 @@ uint32_t RowGroup::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("sorting_columns", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->sorting_columns.size()));
-      std::vector<SortingColumn> ::const_iterator _iter168;
-      for (_iter168 = this->sorting_columns.begin(); _iter168 != this->sorting_columns.end(); ++_iter168)
+      std::vector<SortingColumn> ::const_iterator _iter262;
+      for (_iter262 = this->sorting_columns.begin(); _iter262 != this->sorting_columns.end(); ++_iter262)
       {
-        xfer += (*_iter168).write(oprot);
+        xfer += (*_iter262).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -4437,14 +4437,14 @@ uint32_t OffsetIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->page_locations.clear();
-            uint32_t _size177;
-            ::apache::thrift::protocol::TType _etype180;
-            xfer += iprot->readListBegin(_etype180, _size177);
-            this->page_locations.resize(_size177);
-            uint32_t _i181;
-            for (_i181 = 0; _i181 < _size177; ++_i181)
+            uint32_t _size279;
+            ::apache::thrift::protocol::TType _etype282;
+            xfer += iprot->readListBegin(_etype282, _size279);
+            this->page_locations.resize(_size279);
+            uint32_t _i283;
+            for (_i283 = 0; _i283 < _size279; ++_i283)
             {
-              xfer += this->page_locations[_i181].read(iprot);
+              xfer += this->page_locations[_i283].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -4457,14 +4457,14 @@ uint32_t OffsetIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->unencoded_byte_array_data_bytes.clear();
-            uint32_t _size182;
-            ::apache::thrift::protocol::TType _etype185;
-            xfer += iprot->readListBegin(_etype185, _size182);
-            this->unencoded_byte_array_data_bytes.resize(_size182);
-            uint32_t _i186;
-            for (_i186 = 0; _i186 < _size182; ++_i186)
+            uint32_t _size284;
+            ::apache::thrift::protocol::TType _etype287;
+            xfer += iprot->readListBegin(_etype287, _size284);
+            this->unencoded_byte_array_data_bytes.resize(_size284);
+            uint32_t _i288;
+            for (_i288 = 0; _i288 < _size284; ++_i288)
             {
-              xfer += iprot->readI64(this->unencoded_byte_array_data_bytes[_i186]);
+              xfer += iprot->readI64(this->unencoded_byte_array_data_bytes[_i288]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4496,10 +4496,10 @@ uint32_t OffsetIndex::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("page_locations", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->page_locations.size()));
-    std::vector<PageLocation> ::const_iterator _iter187;
-    for (_iter187 = this->page_locations.begin(); _iter187 != this->page_locations.end(); ++_iter187)
+    std::vector<PageLocation> ::const_iterator _iter289;
+    for (_iter289 = this->page_locations.begin(); _iter289 != this->page_locations.end(); ++_iter289)
     {
-      xfer += (*_iter187).write(oprot);
+      xfer += (*_iter289).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -4509,10 +4509,10 @@ uint32_t OffsetIndex::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("unencoded_byte_array_data_bytes", ::apache::thrift::protocol::T_LIST, 2);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->unencoded_byte_array_data_bytes.size()));
-      std::vector<int64_t> ::const_iterator _iter188;
-      for (_iter188 = this->unencoded_byte_array_data_bytes.begin(); _iter188 != this->unencoded_byte_array_data_bytes.end(); ++_iter188)
+      std::vector<int64_t> ::const_iterator _iter290;
+      for (_iter290 = this->unencoded_byte_array_data_bytes.begin(); _iter290 != this->unencoded_byte_array_data_bytes.end(); ++_iter290)
       {
-        xfer += oprot->writeI64((*_iter188));
+        xfer += oprot->writeI64((*_iter290));
       }
       xfer += oprot->writeListEnd();
     }
@@ -4553,14 +4553,14 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->null_pages.clear();
-            uint32_t _size191;
-            ::apache::thrift::protocol::TType _etype194;
-            xfer += iprot->readListBegin(_etype194, _size191);
-            this->null_pages.resize(_size191);
-            uint32_t _i195;
-            for (_i195 = 0; _i195 < _size191; ++_i195)
+            uint32_t _size295;
+            ::apache::thrift::protocol::TType _etype298;
+            xfer += iprot->readListBegin(_etype298, _size295);
+            this->null_pages.resize(_size295);
+            uint32_t _i299;
+            for (_i299 = 0; _i299 < _size295; ++_i299)
             {
-              xfer += iprot->readBool(this->null_pages[_i195]);
+              xfer += iprot->readBool(this->null_pages[_i299]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4573,14 +4573,14 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->min_values.clear();
-            uint32_t _size196;
-            ::apache::thrift::protocol::TType _etype199;
-            xfer += iprot->readListBegin(_etype199, _size196);
-            this->min_values.resize(_size196);
-            uint32_t _i200;
-            for (_i200 = 0; _i200 < _size196; ++_i200)
+            uint32_t _size300;
+            ::apache::thrift::protocol::TType _etype303;
+            xfer += iprot->readListBegin(_etype303, _size300);
+            this->min_values.resize(_size300);
+            uint32_t _i304;
+            for (_i304 = 0; _i304 < _size300; ++_i304)
             {
-              xfer += iprot->readBinary(this->min_values[_i200]);
+              xfer += iprot->readBinary(this->min_values[_i304]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4593,14 +4593,14 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->max_values.clear();
-            uint32_t _size201;
-            ::apache::thrift::protocol::TType _etype204;
-            xfer += iprot->readListBegin(_etype204, _size201);
-            this->max_values.resize(_size201);
-            uint32_t _i205;
-            for (_i205 = 0; _i205 < _size201; ++_i205)
+            uint32_t _size305;
+            ::apache::thrift::protocol::TType _etype308;
+            xfer += iprot->readListBegin(_etype308, _size305);
+            this->max_values.resize(_size305);
+            uint32_t _i309;
+            for (_i309 = 0; _i309 < _size305; ++_i309)
             {
-              xfer += iprot->readBinary(this->max_values[_i205]);
+              xfer += iprot->readBinary(this->max_values[_i309]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4611,9 +4611,9 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast206;
-          xfer += iprot->readI32(ecast206);
-          this->boundary_order = static_cast<BoundaryOrder::type>(ecast206);
+          int32_t ecast310;
+          xfer += iprot->readI32(ecast310);
+          this->boundary_order = static_cast<BoundaryOrder::type>(ecast310);
           isset_boundary_order = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -4623,14 +4623,14 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->null_counts.clear();
-            uint32_t _size207;
-            ::apache::thrift::protocol::TType _etype210;
-            xfer += iprot->readListBegin(_etype210, _size207);
-            this->null_counts.resize(_size207);
-            uint32_t _i211;
-            for (_i211 = 0; _i211 < _size207; ++_i211)
+            uint32_t _size311;
+            ::apache::thrift::protocol::TType _etype314;
+            xfer += iprot->readListBegin(_etype314, _size311);
+            this->null_counts.resize(_size311);
+            uint32_t _i315;
+            for (_i315 = 0; _i315 < _size311; ++_i315)
             {
-              xfer += iprot->readI64(this->null_counts[_i211]);
+              xfer += iprot->readI64(this->null_counts[_i315]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4643,14 +4643,14 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->repetition_level_histograms.clear();
-            uint32_t _size212;
-            ::apache::thrift::protocol::TType _etype215;
-            xfer += iprot->readListBegin(_etype215, _size212);
-            this->repetition_level_histograms.resize(_size212);
-            uint32_t _i216;
-            for (_i216 = 0; _i216 < _size212; ++_i216)
+            uint32_t _size316;
+            ::apache::thrift::protocol::TType _etype319;
+            xfer += iprot->readListBegin(_etype319, _size316);
+            this->repetition_level_histograms.resize(_size316);
+            uint32_t _i320;
+            for (_i320 = 0; _i320 < _size316; ++_i320)
             {
-              xfer += iprot->readI64(this->repetition_level_histograms[_i216]);
+              xfer += iprot->readI64(this->repetition_level_histograms[_i320]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4663,14 +4663,14 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->definition_level_histograms.clear();
-            uint32_t _size217;
-            ::apache::thrift::protocol::TType _etype220;
-            xfer += iprot->readListBegin(_etype220, _size217);
-            this->definition_level_histograms.resize(_size217);
-            uint32_t _i221;
-            for (_i221 = 0; _i221 < _size217; ++_i221)
+            uint32_t _size321;
+            ::apache::thrift::protocol::TType _etype324;
+            xfer += iprot->readListBegin(_etype324, _size321);
+            this->definition_level_histograms.resize(_size321);
+            uint32_t _i325;
+            for (_i325 = 0; _i325 < _size321; ++_i325)
             {
-              xfer += iprot->readI64(this->definition_level_histograms[_i221]);
+              xfer += iprot->readI64(this->definition_level_histograms[_i325]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4708,10 +4708,10 @@ uint32_t ColumnIndex::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("null_pages", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_BOOL, static_cast<uint32_t>(this->null_pages.size()));
-    std::vector<bool> ::const_iterator _iter222;
-    for (_iter222 = this->null_pages.begin(); _iter222 != this->null_pages.end(); ++_iter222)
+    std::vector<bool> ::const_iterator _iter326;
+    for (_iter326 = this->null_pages.begin(); _iter326 != this->null_pages.end(); ++_iter326)
     {
-      xfer += oprot->writeBool((*_iter222));
+      xfer += oprot->writeBool((*_iter326));
     }
     xfer += oprot->writeListEnd();
   }
@@ -4720,10 +4720,10 @@ uint32_t ColumnIndex::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("min_values", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->min_values.size()));
-    std::vector<std::string> ::const_iterator _iter223;
-    for (_iter223 = this->min_values.begin(); _iter223 != this->min_values.end(); ++_iter223)
+    std::vector<std::string> ::const_iterator _iter327;
+    for (_iter327 = this->min_values.begin(); _iter327 != this->min_values.end(); ++_iter327)
     {
-      xfer += oprot->writeBinary((*_iter223));
+      xfer += oprot->writeBinary((*_iter327));
     }
     xfer += oprot->writeListEnd();
   }
@@ -4732,10 +4732,10 @@ uint32_t ColumnIndex::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("max_values", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->max_values.size()));
-    std::vector<std::string> ::const_iterator _iter224;
-    for (_iter224 = this->max_values.begin(); _iter224 != this->max_values.end(); ++_iter224)
+    std::vector<std::string> ::const_iterator _iter328;
+    for (_iter328 = this->max_values.begin(); _iter328 != this->max_values.end(); ++_iter328)
     {
-      xfer += oprot->writeBinary((*_iter224));
+      xfer += oprot->writeBinary((*_iter328));
     }
     xfer += oprot->writeListEnd();
   }
@@ -4749,10 +4749,10 @@ uint32_t ColumnIndex::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("null_counts", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->null_counts.size()));
-      std::vector<int64_t> ::const_iterator _iter225;
-      for (_iter225 = this->null_counts.begin(); _iter225 != this->null_counts.end(); ++_iter225)
+      std::vector<int64_t> ::const_iterator _iter329;
+      for (_iter329 = this->null_counts.begin(); _iter329 != this->null_counts.end(); ++_iter329)
       {
-        xfer += oprot->writeI64((*_iter225));
+        xfer += oprot->writeI64((*_iter329));
       }
       xfer += oprot->writeListEnd();
     }
@@ -4762,10 +4762,10 @@ uint32_t ColumnIndex::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("repetition_level_histograms", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->repetition_level_histograms.size()));
-      std::vector<int64_t> ::const_iterator _iter226;
-      for (_iter226 = this->repetition_level_histograms.begin(); _iter226 != this->repetition_level_histograms.end(); ++_iter226)
+      std::vector<int64_t> ::const_iterator _iter330;
+      for (_iter330 = this->repetition_level_histograms.begin(); _iter330 != this->repetition_level_histograms.end(); ++_iter330)
       {
-        xfer += oprot->writeI64((*_iter226));
+        xfer += oprot->writeI64((*_iter330));
       }
       xfer += oprot->writeListEnd();
     }
@@ -4775,10 +4775,10 @@ uint32_t ColumnIndex::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("definition_level_histograms", ::apache::thrift::protocol::T_LIST, 7);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->definition_level_histograms.size()));
-      std::vector<int64_t> ::const_iterator _iter227;
-      for (_iter227 = this->definition_level_histograms.begin(); _iter227 != this->definition_level_histograms.end(); ++_iter227)
+      std::vector<int64_t> ::const_iterator _iter331;
+      for (_iter331 = this->definition_level_histograms.begin(); _iter331 != this->definition_level_histograms.end(); ++_iter331)
       {
-        xfer += oprot->writeI64((*_iter227));
+        xfer += oprot->writeI64((*_iter331));
       }
       xfer += oprot->writeListEnd();
     }
@@ -5119,14 +5119,14 @@ uint32_t FileMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->schema.clear();
-            uint32_t _size238;
-            ::apache::thrift::protocol::TType _etype241;
-            xfer += iprot->readListBegin(_etype241, _size238);
-            this->schema.resize(_size238);
-            uint32_t _i242;
-            for (_i242 = 0; _i242 < _size238; ++_i242)
+            uint32_t _size352;
+            ::apache::thrift::protocol::TType _etype355;
+            xfer += iprot->readListBegin(_etype355, _size352);
+            this->schema.resize(_size352);
+            uint32_t _i356;
+            for (_i356 = 0; _i356 < _size352; ++_i356)
             {
-              xfer += this->schema[_i242].read(iprot);
+              xfer += this->schema[_i356].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5147,14 +5147,14 @@ uint32_t FileMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->row_groups.clear();
-            uint32_t _size243;
-            ::apache::thrift::protocol::TType _etype246;
-            xfer += iprot->readListBegin(_etype246, _size243);
-            this->row_groups.resize(_size243);
-            uint32_t _i247;
-            for (_i247 = 0; _i247 < _size243; ++_i247)
+            uint32_t _size357;
+            ::apache::thrift::protocol::TType _etype360;
+            xfer += iprot->readListBegin(_etype360, _size357);
+            this->row_groups.resize(_size357);
+            uint32_t _i361;
+            for (_i361 = 0; _i361 < _size357; ++_i361)
             {
-              xfer += this->row_groups[_i247].read(iprot);
+              xfer += this->row_groups[_i361].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5167,14 +5167,14 @@ uint32_t FileMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->key_value_metadata.clear();
-            uint32_t _size248;
-            ::apache::thrift::protocol::TType _etype251;
-            xfer += iprot->readListBegin(_etype251, _size248);
-            this->key_value_metadata.resize(_size248);
-            uint32_t _i252;
-            for (_i252 = 0; _i252 < _size248; ++_i252)
+            uint32_t _size362;
+            ::apache::thrift::protocol::TType _etype365;
+            xfer += iprot->readListBegin(_etype365, _size362);
+            this->key_value_metadata.resize(_size362);
+            uint32_t _i366;
+            for (_i366 = 0; _i366 < _size362; ++_i366)
             {
-              xfer += this->key_value_metadata[_i252].read(iprot);
+              xfer += this->key_value_metadata[_i366].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5195,14 +5195,14 @@ uint32_t FileMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->column_orders.clear();
-            uint32_t _size253;
-            ::apache::thrift::protocol::TType _etype256;
-            xfer += iprot->readListBegin(_etype256, _size253);
-            this->column_orders.resize(_size253);
-            uint32_t _i257;
-            for (_i257 = 0; _i257 < _size253; ++_i257)
+            uint32_t _size367;
+            ::apache::thrift::protocol::TType _etype370;
+            xfer += iprot->readListBegin(_etype370, _size367);
+            this->column_orders.resize(_size367);
+            uint32_t _i371;
+            for (_i371 = 0; _i371 < _size367; ++_i371)
             {
-              xfer += this->column_orders[_i257].read(iprot);
+              xfer += this->column_orders[_i371].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5260,10 +5260,10 @@ uint32_t FileMetaData::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("schema", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->schema.size()));
-    std::vector<SchemaElement> ::const_iterator _iter258;
-    for (_iter258 = this->schema.begin(); _iter258 != this->schema.end(); ++_iter258)
+    std::vector<SchemaElement> ::const_iterator _iter372;
+    for (_iter372 = this->schema.begin(); _iter372 != this->schema.end(); ++_iter372)
     {
-      xfer += (*_iter258).write(oprot);
+      xfer += (*_iter372).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -5276,10 +5276,10 @@ uint32_t FileMetaData::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("row_groups", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->row_groups.size()));
-    std::vector<RowGroup> ::const_iterator _iter259;
-    for (_iter259 = this->row_groups.begin(); _iter259 != this->row_groups.end(); ++_iter259)
+    std::vector<RowGroup> ::const_iterator _iter373;
+    for (_iter373 = this->row_groups.begin(); _iter373 != this->row_groups.end(); ++_iter373)
     {
-      xfer += (*_iter259).write(oprot);
+      xfer += (*_iter373).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -5289,10 +5289,10 @@ uint32_t FileMetaData::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("key_value_metadata", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->key_value_metadata.size()));
-      std::vector<KeyValue> ::const_iterator _iter260;
-      for (_iter260 = this->key_value_metadata.begin(); _iter260 != this->key_value_metadata.end(); ++_iter260)
+      std::vector<KeyValue> ::const_iterator _iter374;
+      for (_iter374 = this->key_value_metadata.begin(); _iter374 != this->key_value_metadata.end(); ++_iter374)
       {
-        xfer += (*_iter260).write(oprot);
+        xfer += (*_iter374).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -5307,10 +5307,10 @@ uint32_t FileMetaData::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("column_orders", ::apache::thrift::protocol::T_LIST, 7);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->column_orders.size()));
-      std::vector<ColumnOrder> ::const_iterator _iter261;
-      for (_iter261 = this->column_orders.begin(); _iter261 != this->column_orders.end(); ++_iter261)
+      std::vector<ColumnOrder> ::const_iterator _iter375;
+      for (_iter375 = this->column_orders.begin(); _iter375 != this->column_orders.end(); ++_iter375)
       {
-        xfer += (*_iter261).write(oprot);
+        xfer += (*_iter375).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }

--- a/cpp/src/generated/parquet_types.tcc
+++ b/cpp/src/generated/parquet_types.tcc
@@ -326,14 +326,14 @@ uint32_t GeospatialStatistics::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->geospatial_types.clear();
-            uint32_t _size20;
-            ::apache::thrift::protocol::TType _etype23;
-            xfer += iprot->readListBegin(_etype23, _size20);
-            this->geospatial_types.resize(_size20);
-            uint32_t _i24;
-            for (_i24 = 0; _i24 < _size20; ++_i24)
+            uint32_t _size16;
+            ::apache::thrift::protocol::TType _etype19;
+            xfer += iprot->readListBegin(_etype19, _size16);
+            this->geospatial_types.resize(_size16);
+            uint32_t _i20;
+            for (_i20 = 0; _i20 < _size16; ++_i20)
             {
-              xfer += iprot->readI32(this->geospatial_types[_i24]);
+              xfer += iprot->readI32(this->geospatial_types[_i20]);
             }
             xfer += iprot->readListEnd();
           }
@@ -369,10 +369,10 @@ uint32_t GeospatialStatistics::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("geospatial_types", ::apache::thrift::protocol::T_LIST, 2);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I32, static_cast<uint32_t>(this->geospatial_types.size()));
-      std::vector<int32_t> ::const_iterator _iter25;
-      for (_iter25 = this->geospatial_types.begin(); _iter25 != this->geospatial_types.end(); ++_iter25)
+      std::vector<int32_t> ::const_iterator _iter21;
+      for (_iter21 = this->geospatial_types.begin(); _iter21 != this->geospatial_types.end(); ++_iter21)
       {
-        xfer += oprot->writeI32((*_iter25));
+        xfer += oprot->writeI32((*_iter21));
       }
       xfer += oprot->writeListEnd();
     }
@@ -1584,9 +1584,9 @@ uint32_t GeographyType::read(Protocol_* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast114;
-          xfer += iprot->readI32(ecast114);
-          this->algorithm = static_cast<EdgeInterpolationAlgorithm::type>(ecast114);
+          int32_t ecast66;
+          xfer += iprot->readI32(ecast66);
+          this->algorithm = static_cast<EdgeInterpolationAlgorithm::type>(ecast66);
           this->__isset.algorithm = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -1916,9 +1916,9 @@ uint32_t SchemaElement::read(Protocol_* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast123;
-          xfer += iprot->readI32(ecast123);
-          this->type = static_cast<Type::type>(ecast123);
+          int32_t ecast71;
+          xfer += iprot->readI32(ecast71);
+          this->type = static_cast<Type::type>(ecast71);
           this->__isset.type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -1934,9 +1934,9 @@ uint32_t SchemaElement::read(Protocol_* iprot) {
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast124;
-          xfer += iprot->readI32(ecast124);
-          this->repetition_type = static_cast<FieldRepetitionType::type>(ecast124);
+          int32_t ecast72;
+          xfer += iprot->readI32(ecast72);
+          this->repetition_type = static_cast<FieldRepetitionType::type>(ecast72);
           this->__isset.repetition_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -1960,9 +1960,9 @@ uint32_t SchemaElement::read(Protocol_* iprot) {
         break;
       case 6:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast125;
-          xfer += iprot->readI32(ecast125);
-          this->converted_type = static_cast<ConvertedType::type>(ecast125);
+          int32_t ecast73;
+          xfer += iprot->readI32(ecast73);
+          this->converted_type = static_cast<ConvertedType::type>(ecast73);
           this->__isset.converted_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2110,9 +2110,9 @@ uint32_t DataPageHeader::read(Protocol_* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast130;
-          xfer += iprot->readI32(ecast130);
-          this->encoding = static_cast<Encoding::type>(ecast130);
+          int32_t ecast76;
+          xfer += iprot->readI32(ecast76);
+          this->encoding = static_cast<Encoding::type>(ecast76);
           isset_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2120,9 +2120,9 @@ uint32_t DataPageHeader::read(Protocol_* iprot) {
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast131;
-          xfer += iprot->readI32(ecast131);
-          this->definition_level_encoding = static_cast<Encoding::type>(ecast131);
+          int32_t ecast77;
+          xfer += iprot->readI32(ecast77);
+          this->definition_level_encoding = static_cast<Encoding::type>(ecast77);
           isset_definition_level_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2130,9 +2130,9 @@ uint32_t DataPageHeader::read(Protocol_* iprot) {
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast132;
-          xfer += iprot->readI32(ecast132);
-          this->repetition_level_encoding = static_cast<Encoding::type>(ecast132);
+          int32_t ecast78;
+          xfer += iprot->readI32(ecast78);
+          this->repetition_level_encoding = static_cast<Encoding::type>(ecast78);
           isset_repetition_level_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2272,9 +2272,9 @@ uint32_t DictionaryPageHeader::read(Protocol_* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast141;
-          xfer += iprot->readI32(ecast141);
-          this->encoding = static_cast<Encoding::type>(ecast141);
+          int32_t ecast83;
+          xfer += iprot->readI32(ecast83);
+          this->encoding = static_cast<Encoding::type>(ecast83);
           isset_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2382,9 +2382,9 @@ uint32_t DataPageHeaderV2::read(Protocol_* iprot) {
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast146;
-          xfer += iprot->readI32(ecast146);
-          this->encoding = static_cast<Encoding::type>(ecast146);
+          int32_t ecast86;
+          xfer += iprot->readI32(ecast86);
+          this->encoding = static_cast<Encoding::type>(ecast86);
           isset_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2917,9 +2917,9 @@ uint32_t PageHeader::read(Protocol_* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast179;
-          xfer += iprot->readI32(ecast179);
-          this->type = static_cast<PageType::type>(ecast179);
+          int32_t ecast103;
+          xfer += iprot->readI32(ecast103);
+          this->type = static_cast<PageType::type>(ecast103);
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3237,9 +3237,9 @@ uint32_t PageEncodingStats::read(Protocol_* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast192;
-          xfer += iprot->readI32(ecast192);
-          this->page_type = static_cast<PageType::type>(ecast192);
+          int32_t ecast110;
+          xfer += iprot->readI32(ecast110);
+          this->page_type = static_cast<PageType::type>(ecast110);
           isset_page_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3247,9 +3247,9 @@ uint32_t PageEncodingStats::read(Protocol_* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast193;
-          xfer += iprot->readI32(ecast193);
-          this->encoding = static_cast<Encoding::type>(ecast193);
+          int32_t ecast111;
+          xfer += iprot->readI32(ecast111);
+          this->encoding = static_cast<Encoding::type>(ecast111);
           isset_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3336,9 +3336,9 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast198;
-          xfer += iprot->readI32(ecast198);
-          this->type = static_cast<Type::type>(ecast198);
+          int32_t ecast114;
+          xfer += iprot->readI32(ecast114);
+          this->type = static_cast<Type::type>(ecast114);
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3348,16 +3348,16 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->encodings.clear();
-            uint32_t _size199;
-            ::apache::thrift::protocol::TType _etype202;
-            xfer += iprot->readListBegin(_etype202, _size199);
-            this->encodings.resize(_size199);
-            uint32_t _i203;
-            for (_i203 = 0; _i203 < _size199; ++_i203)
+            uint32_t _size115;
+            ::apache::thrift::protocol::TType _etype118;
+            xfer += iprot->readListBegin(_etype118, _size115);
+            this->encodings.resize(_size115);
+            uint32_t _i119;
+            for (_i119 = 0; _i119 < _size115; ++_i119)
             {
-              int32_t ecast204;
-              xfer += iprot->readI32(ecast204);
-              this->encodings[_i203] = static_cast<Encoding::type>(ecast204);
+              int32_t ecast120;
+              xfer += iprot->readI32(ecast120);
+              this->encodings[_i119] = static_cast<Encoding::type>(ecast120);
             }
             xfer += iprot->readListEnd();
           }
@@ -3370,14 +3370,14 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->path_in_schema.clear();
-            uint32_t _size205;
-            ::apache::thrift::protocol::TType _etype208;
-            xfer += iprot->readListBegin(_etype208, _size205);
-            this->path_in_schema.resize(_size205);
-            uint32_t _i209;
-            for (_i209 = 0; _i209 < _size205; ++_i209)
+            uint32_t _size121;
+            ::apache::thrift::protocol::TType _etype124;
+            xfer += iprot->readListBegin(_etype124, _size121);
+            this->path_in_schema.resize(_size121);
+            uint32_t _i125;
+            for (_i125 = 0; _i125 < _size121; ++_i125)
             {
-              xfer += iprot->readString(this->path_in_schema[_i209]);
+              xfer += iprot->readString(this->path_in_schema[_i125]);
             }
             xfer += iprot->readListEnd();
           }
@@ -3388,9 +3388,9 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast210;
-          xfer += iprot->readI32(ecast210);
-          this->codec = static_cast<CompressionCodec::type>(ecast210);
+          int32_t ecast126;
+          xfer += iprot->readI32(ecast126);
+          this->codec = static_cast<CompressionCodec::type>(ecast126);
           isset_codec = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3424,14 +3424,14 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->key_value_metadata.clear();
-            uint32_t _size211;
-            ::apache::thrift::protocol::TType _etype214;
-            xfer += iprot->readListBegin(_etype214, _size211);
-            this->key_value_metadata.resize(_size211);
-            uint32_t _i215;
-            for (_i215 = 0; _i215 < _size211; ++_i215)
+            uint32_t _size127;
+            ::apache::thrift::protocol::TType _etype130;
+            xfer += iprot->readListBegin(_etype130, _size127);
+            this->key_value_metadata.resize(_size127);
+            uint32_t _i131;
+            for (_i131 = 0; _i131 < _size127; ++_i131)
             {
-              xfer += this->key_value_metadata[_i215].read(iprot);
+              xfer += this->key_value_metadata[_i131].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -3476,14 +3476,14 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->encoding_stats.clear();
-            uint32_t _size216;
-            ::apache::thrift::protocol::TType _etype219;
-            xfer += iprot->readListBegin(_etype219, _size216);
-            this->encoding_stats.resize(_size216);
-            uint32_t _i220;
-            for (_i220 = 0; _i220 < _size216; ++_i220)
+            uint32_t _size132;
+            ::apache::thrift::protocol::TType _etype135;
+            xfer += iprot->readListBegin(_etype135, _size132);
+            this->encoding_stats.resize(_size132);
+            uint32_t _i136;
+            for (_i136 = 0; _i136 < _size132; ++_i136)
             {
-              xfer += this->encoding_stats[_i220].read(iprot);
+              xfer += this->encoding_stats[_i136].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -3565,10 +3565,10 @@ uint32_t ColumnMetaData::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("encodings", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I32, static_cast<uint32_t>(this->encodings.size()));
-    std::vector<Encoding::type> ::const_iterator _iter221;
-    for (_iter221 = this->encodings.begin(); _iter221 != this->encodings.end(); ++_iter221)
+    std::vector<Encoding::type> ::const_iterator _iter137;
+    for (_iter137 = this->encodings.begin(); _iter137 != this->encodings.end(); ++_iter137)
     {
-      xfer += oprot->writeI32(static_cast<int32_t>((*_iter221)));
+      xfer += oprot->writeI32(static_cast<int32_t>((*_iter137)));
     }
     xfer += oprot->writeListEnd();
   }
@@ -3577,10 +3577,10 @@ uint32_t ColumnMetaData::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("path_in_schema", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->path_in_schema.size()));
-    std::vector<std::string> ::const_iterator _iter222;
-    for (_iter222 = this->path_in_schema.begin(); _iter222 != this->path_in_schema.end(); ++_iter222)
+    std::vector<std::string> ::const_iterator _iter138;
+    for (_iter138 = this->path_in_schema.begin(); _iter138 != this->path_in_schema.end(); ++_iter138)
     {
-      xfer += oprot->writeString((*_iter222));
+      xfer += oprot->writeString((*_iter138));
     }
     xfer += oprot->writeListEnd();
   }
@@ -3606,10 +3606,10 @@ uint32_t ColumnMetaData::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("key_value_metadata", ::apache::thrift::protocol::T_LIST, 8);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->key_value_metadata.size()));
-      std::vector<KeyValue> ::const_iterator _iter223;
-      for (_iter223 = this->key_value_metadata.begin(); _iter223 != this->key_value_metadata.end(); ++_iter223)
+      std::vector<KeyValue> ::const_iterator _iter139;
+      for (_iter139 = this->key_value_metadata.begin(); _iter139 != this->key_value_metadata.end(); ++_iter139)
       {
-        xfer += (*_iter223).write(oprot);
+        xfer += (*_iter139).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -3638,10 +3638,10 @@ uint32_t ColumnMetaData::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("encoding_stats", ::apache::thrift::protocol::T_LIST, 13);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->encoding_stats.size()));
-      std::vector<PageEncodingStats> ::const_iterator _iter224;
-      for (_iter224 = this->encoding_stats.begin(); _iter224 != this->encoding_stats.end(); ++_iter224)
+      std::vector<PageEncodingStats> ::const_iterator _iter140;
+      for (_iter140 = this->encoding_stats.begin(); _iter140 != this->encoding_stats.end(); ++_iter140)
       {
-        xfer += (*_iter224).write(oprot);
+        xfer += (*_iter140).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -3739,14 +3739,14 @@ uint32_t EncryptionWithColumnKey::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->path_in_schema.clear();
-            uint32_t _size233;
-            ::apache::thrift::protocol::TType _etype236;
-            xfer += iprot->readListBegin(_etype236, _size233);
-            this->path_in_schema.resize(_size233);
-            uint32_t _i237;
-            for (_i237 = 0; _i237 < _size233; ++_i237)
+            uint32_t _size145;
+            ::apache::thrift::protocol::TType _etype148;
+            xfer += iprot->readListBegin(_etype148, _size145);
+            this->path_in_schema.resize(_size145);
+            uint32_t _i149;
+            for (_i149 = 0; _i149 < _size145; ++_i149)
             {
-              xfer += iprot->readString(this->path_in_schema[_i237]);
+              xfer += iprot->readString(this->path_in_schema[_i149]);
             }
             xfer += iprot->readListEnd();
           }
@@ -3786,10 +3786,10 @@ uint32_t EncryptionWithColumnKey::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("path_in_schema", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->path_in_schema.size()));
-    std::vector<std::string> ::const_iterator _iter238;
-    for (_iter238 = this->path_in_schema.begin(); _iter238 != this->path_in_schema.end(); ++_iter238)
+    std::vector<std::string> ::const_iterator _iter150;
+    for (_iter150 = this->path_in_schema.begin(); _iter150 != this->path_in_schema.end(); ++_iter150)
     {
-      xfer += oprot->writeString((*_iter238));
+      xfer += oprot->writeString((*_iter150));
     }
     xfer += oprot->writeListEnd();
   }
@@ -4069,14 +4069,14 @@ uint32_t RowGroup::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->columns.clear();
-            uint32_t _size251;
-            ::apache::thrift::protocol::TType _etype254;
-            xfer += iprot->readListBegin(_etype254, _size251);
-            this->columns.resize(_size251);
-            uint32_t _i255;
-            for (_i255 = 0; _i255 < _size251; ++_i255)
+            uint32_t _size157;
+            ::apache::thrift::protocol::TType _etype160;
+            xfer += iprot->readListBegin(_etype160, _size157);
+            this->columns.resize(_size157);
+            uint32_t _i161;
+            for (_i161 = 0; _i161 < _size157; ++_i161)
             {
-              xfer += this->columns[_i255].read(iprot);
+              xfer += this->columns[_i161].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -4105,14 +4105,14 @@ uint32_t RowGroup::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->sorting_columns.clear();
-            uint32_t _size256;
-            ::apache::thrift::protocol::TType _etype259;
-            xfer += iprot->readListBegin(_etype259, _size256);
-            this->sorting_columns.resize(_size256);
-            uint32_t _i260;
-            for (_i260 = 0; _i260 < _size256; ++_i260)
+            uint32_t _size162;
+            ::apache::thrift::protocol::TType _etype165;
+            xfer += iprot->readListBegin(_etype165, _size162);
+            this->sorting_columns.resize(_size162);
+            uint32_t _i166;
+            for (_i166 = 0; _i166 < _size162; ++_i166)
             {
-              xfer += this->sorting_columns[_i260].read(iprot);
+              xfer += this->sorting_columns[_i166].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -4172,10 +4172,10 @@ uint32_t RowGroup::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("columns", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->columns.size()));
-    std::vector<ColumnChunk> ::const_iterator _iter261;
-    for (_iter261 = this->columns.begin(); _iter261 != this->columns.end(); ++_iter261)
+    std::vector<ColumnChunk> ::const_iterator _iter167;
+    for (_iter167 = this->columns.begin(); _iter167 != this->columns.end(); ++_iter167)
     {
-      xfer += (*_iter261).write(oprot);
+      xfer += (*_iter167).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -4193,10 +4193,10 @@ uint32_t RowGroup::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("sorting_columns", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->sorting_columns.size()));
-      std::vector<SortingColumn> ::const_iterator _iter262;
-      for (_iter262 = this->sorting_columns.begin(); _iter262 != this->sorting_columns.end(); ++_iter262)
+      std::vector<SortingColumn> ::const_iterator _iter168;
+      for (_iter168 = this->sorting_columns.begin(); _iter168 != this->sorting_columns.end(); ++_iter168)
       {
-        xfer += (*_iter262).write(oprot);
+        xfer += (*_iter168).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -4437,14 +4437,14 @@ uint32_t OffsetIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->page_locations.clear();
-            uint32_t _size279;
-            ::apache::thrift::protocol::TType _etype282;
-            xfer += iprot->readListBegin(_etype282, _size279);
-            this->page_locations.resize(_size279);
-            uint32_t _i283;
-            for (_i283 = 0; _i283 < _size279; ++_i283)
+            uint32_t _size177;
+            ::apache::thrift::protocol::TType _etype180;
+            xfer += iprot->readListBegin(_etype180, _size177);
+            this->page_locations.resize(_size177);
+            uint32_t _i181;
+            for (_i181 = 0; _i181 < _size177; ++_i181)
             {
-              xfer += this->page_locations[_i283].read(iprot);
+              xfer += this->page_locations[_i181].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -4457,14 +4457,14 @@ uint32_t OffsetIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->unencoded_byte_array_data_bytes.clear();
-            uint32_t _size284;
-            ::apache::thrift::protocol::TType _etype287;
-            xfer += iprot->readListBegin(_etype287, _size284);
-            this->unencoded_byte_array_data_bytes.resize(_size284);
-            uint32_t _i288;
-            for (_i288 = 0; _i288 < _size284; ++_i288)
+            uint32_t _size182;
+            ::apache::thrift::protocol::TType _etype185;
+            xfer += iprot->readListBegin(_etype185, _size182);
+            this->unencoded_byte_array_data_bytes.resize(_size182);
+            uint32_t _i186;
+            for (_i186 = 0; _i186 < _size182; ++_i186)
             {
-              xfer += iprot->readI64(this->unencoded_byte_array_data_bytes[_i288]);
+              xfer += iprot->readI64(this->unencoded_byte_array_data_bytes[_i186]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4496,10 +4496,10 @@ uint32_t OffsetIndex::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("page_locations", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->page_locations.size()));
-    std::vector<PageLocation> ::const_iterator _iter289;
-    for (_iter289 = this->page_locations.begin(); _iter289 != this->page_locations.end(); ++_iter289)
+    std::vector<PageLocation> ::const_iterator _iter187;
+    for (_iter187 = this->page_locations.begin(); _iter187 != this->page_locations.end(); ++_iter187)
     {
-      xfer += (*_iter289).write(oprot);
+      xfer += (*_iter187).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -4509,10 +4509,10 @@ uint32_t OffsetIndex::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("unencoded_byte_array_data_bytes", ::apache::thrift::protocol::T_LIST, 2);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->unencoded_byte_array_data_bytes.size()));
-      std::vector<int64_t> ::const_iterator _iter290;
-      for (_iter290 = this->unencoded_byte_array_data_bytes.begin(); _iter290 != this->unencoded_byte_array_data_bytes.end(); ++_iter290)
+      std::vector<int64_t> ::const_iterator _iter188;
+      for (_iter188 = this->unencoded_byte_array_data_bytes.begin(); _iter188 != this->unencoded_byte_array_data_bytes.end(); ++_iter188)
       {
-        xfer += oprot->writeI64((*_iter290));
+        xfer += oprot->writeI64((*_iter188));
       }
       xfer += oprot->writeListEnd();
     }
@@ -4553,14 +4553,14 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->null_pages.clear();
-            uint32_t _size295;
-            ::apache::thrift::protocol::TType _etype298;
-            xfer += iprot->readListBegin(_etype298, _size295);
-            this->null_pages.resize(_size295);
-            uint32_t _i299;
-            for (_i299 = 0; _i299 < _size295; ++_i299)
+            uint32_t _size191;
+            ::apache::thrift::protocol::TType _etype194;
+            xfer += iprot->readListBegin(_etype194, _size191);
+            this->null_pages.resize(_size191);
+            uint32_t _i195;
+            for (_i195 = 0; _i195 < _size191; ++_i195)
             {
-              xfer += iprot->readBool(this->null_pages[_i299]);
+              xfer += iprot->readBool(this->null_pages[_i195]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4573,14 +4573,14 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->min_values.clear();
-            uint32_t _size300;
-            ::apache::thrift::protocol::TType _etype303;
-            xfer += iprot->readListBegin(_etype303, _size300);
-            this->min_values.resize(_size300);
-            uint32_t _i304;
-            for (_i304 = 0; _i304 < _size300; ++_i304)
+            uint32_t _size196;
+            ::apache::thrift::protocol::TType _etype199;
+            xfer += iprot->readListBegin(_etype199, _size196);
+            this->min_values.resize(_size196);
+            uint32_t _i200;
+            for (_i200 = 0; _i200 < _size196; ++_i200)
             {
-              xfer += iprot->readBinary(this->min_values[_i304]);
+              xfer += iprot->readBinary(this->min_values[_i200]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4593,14 +4593,14 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->max_values.clear();
-            uint32_t _size305;
-            ::apache::thrift::protocol::TType _etype308;
-            xfer += iprot->readListBegin(_etype308, _size305);
-            this->max_values.resize(_size305);
-            uint32_t _i309;
-            for (_i309 = 0; _i309 < _size305; ++_i309)
+            uint32_t _size201;
+            ::apache::thrift::protocol::TType _etype204;
+            xfer += iprot->readListBegin(_etype204, _size201);
+            this->max_values.resize(_size201);
+            uint32_t _i205;
+            for (_i205 = 0; _i205 < _size201; ++_i205)
             {
-              xfer += iprot->readBinary(this->max_values[_i309]);
+              xfer += iprot->readBinary(this->max_values[_i205]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4611,9 +4611,9 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast310;
-          xfer += iprot->readI32(ecast310);
-          this->boundary_order = static_cast<BoundaryOrder::type>(ecast310);
+          int32_t ecast206;
+          xfer += iprot->readI32(ecast206);
+          this->boundary_order = static_cast<BoundaryOrder::type>(ecast206);
           isset_boundary_order = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -4623,14 +4623,14 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->null_counts.clear();
-            uint32_t _size311;
-            ::apache::thrift::protocol::TType _etype314;
-            xfer += iprot->readListBegin(_etype314, _size311);
-            this->null_counts.resize(_size311);
-            uint32_t _i315;
-            for (_i315 = 0; _i315 < _size311; ++_i315)
+            uint32_t _size207;
+            ::apache::thrift::protocol::TType _etype210;
+            xfer += iprot->readListBegin(_etype210, _size207);
+            this->null_counts.resize(_size207);
+            uint32_t _i211;
+            for (_i211 = 0; _i211 < _size207; ++_i211)
             {
-              xfer += iprot->readI64(this->null_counts[_i315]);
+              xfer += iprot->readI64(this->null_counts[_i211]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4643,14 +4643,14 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->repetition_level_histograms.clear();
-            uint32_t _size316;
-            ::apache::thrift::protocol::TType _etype319;
-            xfer += iprot->readListBegin(_etype319, _size316);
-            this->repetition_level_histograms.resize(_size316);
-            uint32_t _i320;
-            for (_i320 = 0; _i320 < _size316; ++_i320)
+            uint32_t _size212;
+            ::apache::thrift::protocol::TType _etype215;
+            xfer += iprot->readListBegin(_etype215, _size212);
+            this->repetition_level_histograms.resize(_size212);
+            uint32_t _i216;
+            for (_i216 = 0; _i216 < _size212; ++_i216)
             {
-              xfer += iprot->readI64(this->repetition_level_histograms[_i320]);
+              xfer += iprot->readI64(this->repetition_level_histograms[_i216]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4663,14 +4663,14 @@ uint32_t ColumnIndex::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->definition_level_histograms.clear();
-            uint32_t _size321;
-            ::apache::thrift::protocol::TType _etype324;
-            xfer += iprot->readListBegin(_etype324, _size321);
-            this->definition_level_histograms.resize(_size321);
-            uint32_t _i325;
-            for (_i325 = 0; _i325 < _size321; ++_i325)
+            uint32_t _size217;
+            ::apache::thrift::protocol::TType _etype220;
+            xfer += iprot->readListBegin(_etype220, _size217);
+            this->definition_level_histograms.resize(_size217);
+            uint32_t _i221;
+            for (_i221 = 0; _i221 < _size217; ++_i221)
             {
-              xfer += iprot->readI64(this->definition_level_histograms[_i325]);
+              xfer += iprot->readI64(this->definition_level_histograms[_i221]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4708,10 +4708,10 @@ uint32_t ColumnIndex::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("null_pages", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_BOOL, static_cast<uint32_t>(this->null_pages.size()));
-    std::vector<bool> ::const_iterator _iter326;
-    for (_iter326 = this->null_pages.begin(); _iter326 != this->null_pages.end(); ++_iter326)
+    std::vector<bool> ::const_iterator _iter222;
+    for (_iter222 = this->null_pages.begin(); _iter222 != this->null_pages.end(); ++_iter222)
     {
-      xfer += oprot->writeBool((*_iter326));
+      xfer += oprot->writeBool((*_iter222));
     }
     xfer += oprot->writeListEnd();
   }
@@ -4720,10 +4720,10 @@ uint32_t ColumnIndex::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("min_values", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->min_values.size()));
-    std::vector<std::string> ::const_iterator _iter327;
-    for (_iter327 = this->min_values.begin(); _iter327 != this->min_values.end(); ++_iter327)
+    std::vector<std::string> ::const_iterator _iter223;
+    for (_iter223 = this->min_values.begin(); _iter223 != this->min_values.end(); ++_iter223)
     {
-      xfer += oprot->writeBinary((*_iter327));
+      xfer += oprot->writeBinary((*_iter223));
     }
     xfer += oprot->writeListEnd();
   }
@@ -4732,10 +4732,10 @@ uint32_t ColumnIndex::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("max_values", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->max_values.size()));
-    std::vector<std::string> ::const_iterator _iter328;
-    for (_iter328 = this->max_values.begin(); _iter328 != this->max_values.end(); ++_iter328)
+    std::vector<std::string> ::const_iterator _iter224;
+    for (_iter224 = this->max_values.begin(); _iter224 != this->max_values.end(); ++_iter224)
     {
-      xfer += oprot->writeBinary((*_iter328));
+      xfer += oprot->writeBinary((*_iter224));
     }
     xfer += oprot->writeListEnd();
   }
@@ -4749,10 +4749,10 @@ uint32_t ColumnIndex::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("null_counts", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->null_counts.size()));
-      std::vector<int64_t> ::const_iterator _iter329;
-      for (_iter329 = this->null_counts.begin(); _iter329 != this->null_counts.end(); ++_iter329)
+      std::vector<int64_t> ::const_iterator _iter225;
+      for (_iter225 = this->null_counts.begin(); _iter225 != this->null_counts.end(); ++_iter225)
       {
-        xfer += oprot->writeI64((*_iter329));
+        xfer += oprot->writeI64((*_iter225));
       }
       xfer += oprot->writeListEnd();
     }
@@ -4762,10 +4762,10 @@ uint32_t ColumnIndex::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("repetition_level_histograms", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->repetition_level_histograms.size()));
-      std::vector<int64_t> ::const_iterator _iter330;
-      for (_iter330 = this->repetition_level_histograms.begin(); _iter330 != this->repetition_level_histograms.end(); ++_iter330)
+      std::vector<int64_t> ::const_iterator _iter226;
+      for (_iter226 = this->repetition_level_histograms.begin(); _iter226 != this->repetition_level_histograms.end(); ++_iter226)
       {
-        xfer += oprot->writeI64((*_iter330));
+        xfer += oprot->writeI64((*_iter226));
       }
       xfer += oprot->writeListEnd();
     }
@@ -4775,10 +4775,10 @@ uint32_t ColumnIndex::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("definition_level_histograms", ::apache::thrift::protocol::T_LIST, 7);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->definition_level_histograms.size()));
-      std::vector<int64_t> ::const_iterator _iter331;
-      for (_iter331 = this->definition_level_histograms.begin(); _iter331 != this->definition_level_histograms.end(); ++_iter331)
+      std::vector<int64_t> ::const_iterator _iter227;
+      for (_iter227 = this->definition_level_histograms.begin(); _iter227 != this->definition_level_histograms.end(); ++_iter227)
       {
-        xfer += oprot->writeI64((*_iter331));
+        xfer += oprot->writeI64((*_iter227));
       }
       xfer += oprot->writeListEnd();
     }
@@ -4958,6 +4958,46 @@ uint32_t AesGcmCtrV1::write(Protocol_* oprot) const {
 }
 
 template <class Protocol_>
+uint32_t ExternalDBPAV1::read(Protocol_* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    xfer += iprot->skip(ftype);
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+template <class Protocol_>
+uint32_t ExternalDBPAV1::write(Protocol_* oprot) const {
+  uint32_t xfer = 0;
+  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("ExternalDBPAV1");
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+template <class Protocol_>
 uint32_t EncryptionAlgorithm::read(Protocol_* iprot) {
 
   ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
@@ -4995,6 +5035,14 @@ uint32_t EncryptionAlgorithm::read(Protocol_* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->EXTERNAL_DBPA_V1.read(iprot);
+          this->__isset.EXTERNAL_DBPA_V1 = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -5021,6 +5069,11 @@ uint32_t EncryptionAlgorithm::write(Protocol_* oprot) const {
   if (this->__isset.AES_GCM_CTR_V1) {
     xfer += oprot->writeFieldBegin("AES_GCM_CTR_V1", ::apache::thrift::protocol::T_STRUCT, 2);
     xfer += this->AES_GCM_CTR_V1.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.EXTERNAL_DBPA_V1) {
+    xfer += oprot->writeFieldBegin("EXTERNAL_DBPA_V1", ::apache::thrift::protocol::T_STRUCT, 3);
+    xfer += this->EXTERNAL_DBPA_V1.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
   xfer += oprot->writeFieldStop();
@@ -5066,14 +5119,14 @@ uint32_t FileMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->schema.clear();
-            uint32_t _size348;
-            ::apache::thrift::protocol::TType _etype351;
-            xfer += iprot->readListBegin(_etype351, _size348);
-            this->schema.resize(_size348);
-            uint32_t _i352;
-            for (_i352 = 0; _i352 < _size348; ++_i352)
+            uint32_t _size238;
+            ::apache::thrift::protocol::TType _etype241;
+            xfer += iprot->readListBegin(_etype241, _size238);
+            this->schema.resize(_size238);
+            uint32_t _i242;
+            for (_i242 = 0; _i242 < _size238; ++_i242)
             {
-              xfer += this->schema[_i352].read(iprot);
+              xfer += this->schema[_i242].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5094,14 +5147,14 @@ uint32_t FileMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->row_groups.clear();
-            uint32_t _size353;
-            ::apache::thrift::protocol::TType _etype356;
-            xfer += iprot->readListBegin(_etype356, _size353);
-            this->row_groups.resize(_size353);
-            uint32_t _i357;
-            for (_i357 = 0; _i357 < _size353; ++_i357)
+            uint32_t _size243;
+            ::apache::thrift::protocol::TType _etype246;
+            xfer += iprot->readListBegin(_etype246, _size243);
+            this->row_groups.resize(_size243);
+            uint32_t _i247;
+            for (_i247 = 0; _i247 < _size243; ++_i247)
             {
-              xfer += this->row_groups[_i357].read(iprot);
+              xfer += this->row_groups[_i247].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5114,14 +5167,14 @@ uint32_t FileMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->key_value_metadata.clear();
-            uint32_t _size358;
-            ::apache::thrift::protocol::TType _etype361;
-            xfer += iprot->readListBegin(_etype361, _size358);
-            this->key_value_metadata.resize(_size358);
-            uint32_t _i362;
-            for (_i362 = 0; _i362 < _size358; ++_i362)
+            uint32_t _size248;
+            ::apache::thrift::protocol::TType _etype251;
+            xfer += iprot->readListBegin(_etype251, _size248);
+            this->key_value_metadata.resize(_size248);
+            uint32_t _i252;
+            for (_i252 = 0; _i252 < _size248; ++_i252)
             {
-              xfer += this->key_value_metadata[_i362].read(iprot);
+              xfer += this->key_value_metadata[_i252].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5142,14 +5195,14 @@ uint32_t FileMetaData::read(Protocol_* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->column_orders.clear();
-            uint32_t _size363;
-            ::apache::thrift::protocol::TType _etype366;
-            xfer += iprot->readListBegin(_etype366, _size363);
-            this->column_orders.resize(_size363);
-            uint32_t _i367;
-            for (_i367 = 0; _i367 < _size363; ++_i367)
+            uint32_t _size253;
+            ::apache::thrift::protocol::TType _etype256;
+            xfer += iprot->readListBegin(_etype256, _size253);
+            this->column_orders.resize(_size253);
+            uint32_t _i257;
+            for (_i257 = 0; _i257 < _size253; ++_i257)
             {
-              xfer += this->column_orders[_i367].read(iprot);
+              xfer += this->column_orders[_i257].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5207,10 +5260,10 @@ uint32_t FileMetaData::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("schema", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->schema.size()));
-    std::vector<SchemaElement> ::const_iterator _iter368;
-    for (_iter368 = this->schema.begin(); _iter368 != this->schema.end(); ++_iter368)
+    std::vector<SchemaElement> ::const_iterator _iter258;
+    for (_iter258 = this->schema.begin(); _iter258 != this->schema.end(); ++_iter258)
     {
-      xfer += (*_iter368).write(oprot);
+      xfer += (*_iter258).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -5223,10 +5276,10 @@ uint32_t FileMetaData::write(Protocol_* oprot) const {
   xfer += oprot->writeFieldBegin("row_groups", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->row_groups.size()));
-    std::vector<RowGroup> ::const_iterator _iter369;
-    for (_iter369 = this->row_groups.begin(); _iter369 != this->row_groups.end(); ++_iter369)
+    std::vector<RowGroup> ::const_iterator _iter259;
+    for (_iter259 = this->row_groups.begin(); _iter259 != this->row_groups.end(); ++_iter259)
     {
-      xfer += (*_iter369).write(oprot);
+      xfer += (*_iter259).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -5236,10 +5289,10 @@ uint32_t FileMetaData::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("key_value_metadata", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->key_value_metadata.size()));
-      std::vector<KeyValue> ::const_iterator _iter370;
-      for (_iter370 = this->key_value_metadata.begin(); _iter370 != this->key_value_metadata.end(); ++_iter370)
+      std::vector<KeyValue> ::const_iterator _iter260;
+      for (_iter260 = this->key_value_metadata.begin(); _iter260 != this->key_value_metadata.end(); ++_iter260)
       {
-        xfer += (*_iter370).write(oprot);
+        xfer += (*_iter260).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -5254,10 +5307,10 @@ uint32_t FileMetaData::write(Protocol_* oprot) const {
     xfer += oprot->writeFieldBegin("column_orders", ::apache::thrift::protocol::T_LIST, 7);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->column_orders.size()));
-      std::vector<ColumnOrder> ::const_iterator _iter371;
-      for (_iter371 = this->column_orders.begin(); _iter371 != this->column_orders.end(); ++_iter371)
+      std::vector<ColumnOrder> ::const_iterator _iter261;
+      for (_iter261 = this->column_orders.begin(); _iter261 != this->column_orders.end(); ++_iter261)
       {
-        xfer += (*_iter371).write(oprot);
+        xfer += (*_iter261).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -61,6 +61,11 @@ class AesCryptoContext {
     length_buffer_length_ = include_length ? kBufferSizeLength : 0;
     ciphertext_size_delta_ = length_buffer_length_ + kNonceLength;
 
+    if (ParquetCipher::EXTERNAL_DBPA_V1 == alg_id) {
+      std::stringstream ss;
+      ss << "ExternalDataBatchProtectionAgent (DBPA) algorithm is not yet implemented";
+      throw ParquetException(ss.str());
+    }
     if (ParquetCipher::AES_GCM_V1 != alg_id && ParquetCipher::AES_GCM_CTR_V1 != alg_id) {
       std::stringstream ss;
       ss << "Crypto algorithm " << alg_id << " is not supported";

--- a/cpp/src/parquet/parquet.thrift
+++ b/cpp/src/parquet/parquet.thrift
@@ -1237,9 +1237,12 @@ struct AesGcmCtrV1 {
   3: optional bool supply_aad_prefix
 }
 
+struct ExternalDBPAV1 {}
+
 union EncryptionAlgorithm {
   1: AesGcmV1 AES_GCM_V1
   2: AesGcmCtrV1 AES_GCM_CTR_V1
+  3: ExternalDBPAV1 EXTERNAL_DBPA_V1
 }
 
 /**

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -241,6 +241,8 @@ static inline EncryptionAlgorithm FromThrift(format::EncryptionAlgorithm encrypt
   } else if (encryption.__isset.AES_GCM_CTR_V1) {
     encryption_algorithm.algorithm = ParquetCipher::AES_GCM_CTR_V1;
     encryption_algorithm.aad = FromThrift(encryption.AES_GCM_CTR_V1);
+  } else if (encryption.__isset.EXTERNAL_DBPA_V1) {
+    encryption_algorithm.algorithm = ParquetCipher::EXTERNAL_DBPA_V1;
   } else {
     throw ParquetException("Unsupported algorithm");
   }
@@ -382,12 +384,19 @@ static inline format::AesGcmCtrV1 ToAesGcmCtrV1Thrift(AadMetadata aad) {
   return aesGcmCtrV1;
 }
 
+static inline format::ExternalDBPAV1 ToExternalDBPAV1Thrift() {
+  format::ExternalDBPAV1 externalDBPAV1;
+  return externalDBPAV1;
+}
+
 static inline format::EncryptionAlgorithm ToThrift(EncryptionAlgorithm encryption) {
   format::EncryptionAlgorithm encryption_algorithm;
   if (encryption.algorithm == ParquetCipher::AES_GCM_V1) {
     encryption_algorithm.__set_AES_GCM_V1(ToAesGcmV1Thrift(encryption.aad));
-  } else {
+  } else if (encryption.algorithm == ParquetCipher::AES_GCM_CTR_V1) {
     encryption_algorithm.__set_AES_GCM_CTR_V1(ToAesGcmCtrV1Thrift(encryption.aad));
+  } else {
+    encryption_algorithm.__set_EXTERNAL_DBPA_V1(ToExternalDBPAV1Thrift());
   }
   return encryption_algorithm;
 }

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -518,7 +518,7 @@ PARQUET_EXPORT
 std::unique_ptr<Codec> GetCodec(Compression::type codec, int compression_level);
 
 struct ParquetCipher {
-  enum type { AES_GCM_V1 = 0, AES_GCM_CTR_V1 = 1 };
+  enum type { AES_GCM_V1 = 0, AES_GCM_CTR_V1 = 1, EXTERNAL_DBPA_V1 = 2 };
 };
 
 struct AadMetadata {

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -195,6 +195,7 @@ cdef extern from "parquet/api/schema.h" namespace "parquet" nogil:
     enum ParquetCipher" parquet::ParquetCipher::type":
         ParquetCipher_AES_GCM_V1" parquet::ParquetCipher::AES_GCM_V1"
         ParquetCipher_AES_GCM_CTR_V1" parquet::ParquetCipher::AES_GCM_CTR_V1"
+        ParquetCipher_EXTERNAL_DBPA_V1" parquet::ParquetCipher::EXTERNAL_DBPA_V1"
 
     struct AadMetadata:
         c_string aad_prefix

--- a/python/pyarrow/_parquet_encryption.pxd
+++ b/python/pyarrow/_parquet_encryption.pxd
@@ -26,7 +26,8 @@ from pyarrow._parquet cimport (ParquetCipher,
                                FileEncryptionProperties,
                                FileDecryptionProperties,
                                ParquetCipher_AES_GCM_V1,
-                               ParquetCipher_AES_GCM_CTR_V1)
+                               ParquetCipher_AES_GCM_CTR_V1,
+                               ParquetCipher_EXTERNAL_DBPA_V1)
 from pyarrow.lib cimport _Weakrefable
 
 cdef class CryptoFactory(_Weakrefable):

--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -34,6 +34,8 @@ cdef ParquetCipher cipher_from_name(name):
         return ParquetCipher_AES_GCM_V1
     elif name == 'AES_GCM_CTR_V1':
         return ParquetCipher_AES_GCM_CTR_V1
+    elif name == 'EXTERNAL_DBPA_V1':
+        return ParquetCipher_EXTERNAL_DBPA_V1
     else:
         raise ValueError(f'Invalid cipher name: {name!r}')
 
@@ -43,6 +45,8 @@ cdef cipher_to_name(ParquetCipher cipher):
         return 'AES_GCM_V1'
     elif ParquetCipher_AES_GCM_CTR_V1 == cipher:
         return 'AES_GCM_CTR_V1'
+    elif ParquetCipher_EXTERNAL_DBPA_V1 == cipher:
+        return 'EXTERNAL_DBPA_V1'
     else:
         raise ValueError('Invalid cipher value: {0}'.format(cipher))
 

--- a/python/pyarrow/includes/libparquet_encryption.pxd
+++ b/python/pyarrow/includes/libparquet_encryption.pxd
@@ -22,7 +22,8 @@ from pyarrow._parquet cimport (ParquetCipher,
                                CFileEncryptionProperties,
                                CFileDecryptionProperties,
                                ParquetCipher_AES_GCM_V1,
-                               ParquetCipher_AES_GCM_CTR_V1)
+                               ParquetCipher_AES_GCM_CTR_V1,
+                               ParquetCipher_EXTERNAL_DBPA_V1)
 
 
 cdef extern from "parquet/encryption/kms_client.h" \


### PR DESCRIPTION
Add the new enum value for the External DBPA Encryptor.

This change requires us to use thrift generated code. After modifying parquet_thrift and thrift_internal, the command needed to regenerate the code is:

cd cpp
./build-support/update-thrift.sh