### PR TITLE
Adding basic structure for both ExternalDecryptionConfig and External…

### DIFF
--- a/cpp/src/parquet/encryption/crypto_factory.h
+++ b/cpp/src/parquet/encryption/crypto_factory.h
@@ -98,7 +98,7 @@ struct PARQUET_EXPORT ColumnEncryptionAttributes {
     std::string key_id;
 };
 
-/// Encryption Configuration for use with External Encryption services. 
+/// Encryption Configuration for use with External Encryptions. 
 /// Extends the already existing EncryptionConfiguration with more context and with
 /// the capability of specifying encryption algorithm per column.
 struct PARQUET_EXPORT ExternalEncryptionConfiguration : public EncryptionConfiguration {
@@ -120,21 +120,21 @@ struct PARQUET_EXPORT ExternalEncryptionConfiguration : public EncryptionConfigu
   /// If a column name appears in both, an exception will be thrown.
   std::unordered_map<std::string, ColumnEncryptionAttributes> per_column_encryption;
 
-  /// External encryption services may use additional context provided by the application to
-  /// enforce robust access control. The values sent to the external service depend on each
+  /// External encryptors may use additional context provided by the application to
+  /// enforce robust access control. The values sent to the external encryptor depend on each
   /// implementation. 
   /// This value must be a valid JSON-formatted string.
-  /// Validation of the string will be done by the external encryption service, Arrow will only
+  /// Validation of the string will be done by the external encryptor, Arrow will only
   /// forward this value.
   /// Format: "{\"user_id\": \"abc123\", \"location\": {\"lat\": 9.7489, \"lon\": -83.7534}}"
   std::string app_context;
   
   /// Key/value map of the location of configuration files needed by the external
-  /// encryption service. This may include location of a dynamically-linked library, or the
-  /// location of a file where the external service can find urls, certificates, and parameters
-  /// needed to make a remote service call. 
+  /// encryptors. This may include location of a dynamically-linked library, or the
+  /// location of a file where the external encryptor can find urls, certificates, and parameters
+  /// needed to make a remote call. 
   /// For security, these values should never be sent in this config, only the locations of 
-  /// the files that the external service will know how to access.
+  /// the files that the external encryptor will know how to access.
   std::unordered_map<std::string, std::string> connection_config;
 };
 
@@ -146,21 +146,21 @@ struct PARQUET_EXPORT DecryptionConfiguration {
 };
 
 struct PARQUET_EXPORT ExternalDecryptionConfiguration : public DecryptionConfiguration {
-  /// External decryption services may use additional context provided by the application to
-  /// enforce robust access control. The values sent to the external service depend on each
+  /// External decryptors may use additional context provided by the application to
+  /// enforce robust access control. The values sent to the external decryptor depend on each
   /// implementation. 
   /// This value must be a valid JSON-formatted string.
-  /// Validation of the string will be done by the external decryption service, Arrow will only
+  /// Validation of the string will be done by the external decryptors, Arrow will only
   /// forward this value.
   /// Format: "{\"user_id\": \"abc123\", \"location\": {\"lat\": 9.7489, \"lon\": -83.7534}}"
   std::string app_context;
 
   /// Map of the encryption algorithms to the key/value map of the location of configuration files
-  /// needed by the external decryption service. This may include location of a dynamically-linked
-  /// library, or the location of a file where the external service can find urls, certificates,
-  /// and parameters needed to make a remote service call. 
+  /// needed by the external decryptors. This may include location of a dynamically-linked
+  /// library, or the location of a file where the external decryptor can find urls, certificates,
+  /// and parameters needed to make a remote call. 
   /// For security, these values should never be sent in this config, only the locations of 
-  /// the files that the external service will know how to access.
+  /// the files that the external decryptor will know how to access.
   std::unordered_map<ParquetCipher::type, std::unordered_map<std::string, std::string>>
       connection_config;
 };
@@ -184,8 +184,8 @@ class PARQUET_EXPORT CryptoFactory {
       const EncryptionConfiguration& encryption_config, const std::string& file_path = "",
       const std::shared_ptr<::arrow::fs::FileSystem>& file_system = NULLPTR);
 
-  /// Get the external encryption properties for a Parquet file. Used when encryption
-  /// will be provided by an external service.
+  /// Get the external encryption properties for a Parquet file. Used when an external encryptor
+  /// will be used to encrypt the file.
   std::shared_ptr<ExternalFileEncryptionProperties> GetExternalFileEncryptionProperties(
       const KmsConnectionConfig& kms_connection_config,
       const ExternalEncryptionConfiguration& external_encryption_config,

--- a/cpp/src/parquet/encryption/encryption.h
+++ b/cpp/src/parquet/encryption/encryption.h
@@ -127,8 +127,9 @@ class PARQUET_EXPORT ColumnEncryptionProperties {
     Builder* key_id(const std::string& key_id);
 
     /// Set ParquetCipher type to use.
-    /// This field is declared as optional. If the value is not set, then the ParquetCipher
-    /// declared in the FileEncryptionProperties will be used.
+    /// This field is declared as optional, present when per column encryption was used. If the
+    /// value is not set, then the ParquetCipher declared in the FileEncryptionProperties will be
+    /// used.
     Builder* parquet_cipher(ParquetCipher::type parquet_cipher);
 
     std::shared_ptr<ColumnEncryptionProperties> build() {
@@ -190,8 +191,8 @@ class PARQUET_EXPORT ColumnDecryptionProperties {
     Builder* key(const std::string& key);
 
     /// Set ParquetCipher type to use.
-    /// This field is declared as optional. If the value is not set, then the ParquetCipher
-    /// declared in the InternalFileDecryptor will be used.
+    /// This field is declared as optional, present when per column encryption was used. If the
+    /// value is not set, then the ParquetCipher declared in the InternalFileDecryptor will be used.
     Builder* parquet_cipher(ParquetCipher::type parquet_cipher);
 
     std::shared_ptr<ColumnDecryptionProperties> build();

--- a/cpp/src/parquet/encryption/properties_test.cc
+++ b/cpp/src/parquet/encryption/properties_test.cc
@@ -68,6 +68,26 @@ TEST(TestColumnEncryptionProperties, ColumnParquetCipherSpecified) {
   ASSERT_EQ(ParquetCipher::AES_GCM_CTR_V1, properties->parquet_cipher().value());
 }
 
+TEST(TestColumnDecryptionProperties, ColumnParquetCipherNotSpecified) {
+  std::string column_path = "column_path";
+  ColumnDecryptionProperties::Builder column_builder(column_path);
+  std::shared_ptr<ColumnDecryptionProperties> properties = column_builder.build();
+
+  ASSERT_EQ(column_path, properties->column_path());
+  ASSERT_EQ(false, properties->parquet_cipher().has_value());
+}
+
+TEST(TestColumnDecryptionProperties, ColumnParquetCipherSpecified) {
+  std::string column_path = "column_path";
+  ColumnDecryptionProperties::Builder column_builder(column_path);
+  column_builder.parquet_cipher(ParquetCipher::AES_GCM_CTR_V1);
+  std::shared_ptr<ColumnDecryptionProperties> properties = column_builder.build();
+
+  ASSERT_EQ(column_path, properties->column_path());
+  ASSERT_EQ(true, properties->parquet_cipher().has_value());
+  ASSERT_EQ(ParquetCipher::AES_GCM_CTR_V1, properties->parquet_cipher().value());
+}
+
 // Encrypt all columns and the footer with the same key.
 // (uniform encryption)
 TEST(TestEncryptionProperties, UniformEncryption) {


### PR DESCRIPTION
Add the basic structs and classes for ExternalDecryptionConfig and ExternalFileDecryptionProperties.

Following definitions in [Internal Config and Properties doc](https://docs.google.com/document/d/1Tjb45rQ2x9FydFmFIRo-U6PNJnEQ5_CfdCC4EU8M6D0/edit?tab=t.0).

Also adding the ParquetCipher::type to the ColumnDecryptionProperties.

This change is analogous to the work already done for EncryptionConfig and FileProperties. 

Leaving unit testing of the new structs for the next PR when the changes to the CryptoFactory are made.
