### PR TITLE
Adding the new encryptor and decryptor interfaces

### DIFF
--- a/cpp/src/parquet/encryption/decryptor_interface.h
+++ b/cpp/src/parquet/encryption/decryptor_interface.h
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "parquet/platform.h"
+
+namespace parquet::encryption {
+
+class PARQUET_EXPORT DecryptorInterface {
+ public:
+  virtual ~DecryptorInterface() = default;
+
+  /// Calculate the size of the plaintext for a given ciphertext length.
+  [[nodiscard]] virtual int32_t PlaintextLength(int32_t ciphertext_len) const = 0;
+
+  /// Calculate the size of the ciphertext for a given plaintext length.
+  [[nodiscard]] virtual int32_t CiphertextLength(int32_t plaintext_len) const = 0;
+
+  /// Decrypt the ciphertext and leave the results in the plaintext buffer.
+  virtual int32_t Decrypt(::arrow::util::span<const uint8_t> ciphertext,
+                          ::arrow::util::span<uint8_t> plaintext) = 0;
+};
+
+}  // namespace parquet::encryption

--- a/cpp/src/parquet/encryption/encryptor_interface.h
+++ b/cpp/src/parquet/encryption/encryptor_interface.h
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "parquet/platform.h"
+
+namespace parquet::encryption {
+
+class PARQUET_EXPORT EncryptorInterface {
+ public:
+  virtual ~EncryptorInterface() = default;
+
+  /// Calculate the size of the ciphertext for a given plaintext length.
+  [[nodiscard]]virtual int32_t CiphertextLength(int64_t plaintext_len) const = 0;
+
+  /// Encrypt the plaintext and leave the results in the ciphertext buffer.
+  virtual int32_t Encrypt(::arrow::util::span<const uint8_t> plaintext,
+                          ::arrow::util::span<uint8_t> ciphertext) = 0;
+
+  /// Encrypt footer metadata for signature verification purposes only.
+  /// This method is used specifically for footer signature verification in encrypted
+  /// Parquet files with plaintext footers. It encrypts the footer metadata using
+  /// the provided key, AAD, and nonce to generate an authentication tag that can
+  /// be compared against a stored signature.
+  virtual int32_t SignedFooterEncrypt(::arrow::util::span<const uint8_t> footer,
+                                      ::arrow::util::span<const uint8_t> key,
+                                      ::arrow::util::span<const uint8_t> aad,
+                                      ::arrow::util::span<const uint8_t> nonce,
+                                      ::arrow::util::span<uint8_t> encrypted_footer) = 0;
+};
+
+}  // namespace parquet::encryption


### PR DESCRIPTION
Adding the basic Encryptor and Decryptor interfaces.

These are intended to abstract away the Aes version of the encryptors and decryptors so user can choose other types to use.