### PR TITLE
Exposing column information at encryptor and decryptor creation time

### DIFF
--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -20,9 +20,8 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <vector>
 
-#include "parquet/schema.h"
+#include "parquet/metadata.h"
 
 namespace parquet {
 
@@ -96,8 +95,10 @@ class InternalFileDecryptor {
   // Get a Decryptor instance for column chunk data.
   std::unique_ptr<Decryptor> GetColumnDataDecryptor(
       const std::string& column_path, const std::string& column_key_metadata,
-      const std::string& aad = "") {
-    return GetColumnDecryptor(column_path, column_key_metadata, aad, /*metadata=*/false);
+      const std::string& aad = "",
+      const ColumnChunkMetaData* column_chunk_metadata = nullptr) {
+    return GetColumnDecryptor(
+      column_path, column_key_metadata, aad, /*metadata=*/false, column_chunk_metadata);
   }
 
   // Get a Decryptor factory for column chunk metadata.
@@ -106,7 +107,7 @@ class InternalFileDecryptor {
   // This is a static function as it accepts a null `InternalFileDecryptor*`
   // argument if the column is not encrypted.
   static std::function<std::unique_ptr<Decryptor>()> GetColumnMetaDecryptorFactory(
-      InternalFileDecryptor*, const ColumnCryptoMetaData* crypto_metadata,
+      InternalFileDecryptor* file_decryptor, const ColumnCryptoMetaData* crypto_metadata,
       const std::string& aad = "");
   // Get a Decryptor factory for column chunk data.
   //
@@ -114,7 +115,8 @@ class InternalFileDecryptor {
   // This is a static function as it accepts a null `InternalFileDecryptor*`
   // argument if the column is not encrypted.
   static std::function<std::unique_ptr<Decryptor>()> GetColumnDataDecryptorFactory(
-      InternalFileDecryptor*, const ColumnCryptoMetaData* crypto_metadata,
+      InternalFileDecryptor* file_decryptor, const ColumnCryptoMetaData* crypto_metadata,
+      const ColumnChunkMetaData* column_chunk_metadata,
       const std::string& aad = "");
 
  private:
@@ -134,12 +136,14 @@ class InternalFileDecryptor {
 
   std::unique_ptr<Decryptor> GetFooterDecryptor(const std::string& aad, bool metadata);
 
-  std::unique_ptr<Decryptor> GetColumnDecryptor(const std::string& column_path,
-                                                const std::string& column_key_metadata,
-                                                const std::string& aad, bool metadata);
+  std::unique_ptr<Decryptor> GetColumnDecryptor(
+    const std::string& column_path, const std::string& column_key_metadata,
+    const std::string& aad, bool metadata,
+    const ColumnChunkMetaData* column_chunk_metadata = nullptr);
 
   std::function<std::unique_ptr<Decryptor>()> GetColumnDecryptorFactory(
-      const ColumnCryptoMetaData* crypto_metadata, const std::string& aad, bool metadata);
+      const ColumnCryptoMetaData* crypto_metadata, const std::string& aad, bool metadata,
+      const ColumnChunkMetaData* column_chunk_metadata = nullptr);
 };
 
 void UpdateDecryptor(Decryptor* decryptor, int16_t row_group_ordinal,

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -95,8 +95,8 @@ class InternalFileDecryptor {
   // Get a Decryptor instance for column chunk data.
   std::unique_ptr<Decryptor> GetColumnDataDecryptor(
       const std::string& column_path, const std::string& column_key_metadata,
-      const std::string& aad = "",
-      const ColumnChunkMetaData* column_chunk_metadata = nullptr) {
+      const ColumnChunkMetaData* column_chunk_metadata = nullptr,
+      const std::string& aad = "") {
     return GetColumnDecryptor(
       column_path, column_key_metadata, aad, /*metadata=*/false, column_chunk_metadata);
   }
@@ -116,7 +116,7 @@ class InternalFileDecryptor {
   // argument if the column is not encrypted.
   static std::function<std::unique_ptr<Decryptor>()> GetColumnDataDecryptorFactory(
       InternalFileDecryptor* file_decryptor, const ColumnCryptoMetaData* crypto_metadata,
-      const ColumnChunkMetaData* column_chunk_metadata,
+      const ColumnChunkMetaData* column_chunk_metadata = nullptr,
       const std::string& aad = "");
 
  private:

--- a/cpp/src/parquet/encryption/internal_file_encryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.cc
@@ -75,17 +75,18 @@ std::shared_ptr<Encryptor> InternalFileEncryptor::GetFooterSigningEncryptor() {
 
 std::shared_ptr<Encryptor> InternalFileEncryptor::GetColumnMetaEncryptor(
     const std::string& column_path) {
-  return GetColumnEncryptor(column_path, true);
+  return GetColumnEncryptor(column_path, true, nullptr);
 }
 
 std::shared_ptr<Encryptor> InternalFileEncryptor::GetColumnDataEncryptor(
-    const std::string& column_path) {
-  return GetColumnEncryptor(column_path, false);
+    const std::string& column_path, const ColumnChunkMetaDataBuilder* column_chunk_metadata) {
+  return GetColumnEncryptor(column_path, false, column_chunk_metadata);
 }
 
 std::shared_ptr<Encryptor>
 InternalFileEncryptor::InternalFileEncryptor::GetColumnEncryptor(
-    const std::string& column_path, bool metadata) {
+    const std::string& column_path, bool metadata,
+    const ColumnChunkMetaDataBuilder* column_chunk_metadata) {
   // first look if we already got the encryptor from before
   if (metadata) {
     if (column_metadata_map_.find(column_path) != column_metadata_map_.end()) {
@@ -110,7 +111,7 @@ InternalFileEncryptor::InternalFileEncryptor::GetColumnEncryptor(
 
   ParquetCipher::type algorithm = properties_->algorithm().algorithm;
   auto aes_encryptor = metadata ? GetMetaAesEncryptor(algorithm, key.size())
-                                : GetDataAesEncryptor(algorithm, key.size());
+                                : GetDataAesEncryptor(algorithm, key.size(), column_chunk_metadata);
 
   std::string file_aad = properties_->file_aad();
   std::shared_ptr<Encryptor> encryptor =
@@ -144,7 +145,8 @@ encryption::AesEncryptor* InternalFileEncryptor::GetMetaAesEncryptor(
 }
 
 encryption::AesEncryptor* InternalFileEncryptor::GetDataAesEncryptor(
-    ParquetCipher::type algorithm, size_t key_size) {
+    ParquetCipher::type algorithm, size_t key_size,
+    const ColumnChunkMetaDataBuilder* column_chunk_metadata) {
   auto key_len = static_cast<int32_t>(key_size);
   int index = MapKeyLenToEncryptorArrayIndex(key_len);
   if (data_encryptor_[index] == nullptr) {

--- a/cpp/src/parquet/encryption/internal_file_encryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.cc
@@ -75,7 +75,7 @@ std::shared_ptr<Encryptor> InternalFileEncryptor::GetFooterSigningEncryptor() {
 
 std::shared_ptr<Encryptor> InternalFileEncryptor::GetColumnMetaEncryptor(
     const std::string& column_path) {
-  return GetColumnEncryptor(column_path, true, nullptr);
+  return GetColumnEncryptor(column_path, true);
 }
 
 std::shared_ptr<Encryptor> InternalFileEncryptor::GetColumnDataEncryptor(

--- a/cpp/src/parquet/encryption/internal_file_encryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.h
@@ -20,10 +20,9 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "parquet/encryption/encryption.h"
-#include "parquet/schema.h"
+#include "parquet/metadata.h"
 
 namespace parquet {
 
@@ -76,7 +75,9 @@ class InternalFileEncryptor {
   std::shared_ptr<Encryptor> GetFooterEncryptor();
   std::shared_ptr<Encryptor> GetFooterSigningEncryptor();
   std::shared_ptr<Encryptor> GetColumnMetaEncryptor(const std::string& column_path);
-  std::shared_ptr<Encryptor> GetColumnDataEncryptor(const std::string& column_path);
+  std::shared_ptr<Encryptor> GetColumnDataEncryptor(
+    const std::string& column_path,
+    const ColumnChunkMetaDataBuilder* column_chunk_metadata = nullptr);
 
  private:
   FileEncryptionProperties* properties_;
@@ -94,13 +95,15 @@ class InternalFileEncryptor {
 
   ::arrow::MemoryPool* pool_;
 
-  std::shared_ptr<Encryptor> GetColumnEncryptor(const std::string& column_path,
-                                                bool metadata);
+  std::shared_ptr<Encryptor> GetColumnEncryptor(
+    const std::string& column_path, bool metadata,
+    const ColumnChunkMetaDataBuilder* column_chunk_metadata = nullptr);
 
   encryption::AesEncryptor* GetMetaAesEncryptor(ParquetCipher::type algorithm,
                                                 size_t key_len);
-  encryption::AesEncryptor* GetDataAesEncryptor(ParquetCipher::type algorithm,
-                                                size_t key_len);
+  encryption::AesEncryptor* GetDataAesEncryptor(
+    ParquetCipher::type algorithm, size_t key_len,
+    const ColumnChunkMetaDataBuilder* column_chunk_metadata = nullptr);
 
   int MapKeyLenToEncryptorArrayIndex(int32_t key_len) const;
 };

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -263,7 +263,7 @@ class SerializedRowGroup : public RowGroupReader::Contents {
     auto meta_decryptor_factory = InternalFileDecryptor::GetColumnMetaDecryptorFactory(
         file_decryptor, crypto_metadata.get());
     auto data_decryptor_factory = InternalFileDecryptor::GetColumnDataDecryptorFactory(
-        file_decryptor, crypto_metadata.get());
+        file_decryptor, crypto_metadata.get(), col.get());
 
     constexpr auto kEncryptedOrdinalLimit = 32767;
     if (ARROW_PREDICT_FALSE(row_group_ordinal_ > kEncryptedOrdinalLimit)) {

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -271,7 +271,7 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
         file_encryptor_ ? file_encryptor_->GetColumnMetaEncryptor(path->ToDotString())
                         : nullptr;
     auto data_encryptor =
-        file_encryptor_ ? file_encryptor_->GetColumnDataEncryptor(path->ToDotString())
+        file_encryptor_ ? file_encryptor_->GetColumnDataEncryptor(path->ToDotString(), col_meta)
                         : nullptr;
     auto ci_builder = page_index_builder_ && column_properties.page_index_enabled()
                           ? page_index_builder_->GetColumnIndexBuilder(column_ordinal)

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -318,6 +318,10 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
     return LoadEnumSafe(&column_metadata_->codec);
   }
 
+  const ColumnDescriptor* descr() const { return descr_; }
+
+  const ReaderProperties* properties() const { return &properties_; }
+
   const std::vector<Encoding::type>& encodings() const { return encodings_; }
 
   const std::vector<PageEncodingStats>& encoding_stats() const { return encoding_stats_; }
@@ -479,6 +483,10 @@ int64_t ColumnChunkMetaData::index_page_offset() const {
 Compression::type ColumnChunkMetaData::compression() const {
   return impl_->compression();
 }
+
+const ColumnDescriptor* ColumnChunkMetaData::descr() const { return impl_->descr(); }
+
+const ReaderProperties* ColumnChunkMetaData::properties() const { return impl_->properties(); }
 
 bool ColumnChunkMetaData::can_decompress() const {
   return ::arrow::util::Codec::IsAvailable(compression());
@@ -1546,6 +1554,8 @@ class ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilderImpl {
 
   const void* contents() const { return column_chunk_; }
 
+  const WriterProperties* properties() const { return properties_.get(); }
+
   // column chunk
   void set_file_path(const std::string& val) { column_chunk_->__set_file_path(val); }
 
@@ -1761,6 +1771,10 @@ void ColumnChunkMetaDataBuilder::WriteTo(::arrow::io::OutputStream* sink) {
 
 const ColumnDescriptor* ColumnChunkMetaDataBuilder::descr() const {
   return impl_->descr();
+}
+
+const WriterProperties* ColumnChunkMetaDataBuilder::properties() const {
+  return impl_->properties();
 }
 
 void ColumnChunkMetaDataBuilder::SetStatistics(const EncodedStatistics& result) {

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -144,6 +144,12 @@ class PARQUET_EXPORT ColumnChunkMetaData {
   std::shared_ptr<Statistics> statistics() const;
   std::shared_ptr<SizeStatistics> size_statistics() const;
 
+  // get the column descriptor
+  const ColumnDescriptor* descr() const;
+
+  // get the reader properties
+  const ReaderProperties* properties() const;
+
   Compression::type compression() const;
   // Indicate if the ColumnChunk compression is supported by the current
   // compiled parquet library.
@@ -444,6 +450,9 @@ class PARQUET_EXPORT ColumnChunkMetaDataBuilder {
 
   // get the column descriptor
   const ColumnDescriptor* descr() const;
+
+  // get the writer properties
+  const WriterProperties* properties() const;
 
   int64_t total_compressed_size() const;
   // commit the metadata


### PR DESCRIPTION
Expose column information at encryptor and decryptor creation time.

When writing, the ColumnChunkMetaDataBuilder contains information to the column's type, compression, encoding, and format. It also contains a pointer to the WriterProperties, where the ExternalFileEncryptionProperties are found.

At read time, the ColumnChunkMetaData is analogous, and containing a pointer to the ReaderProperties, where the ExternalFileDecryptionProperties are found.

No logic changed here, so no tests are modified. Assigning nullptr as default values so nothing is broken.