### PR TITLE
Adding latest DBPAInterface to dev-miniapp

### DIFF
--- a/cpp/src/parquet/encryption/external/dbpa_interface.h
+++ b/cpp/src/parquet/encryption/external/dbpa_interface.h
@@ -2,31 +2,109 @@
 
 #pragma once
 
+#include <cstdint>
+#include <cstddef>
+#include <map>
 #include <memory>
-#include "parquet/platform.h"
-#include "arrow/util/span.h"
+#include <string>
+#include <utility>
+#include "span.hpp"
+#include "enums.h"
 
-using ::arrow::util::span;
+#ifndef DBPS_EXPORT
+#define DBPS_EXPORT
+#endif
 
-namespace parquet::encryption::external {
+// TODO: this file was copied from
+// https://github.com/protegrity/DataBatchProtectionService
+// we need to find a better way to share it between repos.
 
-    //TODO: this will change once we have a solid defition of interfaces 
+namespace dbps::external {
 
-    class EncryptionResult {
-    };
+using tcb::span;
 
-    class DecryptionResult {
-    };
+/*
+ * DataBatchProtectionAgentInterface, EncryptionResult and DecryptionResult implementation contracts:
+ * - While handle to EncryptionResult/DecryptionResult exists, ciphertext()/plaintext() is guaranteed to return valid data
+ * - Read operations are not destructive. Multiple calls return the same data
+ * - Destructor must dispose of internal memory (either by delegation or cleanup)
+ * - No throwing exceptions. Errors reported via success() flag and error methods.
+ * - Library users must check size() to ensure the actual size of the returned payload.
+ */
 
-    class PARQUET_EXPORT DataBatchProtectionAgentInterface {
-        public:
-         virtual std::unique_ptr<EncryptionResult> Encrypt(
-            span<const uint8_t> plaintext, 
-            span<uint8_t> ciphertext) = 0;
+class DBPS_EXPORT EncryptionResult {
+public:
+    virtual span<const uint8_t> ciphertext() const = 0;
 
-        virtual std::unique_ptr<DecryptionResult> Decrypt(
-            span<const uint8_t> ciphertext) = 0;
+    // Allows a larger backing buffer than the exact ciphertext size.
+    // Library users must check size() to ensure the actual size of the returned payload.
+    virtual std::size_t size() const = 0;
 
-        virtual ~DataBatchProtectionAgentInterface() = default;
-    };
+    // Success flag; false indicates an error.
+    virtual bool success() const = 0;
+
+    // Error details (valid when success() == false).
+    virtual const std::string& error_message() const = 0;
+    virtual const std::map<std::string, std::string>& error_fields() const = 0;
+
+    virtual ~EncryptionResult() = default;
+};
+
+class DBPS_EXPORT DecryptionResult {
+public:
+    virtual span<const uint8_t> plaintext() const = 0;
+
+    // Allows a larger backing buffer than the exact plaintext size.
+    // Library users must check size() to ensure the actual size of the returned payload.
+    virtual std::size_t size() const = 0;
+
+    // Success flag; false indicates an error.
+    virtual bool success() const = 0;
+
+    // Error details (valid when success() == false).
+    virtual const std::string& error_message() const = 0;
+    virtual const std::map<std::string, std::string>& error_fields() const = 0;
+
+    virtual ~DecryptionResult() = default;
+};
+
+class DBPS_EXPORT DataBatchProtectionAgentInterface {
+public:
+    DataBatchProtectionAgentInterface() = default;
+
+    // user_id is not stored as a member; it is expected to be embedded into app_context
+    // (e.g., as a serialized map/JSON field).
+    virtual void init(
+        std::string column_name,
+        std::map<std::string, std::string> connection_config,
+        std::string app_context,
+        std::string column_key_id,
+        Type::type data_type,
+        CompressionCodec::type compression_type)
+    {
+        column_name_ = std::move(column_name);
+        connection_config_ = std::move(connection_config);
+        app_context_ = std::move(app_context);
+        column_key_id_ = std::move(column_key_id);
+        data_type_ = data_type;
+        compression_type_ = compression_type;
+    }
+
+    virtual std::unique_ptr<EncryptionResult> Encrypt(
+        span<const uint8_t> plaintext) = 0;
+
+    virtual std::unique_ptr<DecryptionResult> Decrypt(
+        span<const uint8_t> ciphertext) = 0;
+
+    virtual ~DataBatchProtectionAgentInterface() = default;
+
+private:
+    std::string column_name_;
+    std::map<std::string, std::string> connection_config_;
+    std::string app_context_;  // includes user_id
+
+    std::string column_key_id_;
+    Type::type data_type_;
+    CompressionCodec::type compression_type_;
+};
 }

--- a/cpp/src/parquet/encryption/external/dbpa_library_wrapper.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_library_wrapper.cc
@@ -2,16 +2,13 @@
 
 #include "parquet/encryption/external/dbpa_library_wrapper.h"
 #include "parquet/encryption/external/dbpa_interface.h"
-#include "arrow/util/span.h"
-#include <dlfcn.h>
+
 #include <stdexcept>
 #include <functional>
 
 #include <iostream>
 
 #include "arrow/util/io_util.h"
-
-using ::arrow::util::span;
 
 namespace parquet::encryption::external {
 
@@ -61,4 +58,4 @@ DBPALibraryWrapper::~DBPALibraryWrapper() {
   handle_closing_fn_(library_handle_);
   library_handle_ = nullptr;
 } //DBPALibraryWrapper::~DBPALibraryWrapper()
-}  // namespace parquet::encryption::external 
+}  // namespace parquet::encryption::external

--- a/cpp/src/parquet/encryption/external/dbpa_library_wrapper.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_library_wrapper.cc
@@ -60,21 +60,5 @@ DBPALibraryWrapper::~DBPALibraryWrapper() {
   // Now we can close the shared library using the provided function
   handle_closing_fn_(library_handle_);
   library_handle_ = nullptr;
-}
-
-// Decorator implementation of Encrypt method
-std::unique_ptr<EncryptionResult> DBPALibraryWrapper::Encrypt(
-    span<const uint8_t> plaintext,
-    span<uint8_t> ciphertext) {
-  
-  return wrapped_agent_->Encrypt(plaintext, ciphertext);
-}
-
-// Decorator implementation of Decrypt method
-std::unique_ptr<DecryptionResult> DBPALibraryWrapper::Decrypt(
-    span<const uint8_t> ciphertext) {
-  
-    return wrapped_agent_->Decrypt(ciphertext);
-}
-
+} //DBPALibraryWrapper::~DBPALibraryWrapper()
 }  // namespace parquet::encryption::external 

--- a/cpp/src/parquet/encryption/external/dbpa_library_wrapper.h
+++ b/cpp/src/parquet/encryption/external/dbpa_library_wrapper.h
@@ -19,7 +19,7 @@ void DefaultSharedLibraryClosingFn(void* library_handle);
 
 // Decorator/Wrapper class for the DataBatchProtectionAgentInterface
 // Its main purpose is to close the shared library when Arrow is about to destroy 
-// an intance of an DPBAgent
+// an instance of an DBPAgent
 //
 // In the constructor we allow to pass a function that will be used to close the shared library.
 // This simplifies testing, as we can use a mock function to avoid actually closing the shared library.
@@ -46,14 +46,18 @@ class DBPALibraryWrapper : public DataBatchProtectionAgentInterface {
   // (such as a segfault).
   ~DBPALibraryWrapper() override;
 
-  // Decorator implementation of Encrypt method
-  std::unique_ptr<EncryptionResult> Encrypt(
+  // Decorator implementation of Encrypt method - inlined for performance
+  inline std::unique_ptr<EncryptionResult> Encrypt(
       span<const uint8_t> plaintext,
-      span<uint8_t> ciphertext) override;
+      span<uint8_t> ciphertext) override {
+    return wrapped_agent_->Encrypt(plaintext, ciphertext);
+  }
 
-  // Decorator implementation of Decrypt method
-  std::unique_ptr<DecryptionResult> Decrypt(
-      span<const uint8_t> ciphertext) override;
+  // Decorator implementation of Decrypt method - inlined for performance
+  inline std::unique_ptr<DecryptionResult> Decrypt(
+      span<const uint8_t> ciphertext) override {
+    return wrapped_agent_->Decrypt(ciphertext);
+  }
 };
 
 }  // namespace parquet::encryption::external 

--- a/cpp/src/parquet/encryption/external/dbpa_library_wrapper_test.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_library_wrapper_test.cc
@@ -85,9 +85,9 @@ class DestructionOrderTracker {
 }; //DestructionOrderTracker
 
 // Companion object to hold mock state that persists after mock instance destruction
-class MockCompanionDPBA {
+class MockCompanionDBPA {
  public:
-  MockCompanionDPBA(std::shared_ptr<DestructionOrderTracker> order_tracker = nullptr) 
+  MockCompanionDBPA(std::shared_ptr<DestructionOrderTracker> order_tracker = nullptr) 
       : encrypt_called_(false), 
         decrypt_called_(false),
         destructor_called_(false),
@@ -131,7 +131,7 @@ class MockCompanionDPBA {
   std::vector<uint8_t> decrypt_ciphertext_;
   size_t encrypt_ciphertext_size_;
   std::shared_ptr<DestructionOrderTracker> order_tracker_;
-}; //MockCompanionDPBA
+}; //MockCompanionDBPA
 
 // Companion object to track shared library handle management operations
 class SharedLibHandleManagementCompanion {
@@ -174,8 +174,8 @@ class SharedLibHandleManagementCompanion {
 // Mock implementation of DataBatchProtectionAgentInterface for testing delegation
 class MockDataBatchProtectionAgent : public DataBatchProtectionAgentInterface {
  public:
-  explicit MockDataBatchProtectionAgent(std::shared_ptr<MockCompanionDPBA> companion = nullptr) 
-      : companion_(companion ? companion : std::make_shared<MockCompanionDPBA>()) {}
+  explicit MockDataBatchProtectionAgent(std::shared_ptr<MockCompanionDBPA> companion = nullptr) 
+      : companion_(companion ? companion : std::make_shared<MockCompanionDBPA>()) {}
   
   ~MockDataBatchProtectionAgent() override {
     companion_->SetDestructorCalled(true);
@@ -207,10 +207,10 @@ class MockDataBatchProtectionAgent : public DataBatchProtectionAgentInterface {
   }
 
   // Getter for the companion object
-  std::shared_ptr<MockCompanionDPBA> GetCompanion() const { return companion_; }
+  std::shared_ptr<MockCompanionDBPA> GetCompanion() const { return companion_; }
 
  private:
-  std::shared_ptr<MockCompanionDPBA> companion_;
+  std::shared_ptr<MockCompanionDBPA> companion_;
 };
 
 // Test fixture for DBPALibraryWrapper tests
@@ -225,7 +225,7 @@ class DBPALibraryWrapperTest : public ::testing::Test {
     destruction_order_tracker_ = std::make_shared<DestructionOrderTracker>();
     
     // Create companion objects with shared order tracker
-    mock_companion_ = std::make_shared<MockCompanionDPBA>(destruction_order_tracker_);
+    mock_companion_ = std::make_shared<MockCompanionDBPA>(destruction_order_tracker_);
     handle_companion_ = std::make_shared<SharedLibHandleManagementCompanion>(destruction_order_tracker_);
     
     // Create mock agent
@@ -265,7 +265,7 @@ class DBPALibraryWrapperTest : public ::testing::Test {
   std::string test_plaintext_;
   std::vector<uint8_t> test_ciphertext_;
   std::shared_ptr<DestructionOrderTracker> destruction_order_tracker_;
-  std::shared_ptr<MockCompanionDPBA> mock_companion_;
+  std::shared_ptr<MockCompanionDBPA> mock_companion_;
   std::shared_ptr<SharedLibHandleManagementCompanion> handle_companion_;
   std::unique_ptr<MockDataBatchProtectionAgent> mock_agent_;
   MockDataBatchProtectionAgent* mock_agent_ptr_;
@@ -609,7 +609,7 @@ TEST_F(DBPALibraryWrapperTest, DestructorOrderVerification) {
   destruction_order_tracker_->Clear();
   
   // Create a custom mock agent that tracks destruction order
-  auto custom_companion = std::make_shared<MockCompanionDPBA>(destruction_order_tracker_);
+      auto custom_companion = std::make_shared<MockCompanionDBPA>(destruction_order_tracker_);
   auto custom_agent = std::make_unique<MockDataBatchProtectionAgent>(custom_companion);
   
   void* dummy_handle = reinterpret_cast<void*>(0x12345678);

--- a/cpp/src/parquet/encryption/external/dbpa_test_agent.h
+++ b/cpp/src/parquet/encryption/external/dbpa_test_agent.h
@@ -5,35 +5,43 @@
 #include <memory>
 #include <string>
 
-#include "parquet/platform.h"
 #include "parquet/encryption/external/dbpa_interface.h"
+#include "span.hpp"
+
+using tcb::span;
+
+using dbps::external::DataBatchProtectionAgentInterface;
+using dbps::external::EncryptionResult;
+using dbps::external::DecryptionResult;
+using dbps::external::Type;
+using dbps::external::CompressionCodec;
 
 namespace parquet::encryption::external {
 
 // Implementation of the DataBatchProtectionAgentInterface for testing purposes.
-// It is not used in production.
-class PARQUET_EXPORT DBPATestAgent : public DataBatchProtectionAgentInterface {
+// It is used to test library wrapper/loading code.
+// Will never be used in production.
+class DBPATestAgent : public DataBatchProtectionAgentInterface {
  public:
   explicit DBPATestAgent();
 
-  void init(std::string agent_name, 
-            std::string configuration,
-            bool enable_logging = true);
+  void init(
+      std::string column_name,
+      std::map<std::string, std::string> connection_config,
+      std::string app_context,
+      std::string column_key_id,
+      Type::type data_type,
+      CompressionCodec::type compression_type) override {
+    // init() intentionally left blank
+  }
 
   std::unique_ptr<EncryptionResult> Encrypt(
-      span<const uint8_t> plaintext, 
-      span<uint8_t> ciphertext) override;
+      span<const uint8_t> plaintext) override;
 
   std::unique_ptr<DecryptionResult> Decrypt(
       span<const uint8_t> ciphertext) override;
 
   ~DBPATestAgent();
-
- private:
-  std::string agent_name_;
-  std::string configuration_;
-  bool enable_logging_;
-  bool is_initialized_;
 };
 
 }  // namespace parquet::encryption::external 

--- a/cpp/src/parquet/encryption/external/enums.h
+++ b/cpp/src/parquet/encryption/external/enums.h
@@ -1,0 +1,57 @@
+//TODO: figure out the licensing.
+
+#pragma once
+
+// TODO: this file was copied from
+// https://github.com/protegrity/DataBatchProtectionService
+// we need to find a better way to share it between repos.
+
+namespace dbps::external {
+
+// Captures the data type of the data batch elements.
+// Intentionally similar to parquet::Type to ease mapping and for compatibility with a known enum.
+struct Type {
+    enum type {
+        BOOLEAN = 0,
+        INT32 = 1,
+        INT64 = 2,
+        INT96 = 3,
+        FLOAT = 4,
+        DOUBLE = 5,
+        BYTE_ARRAY = 6,
+        FIXED_LEN_BYTE_ARRAY = 7
+    };
+};
+
+// Intentionally similar to arrow::CompressionCodec
+struct CompressionCodec {
+    enum type {
+        UNCOMPRESSED = 0,
+        SNAPPY = 1,
+        GZIP = 2,
+        LZO = 3,
+        BROTLI = 4,
+        LZ4 = 5,
+        ZSTD = 6,
+        LZ4_RAW = 7
+    };
+};
+
+// Format for data values
+struct Format {
+    enum type {
+        JSON = 0,
+        CSV = 1,
+        RAW_C_DATA = 2
+    };
+};
+
+// Encoding applied to the data when serialized to send over the wire
+struct Encoding {
+    enum type {
+        UTF8 = 0,
+        BASE64 = 1
+    };
+};
+
+}

--- a/cpp/src/parquet/encryption/external/loadable_encryptor_utils.cc
+++ b/cpp/src/parquet/encryption/external/loadable_encryptor_utils.cc
@@ -4,7 +4,6 @@
 #include "parquet/encryption/external/dbpa_interface.h"
 #include "parquet/encryption/external/dbpa_library_wrapper.h"
 
-#include "arrow/util/span.h"
 #include "arrow/util/io_util.h" //utils for loading shared libraries
 #include "arrow/result.h"
 
@@ -13,7 +12,6 @@
 #include <string>
 #include <memory>
 
-using ::arrow::util::span;
 using ::arrow::Result;
 
 namespace parquet::encryption::external {

--- a/cpp/src/parquet/encryption/external/loadable_encryptor_utils.cc
+++ b/cpp/src/parquet/encryption/external/loadable_encryptor_utils.cc
@@ -34,7 +34,7 @@ std::unique_ptr<DataBatchProtectionAgentInterface> CreateInstance(void* library_
   //create_instance_fn is a function pointer to the create_new_instance function in the shared library.
   create_encryptor_t create_instance_fn = reinterpret_cast<create_encryptor_t>(symbol_result.ValueOrDie());
 
-  //at this point, we have the create_instance function pointer (from the shared library)
+  // at this point, we have the create_instance function pointer (from the shared library)
   // so we can create a new instance of the DataBatchProtectionAgentInterface
   DataBatchProtectionAgentInterface* instance = create_instance_fn();
 
@@ -51,6 +51,7 @@ std::unique_ptr<DataBatchProtectionAgentInterface> CreateInstance(void* library_
 
 
 std::unique_ptr<DataBatchProtectionAgentInterface> LoadableEncryptorUtils::LoadFromLibrary(const std::string& library_path) {
+  //TODO: remove this.
   std::cout << "Inside LoadableEncryptorUtils::LoadFromLibrary" << std::endl;
 
   if (library_path.empty()) {

--- a/cpp/src/parquet/encryption/external/loadable_encryptor_utils.h
+++ b/cpp/src/parquet/encryption/external/loadable_encryptor_utils.h
@@ -8,6 +8,8 @@
 #include "parquet/platform.h"
 #include "parquet/encryption/external/dbpa_interface.h"
 
+using dbps::external::DataBatchProtectionAgentInterface;
+
 namespace parquet::encryption::external {
 
 class PARQUET_EXPORT LoadableEncryptorUtils {

--- a/cpp/src/parquet/encryption/external/loadable_encryptor_utils_test.cc
+++ b/cpp/src/parquet/encryption/external/loadable_encryptor_utils_test.cc
@@ -21,8 +21,6 @@
 #include <windows.h>
 #endif
 
-using ::arrow::util::span;
-
 namespace parquet::encryption::external::test {
 
 // Test fixture for LoadableEncryptorUtils tests

--- a/cpp/src/parquet/encryption/external/span.hpp
+++ b/cpp/src/parquet/encryption/external/span.hpp
@@ -1,0 +1,618 @@
+
+/*
+This is an implementation of C++20's std::span
+http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/n4820.pdf
+*/
+
+//          Copyright Tristan Brindle 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../../LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef TCB_SPAN_HPP_INCLUDED
+#define TCB_SPAN_HPP_INCLUDED
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#ifndef TCB_SPAN_NO_EXCEPTIONS
+// Attempt to discover whether we're being compiled with exception support
+#if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
+#define TCB_SPAN_NO_EXCEPTIONS
+#endif
+#endif
+
+#ifndef TCB_SPAN_NO_EXCEPTIONS
+#include <cstdio>
+#include <stdexcept>
+#endif
+
+// Various feature test macros
+
+#ifndef TCB_SPAN_NAMESPACE_NAME
+#define TCB_SPAN_NAMESPACE_NAME tcb
+#endif
+
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#define TCB_SPAN_HAVE_CPP17
+#endif
+
+#if __cplusplus >= 201402L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
+#define TCB_SPAN_HAVE_CPP14
+#endif
+
+namespace TCB_SPAN_NAMESPACE_NAME {
+
+// Establish default contract checking behavior
+#if !defined(TCB_SPAN_THROW_ON_CONTRACT_VIOLATION) &&                          \
+    !defined(TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION) &&                      \
+    !defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#if defined(NDEBUG) || !defined(TCB_SPAN_HAVE_CPP14)
+#define TCB_SPAN_NO_CONTRACT_CHECKING
+#else
+#define TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION
+#endif
+#endif
+
+#if defined(TCB_SPAN_THROW_ON_CONTRACT_VIOLATION)
+struct contract_violation_error : std::logic_error {
+    explicit contract_violation_error(const char* msg) : std::logic_error(msg)
+    {}
+};
+
+inline void contract_violation(const char* msg)
+{
+    throw contract_violation_error(msg);
+}
+
+#elif defined(TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION)
+[[noreturn]] inline void contract_violation(const char* /*unused*/)
+{
+    std::terminate();
+}
+#endif
+
+#if !defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#define TCB_SPAN_STRINGIFY(cond) #cond
+#define TCB_SPAN_EXPECT(cond)                                                  \
+    cond ? (void) 0 : contract_violation("Expected " TCB_SPAN_STRINGIFY(cond))
+#else
+#define TCB_SPAN_EXPECT(cond)
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_inline_variables)
+#define TCB_SPAN_INLINE_VAR inline
+#else
+#define TCB_SPAN_INLINE_VAR
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14) ||                                            \
+    (defined(__cpp_constexpr) && __cpp_constexpr >= 201304)
+#define TCB_SPAN_HAVE_CPP14_CONSTEXPR
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14_CONSTEXPR)
+#define TCB_SPAN_CONSTEXPR14 constexpr
+#else
+#define TCB_SPAN_CONSTEXPR14
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14_CONSTEXPR) &&                                  \
+    (!defined(_MSC_VER) || _MSC_VER > 1900)
+#define TCB_SPAN_CONSTEXPR_ASSIGN constexpr
+#else
+#define TCB_SPAN_CONSTEXPR_ASSIGN
+#endif
+
+#if defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#define TCB_SPAN_CONSTEXPR11 constexpr
+#else
+#define TCB_SPAN_CONSTEXPR11 TCB_SPAN_CONSTEXPR14
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_deduction_guides)
+#define TCB_SPAN_HAVE_DEDUCTION_GUIDES
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_byte)
+#define TCB_SPAN_HAVE_STD_BYTE
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_array_constexpr)
+#define TCB_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC
+#endif
+
+#if defined(TCB_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC)
+#define TCB_SPAN_ARRAY_CONSTEXPR constexpr
+#else
+#define TCB_SPAN_ARRAY_CONSTEXPR
+#endif
+
+#ifdef TCB_SPAN_HAVE_STD_BYTE
+using byte = std::byte;
+#else
+using byte = unsigned char;
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17)
+#define TCB_SPAN_NODISCARD [[nodiscard]]
+#else
+#define TCB_SPAN_NODISCARD
+#endif
+
+TCB_SPAN_INLINE_VAR constexpr std::size_t dynamic_extent = SIZE_MAX;
+
+template <typename ElementType, std::size_t Extent = dynamic_extent>
+class span;
+
+namespace detail {
+
+template <typename E, std::size_t S>
+struct span_storage {
+    constexpr span_storage() noexcept = default;
+
+    constexpr span_storage(E* p_ptr, std::size_t /*unused*/) noexcept
+       : ptr(p_ptr)
+    {}
+
+    E* ptr = nullptr;
+    static constexpr std::size_t size = S;
+};
+
+template <typename E>
+struct span_storage<E, dynamic_extent> {
+    constexpr span_storage() noexcept = default;
+
+    constexpr span_storage(E* p_ptr, std::size_t p_size) noexcept
+        : ptr(p_ptr), size(p_size)
+    {}
+
+    E* ptr = nullptr;
+    std::size_t size = 0;
+};
+
+// Reimplementation of C++17 std::size() and std::data()
+#if defined(TCB_SPAN_HAVE_CPP17) ||                                            \
+    defined(__cpp_lib_nonmember_container_access)
+using std::data;
+using std::size;
+#else
+template <class C>
+constexpr auto size(const C& c) -> decltype(c.size())
+{
+    return c.size();
+}
+
+template <class T, std::size_t N>
+constexpr std::size_t size(const T (&)[N]) noexcept
+{
+    return N;
+}
+
+template <class C>
+constexpr auto data(C& c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class C>
+constexpr auto data(const C& c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class T, std::size_t N>
+constexpr T* data(T (&array)[N]) noexcept
+{
+    return array;
+}
+
+template <class E>
+constexpr const E* data(std::initializer_list<E> il) noexcept
+{
+    return il.begin();
+}
+#endif // TCB_SPAN_HAVE_CPP17
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_void_t)
+using std::void_t;
+#else
+template <typename...>
+using void_t = void;
+#endif
+
+template <typename T>
+using uncvref_t =
+    typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+
+template <typename>
+struct is_span : std::false_type {};
+
+template <typename T, std::size_t S>
+struct is_span<span<T, S>> : std::true_type {};
+
+template <typename>
+struct is_std_array : std::false_type {};
+
+template <typename T, std::size_t N>
+struct is_std_array<std::array<T, N>> : std::true_type {};
+
+template <typename, typename = void>
+struct has_size_and_data : std::false_type {};
+
+template <typename T>
+struct has_size_and_data<T, void_t<decltype(detail::size(std::declval<T>())),
+                                   decltype(detail::data(std::declval<T>()))>>
+    : std::true_type {};
+
+template <typename C, typename U = uncvref_t<C>>
+struct is_container {
+    static constexpr bool value =
+        !is_span<U>::value && !is_std_array<U>::value &&
+        !std::is_array<U>::value && has_size_and_data<C>::value;
+};
+
+template <typename T>
+using remove_pointer_t = typename std::remove_pointer<T>::type;
+
+template <typename, typename, typename = void>
+struct is_container_element_type_compatible : std::false_type {};
+
+template <typename T, typename E>
+struct is_container_element_type_compatible<
+    T, E,
+    typename std::enable_if<
+        !std::is_same<
+            typename std::remove_cv<decltype(detail::data(std::declval<T>()))>::type,
+            void>::value &&
+        std::is_convertible<
+            remove_pointer_t<decltype(detail::data(std::declval<T>()))> (*)[],
+            E (*)[]>::value
+        >::type>
+    : std::true_type {};
+
+template <typename, typename = size_t>
+struct is_complete : std::false_type {};
+
+template <typename T>
+struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
+
+} // namespace detail
+
+template <typename ElementType, std::size_t Extent>
+class span {
+    static_assert(std::is_object<ElementType>::value,
+                  "A span's ElementType must be an object type (not a "
+                  "reference type or void)");
+    static_assert(detail::is_complete<ElementType>::value,
+                  "A span's ElementType must be a complete type (not a forward "
+                  "declaration)");
+    static_assert(!std::is_abstract<ElementType>::value,
+                  "A span's ElementType cannot be an abstract class type");
+
+    using storage_type = detail::span_storage<ElementType, Extent>;
+
+public:
+    // constants and types
+    using element_type = ElementType;
+    using value_type = typename std::remove_cv<ElementType>::type;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = element_type*;
+    using const_pointer = const element_type*;
+    using reference = element_type&;
+    using const_reference = const element_type&;
+    using iterator = pointer;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+
+    static constexpr size_type extent = Extent;
+
+    // [span.cons], span constructors, copy, assignment, and destructor
+    template <
+        std::size_t E = Extent,
+        typename std::enable_if<(E == dynamic_extent || E <= 0), int>::type = 0>
+    constexpr span() noexcept
+    {}
+
+    TCB_SPAN_CONSTEXPR11 span(pointer ptr, size_type count)
+        : storage_(ptr, count)
+    {
+        TCB_SPAN_EXPECT(extent == dynamic_extent || count == extent);
+    }
+
+    TCB_SPAN_CONSTEXPR11 span(pointer first_elem, pointer last_elem)
+        : storage_(first_elem, last_elem - first_elem)
+    {
+        TCB_SPAN_EXPECT(extent == dynamic_extent ||
+                        last_elem - first_elem ==
+                            static_cast<std::ptrdiff_t>(extent));
+    }
+
+    template <std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          element_type (&)[N], ElementType>::value,
+                  int>::type = 0>
+    constexpr span(element_type (&arr)[N]) noexcept : storage_(arr, N)
+    {}
+
+    template <typename T, std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          std::array<T, N>&, ElementType>::value,
+                  int>::type = 0>
+    TCB_SPAN_ARRAY_CONSTEXPR span(std::array<T, N>& arr) noexcept
+        : storage_(arr.data(), N)
+    {}
+
+    template <typename T, std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          const std::array<T, N>&, ElementType>::value,
+                  int>::type = 0>
+    TCB_SPAN_ARRAY_CONSTEXPR span(const std::array<T, N>& arr) noexcept
+        : storage_(arr.data(), N)
+    {}
+
+    template <
+        typename Container, std::size_t E = Extent,
+        typename std::enable_if<
+            E == dynamic_extent && detail::is_container<Container>::value &&
+                detail::is_container_element_type_compatible<
+                    Container&, ElementType>::value,
+            int>::type = 0>
+    constexpr span(Container& cont)
+        : storage_(detail::data(cont), detail::size(cont))
+    {}
+
+    template <
+        typename Container, std::size_t E = Extent,
+        typename std::enable_if<
+            E == dynamic_extent && detail::is_container<Container>::value &&
+                detail::is_container_element_type_compatible<
+                    const Container&, ElementType>::value,
+            int>::type = 0>
+    constexpr span(const Container& cont)
+        : storage_(detail::data(cont), detail::size(cont))
+    {}
+
+    constexpr span(const span& other) noexcept = default;
+
+    template <typename OtherElementType, std::size_t OtherExtent,
+              typename std::enable_if<
+                  (Extent == dynamic_extent || OtherExtent == dynamic_extent ||
+                   Extent == OtherExtent) &&
+                      std::is_convertible<OtherElementType (*)[],
+                                          ElementType (*)[]>::value,
+                  int>::type = 0>
+    constexpr span(const span<OtherElementType, OtherExtent>& other) noexcept
+        : storage_(other.data(), other.size())
+    {}
+
+    ~span() noexcept = default;
+
+    TCB_SPAN_CONSTEXPR_ASSIGN span&
+    operator=(const span& other) noexcept = default;
+
+    // [span.sub], span subviews
+    template <std::size_t Count>
+    TCB_SPAN_CONSTEXPR11 span<element_type, Count> first() const
+    {
+        TCB_SPAN_EXPECT(Count <= size());
+        return {data(), Count};
+    }
+
+    template <std::size_t Count>
+    TCB_SPAN_CONSTEXPR11 span<element_type, Count> last() const
+    {
+        TCB_SPAN_EXPECT(Count <= size());
+        return {data() + (size() - Count), Count};
+    }
+
+    template <std::size_t Offset, std::size_t Count = dynamic_extent>
+    using subspan_return_t =
+        span<ElementType, Count != dynamic_extent
+                              ? Count
+                              : (Extent != dynamic_extent ? Extent - Offset
+                                                          : dynamic_extent)>;
+
+    template <std::size_t Offset, std::size_t Count = dynamic_extent>
+    TCB_SPAN_CONSTEXPR11 subspan_return_t<Offset, Count> subspan() const
+    {
+        TCB_SPAN_EXPECT(Offset <= size() &&
+                        (Count == dynamic_extent || Offset + Count <= size()));
+        return {data() + Offset,
+                Count != dynamic_extent ? Count : size() - Offset};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    first(size_type count) const
+    {
+        TCB_SPAN_EXPECT(count <= size());
+        return {data(), count};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    last(size_type count) const
+    {
+        TCB_SPAN_EXPECT(count <= size());
+        return {data() + (size() - count), count};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    subspan(size_type offset, size_type count = dynamic_extent) const
+    {
+        TCB_SPAN_EXPECT(offset <= size() &&
+                        (count == dynamic_extent || offset + count <= size()));
+        return {data() + offset,
+                count == dynamic_extent ? size() - offset : count};
+    }
+
+    // [span.obs], span observers
+    constexpr size_type size() const noexcept { return storage_.size; }
+
+    constexpr size_type size_bytes() const noexcept
+    {
+        return size() * sizeof(element_type);
+    }
+
+    TCB_SPAN_NODISCARD constexpr bool empty() const noexcept
+    {
+        return size() == 0;
+    }
+
+    // [span.elem], span element access
+    TCB_SPAN_CONSTEXPR11 reference operator[](size_type idx) const
+    {
+        TCB_SPAN_EXPECT(idx < size());
+        return *(data() + idx);
+    }
+
+    TCB_SPAN_CONSTEXPR11 reference front() const
+    {
+        TCB_SPAN_EXPECT(!empty());
+        return *data();
+    }
+
+    TCB_SPAN_CONSTEXPR11 reference back() const
+    {
+        TCB_SPAN_EXPECT(!empty());
+        return *(data() + (size() - 1));
+    }
+
+    constexpr pointer data() const noexcept { return storage_.ptr; }
+
+    // [span.iterators], span iterator support
+    constexpr iterator begin() const noexcept { return data(); }
+
+    constexpr iterator end() const noexcept { return data() + size(); }
+
+    TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rbegin() const noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rend() const noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+private:
+    storage_type storage_{};
+};
+
+#ifdef TCB_SPAN_HAVE_DEDUCTION_GUIDES
+
+/* Deduction Guides */
+template <class T, size_t N>
+span(T (&)[N])->span<T, N>;
+
+template <class T, size_t N>
+span(std::array<T, N>&)->span<T, N>;
+
+template <class T, size_t N>
+span(const std::array<T, N>&)->span<const T, N>;
+
+template <class Container>
+span(Container&)->span<typename std::remove_reference<
+    decltype(*detail::data(std::declval<Container&>()))>::type>;
+
+template <class Container>
+span(const Container&)->span<const typename Container::value_type>;
+
+#endif // TCB_HAVE_DEDUCTION_GUIDES
+
+template <typename ElementType, std::size_t Extent>
+constexpr span<ElementType, Extent>
+make_span(span<ElementType, Extent> s) noexcept
+{
+    return s;
+}
+
+template <typename T, std::size_t N>
+constexpr span<T, N> make_span(T (&arr)[N]) noexcept
+{
+    return {arr};
+}
+
+template <typename T, std::size_t N>
+TCB_SPAN_ARRAY_CONSTEXPR span<T, N> make_span(std::array<T, N>& arr) noexcept
+{
+    return {arr};
+}
+
+template <typename T, std::size_t N>
+TCB_SPAN_ARRAY_CONSTEXPR span<const T, N>
+make_span(const std::array<T, N>& arr) noexcept
+{
+    return {arr};
+}
+
+template <typename Container>
+constexpr span<typename std::remove_reference<
+    decltype(*detail::data(std::declval<Container&>()))>::type>
+make_span(Container& cont)
+{
+    return {cont};
+}
+
+template <typename Container>
+constexpr span<const typename Container::value_type>
+make_span(const Container& cont)
+{
+    return {cont};
+}
+
+template <typename ElementType, std::size_t Extent>
+span<const byte, ((Extent == dynamic_extent) ? dynamic_extent
+                                             : sizeof(ElementType) * Extent)>
+as_bytes(span<ElementType, Extent> s) noexcept
+{
+    return {reinterpret_cast<const byte*>(s.data()), s.size_bytes()};
+}
+
+template <
+    class ElementType, size_t Extent,
+    typename std::enable_if<!std::is_const<ElementType>::value, int>::type = 0>
+span<byte, ((Extent == dynamic_extent) ? dynamic_extent
+                                       : sizeof(ElementType) * Extent)>
+as_writable_bytes(span<ElementType, Extent> s) noexcept
+{
+    return {reinterpret_cast<byte*>(s.data()), s.size_bytes()};
+}
+
+template <std::size_t N, typename E, std::size_t S>
+constexpr auto get(span<E, S> s) -> decltype(s[N])
+{
+    return s[N];
+}
+
+} // namespace TCB_SPAN_NAMESPACE_NAME
+
+namespace std {
+
+template <typename ElementType, size_t Extent>
+class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<ElementType, Extent>>
+    : public integral_constant<size_t, Extent> {};
+
+template <typename ElementType>
+class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<
+    ElementType, TCB_SPAN_NAMESPACE_NAME::dynamic_extent>>; // not defined
+
+template <size_t I, typename ElementType, size_t Extent>
+class tuple_element<I, TCB_SPAN_NAMESPACE_NAME::span<ElementType, Extent>> {
+public:
+    static_assert(Extent != TCB_SPAN_NAMESPACE_NAME::dynamic_extent &&
+                      I < Extent,
+                  "");
+    using type = ElementType;
+};
+
+} // end namespace std
+
+#endif // TCB_SPAN_HPP_INCLUDED


### PR DESCRIPTION
### Rationale for this change
In this change, we are merging-in the latest version of [DataBatchProtectionAgentInterface](https://github.com/protegrity/DataBatchProtectionService/) into the mini-app code branch

### What changes are included in this PR?
- Copying the latest version of `dbpa_interface.h` (and some of the required dependencies, like `enums.h`)
- Updating the code to use `tcb::span` (instead of `std::span`, which cannot be used given that Arrow is C++17 and `std::span` is C++20)
- Modify the `dbpa_library_wrapper` to also decorate the `init()` method (this method was not considered in the earlier version of `dbpa_interface`). Modified the tests to include `init()`
- Modify tests to account for the fact that `EncryptionResult` and `DecryptionResult` are now well defined.
- In `dbpa_library_wrapper`, moved some of the decorated methods to the `*.h` file and inlined them.

### Are these changes tested?
- All existing tests pass, and the newly updated tests also pass.
