### PR TITLE
Fixing problems in ExternalEncryptionConfig bindings

### DIFF
--- a/cpp/src/parquet/encryption/crypto_factory.cc
+++ b/cpp/src/parquet/encryption/crypto_factory.cc
@@ -182,7 +182,7 @@ CryptoFactory::GetExternalFileEncryptionProperties(
       key_wrapper.GetEncryptionKeyMetadata(footer_key, external_encryption_config.footer_key, true);
   
   ExternalFileEncryptionProperties::Builder external_properties_builder =
-      ExternalFileEncryptionProperties::Builder(external_encryption_config.footer_key);
+      ExternalFileEncryptionProperties::Builder(footer_key);
   external_properties_builder.footer_key_metadata(footer_key_metadata);
   external_properties_builder.algorithm(external_encryption_config.encryption_algorithm);
 

--- a/cpp/src/parquet/encryption/crypto_factory_test.cc
+++ b/cpp/src/parquet/encryption/crypto_factory_test.cc
@@ -84,7 +84,7 @@ TEST_F(CryptoFactoryTest, BasicEncryptionConfig) {
     config.column_keys = "kc1:col1,col2;kc2:col3,col4";
 
     auto properties = crypto_factory_.GetExternalFileEncryptionProperties(kms_config_, config);
-    EXPECT_EQ("kf", properties->footer_key());
+    EXPECT_EQ(16, properties->footer_key().size());
     EXPECT_TRUE(properties->footer_key_metadata().size() > 0);
     EXPECT_EQ(ParquetCipher::AES_GCM_V1, properties->algorithm().algorithm);
     EXPECT_FALSE(properties->encrypted_footer());
@@ -129,7 +129,7 @@ TEST_F(CryptoFactoryTest, ExternalEncryptionConfig) {
     };
 
     auto properties = crypto_factory_.GetExternalFileEncryptionProperties(kms_config_, config);
-    EXPECT_EQ("kf", properties->footer_key());
+    EXPECT_EQ(16, properties->footer_key().size());
     EXPECT_TRUE(properties->footer_key_metadata().size() > 0);
     EXPECT_EQ(ParquetCipher::AES_GCM_V1, properties->algorithm().algorithm);
     EXPECT_FALSE(properties->encrypted_footer());

--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -181,7 +181,7 @@ cdef class EncryptionConfiguration(_Weakrefable):
         return self.configuration
 
 cdef class ExternalEncryptionConfiguration(EncryptionConfiguration):
-    """ExternalEncryptionConfiguration is a Cython extension class that inherits from EncryptionConfiguration."""
+    """ExternalEncryptionConfiguration inherits from EncryptionConfiguration."""
     __slots__ = ()
   
     def __init__(self, footer_key, *, column_keys=None,
@@ -190,6 +190,10 @@ cdef class ExternalEncryptionConfiguration(EncryptionConfiguration):
                  cache_lifetime=None, internal_key_material=None,
                  data_key_length_bits=None, per_column_encryption=None,
                  app_context=None, connection_config=None):
+
+        # Initialize pointer first so the get/set forwards work.
+        self.external_configuration.reset(
+            new CExternalEncryptionConfiguration(tobytes(footer_key)))
 
         super().__init__(footer_key,
             column_keys=column_keys,
@@ -200,8 +204,8 @@ cdef class ExternalEncryptionConfiguration(EncryptionConfiguration):
             internal_key_material=internal_key_material,
             data_key_length_bits=data_key_length_bits)
 
-        self.external_configuration.reset(
-            new CExternalEncryptionConfiguration(tobytes(footer_key)))
+        self.external_configuration.get().footer_key = \
+            self.configuration.get().footer_key
         
         if app_context is not None:
             self.app_context = app_context
@@ -209,6 +213,71 @@ cdef class ExternalEncryptionConfiguration(EncryptionConfiguration):
             self.connection_config = connection_config
         if per_column_encryption is not None:
             self.per_column_encryption = per_column_encryption
+
+    """ Forward all attributes get/set methods to the superclass """
+    @property
+    def column_keys(self):
+        return EncryptionConfiguration.column_keys.__get__(self)
+
+    @column_keys.setter
+    def column_keys(self, dict value):
+        EncryptionConfiguration.column_keys.__set__(self, value)
+        self.external_configuration.get().column_keys = self.configuration.get().column_keys
+
+    @property
+    def encryption_algorithm(self):
+        return EncryptionConfiguration.encryption_algorithm.__get__(self)
+
+    @encryption_algorithm.setter
+    def encryption_algorithm(self, value):
+        EncryptionConfiguration.encryption_algorithm.__set__(self, value)
+        self.external_configuration.get().encryption_algorithm = \
+            self.configuration.get().encryption_algorithm
+
+    @property
+    def plaintext_footer(self):
+        return EncryptionConfiguration.plaintext_footer.__get__(self)
+
+    @plaintext_footer.setter
+    def plaintext_footer(self, value):
+        EncryptionConfiguration.plaintext_footer.__set__(self, value)
+        self.external_configuration.get().plaintext_footer = value
+
+    @property
+    def double_wrapping(self):
+        return EncryptionConfiguration.double_wrapping.__get__(self)
+
+    @double_wrapping.setter
+    def double_wrapping(self, value):
+        EncryptionConfiguration.double_wrapping.__set__(self, value)
+        self.external_configuration.get().double_wrapping = value
+
+    @property
+    def cache_lifetime(self):
+        return EncryptionConfiguration.cache_lifetime.__get__(self)
+
+    @cache_lifetime.setter
+    def cache_lifetime(self, value):
+        EncryptionConfiguration.cache_lifetime.__set__(self, value)
+        self.external_configuration.get().cache_lifetime_seconds = value.total_seconds()
+
+    @property
+    def internal_key_material(self):
+        return EncryptionConfiguration.internal_key_material.__get__(self)
+
+    @internal_key_material.setter
+    def internal_key_material(self, value):
+        EncryptionConfiguration.internal_key_material.__set__(self, value)
+        self.external_configuration.get().internal_key_material = value
+
+    @property
+    def data_key_length_bits(self):
+        return EncryptionConfiguration.data_key_length_bits.__get__(self)
+
+    @data_key_length_bits.setter
+    def data_key_length_bits(self, value):
+        EncryptionConfiguration.data_key_length_bits.__set__(self, value)
+        self.external_configuration.get().data_key_length_bits = value
 
     @property
     def app_context(self):

--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -215,6 +215,7 @@ cdef class ExternalEncryptionConfiguration(EncryptionConfiguration):
             self.per_column_encryption = per_column_encryption
 
     """ Forward all attributes get/set methods to the superclass """
+    """ The superclass already converts to/from bytes and does additional processing needed """
     @property
     def column_keys(self):
         return EncryptionConfiguration.column_keys.__get__(self)

--- a/python/scripts/base_app.py
+++ b/python/scripts/base_app.py
@@ -114,6 +114,33 @@ def get_kms_connection_config():
         }
     )
 
+def get_external_encryption_config(plaintext_footer=True):
+    return ppe.ExternalEncryptionConfiguration(
+        footer_key = "footer_key",
+        column_keys = {
+            "productid_key": ["productId"]
+        },
+        encryption_algorithm = "AES_GCM_V1",
+        cache_lifetime=datetime.timedelta(minutes=2.0),
+        data_key_length_bits = 128,
+        plaintext_footer=plaintext_footer,
+        per_column_encryption = {
+            "orderId": {
+                "encryption_algorithm": "AES_GCM_V1",
+                "encryption_key": "orderid_key"
+            },
+        },
+        app_context = {
+            "user_id": "Picard1701",
+            "location": "Presidio"
+        },
+        connection_config = {
+            "EXTERNAL_DBPA_V1": {
+                "config_file": "path/to/config/file",
+                "config_file_decryption_key": "some_key"
+            }
+        }
+    )
 
 def get_encryption_config(plaintext_footer=True):
     return ppe.EncryptionConfiguration(


### PR DESCRIPTION
Fixing problems in the ExternalEncryptionConfig Cython bindings.

While debugging PR #57 I noticed the test setup was incorrect (repeated columns in per_column_encryption and column_keys). Since that should've caused exceptions, I started debugging whether the ExternalEncryptionConfig made its way correctly to the Arrow code.

Found and fixed the errors, plus a small bug in crypto_factory.cc related to the footer_key.

Fixed the bindings and the test.

Verified using the base app and sending an ExternalEncryptionConfig and printing out values in the CryptoFactory (there's no good way to test this right now).

Up next, fixing the rest of the existing bindings (ExternalDecryptionConfig and ExternalFileEncryptionProperties) until I make my way back to fixing the code in PR #57 