### PR TITLE
Wiring DBPAgent into ExternalEncryptorImpl/ExternalDecryptor impl

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -242,7 +242,8 @@ if(PARQUET_REQUIRE_ENCRYPTION)
   set(PARQUET_SRCS ${PARQUET_SRCS} encryption/encryption_internal.cc
                    encryption/openssl_internal.cc
                    encryption/external/loadable_encryptor_utils.cc
-                   encryption/external/dbpa_library_wrapper.cc)
+                   encryption/external/dbpa_library_wrapper.cc
+                   encryption/external/dbpa_utils.cc)
   # Encryption key management
   set(PARQUET_SRCS
       ${PARQUET_SRCS}

--- a/cpp/src/parquet/encryption/external/dbpa_utils.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_utils.cc
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/encryption/external/dbpa_utils.h"
+
+#include <stdexcept>
+
+namespace parquet::encryption::external {
+
+dbps::external::Type::type dbpa_utils::ParquetTypeToExternal(parquet::Type::type parquet_type) {
+    // The enums have identical values, so we can do a direct cast
+    switch (parquet_type) {
+        case parquet::Type::BOOLEAN:
+            return dbps::external::Type::BOOLEAN;
+        case parquet::Type::INT32:
+            return dbps::external::Type::INT32;
+        case parquet::Type::INT64:
+            return dbps::external::Type::INT64;
+        case parquet::Type::INT96:
+            return dbps::external::Type::INT96;
+        case parquet::Type::FLOAT:
+            return dbps::external::Type::FLOAT;
+        case parquet::Type::DOUBLE:
+            return dbps::external::Type::DOUBLE;
+        case parquet::Type::BYTE_ARRAY:
+            return dbps::external::Type::BYTE_ARRAY;
+        case parquet::Type::FIXED_LEN_BYTE_ARRAY:
+            return dbps::external::Type::FIXED_LEN_BYTE_ARRAY;
+        case parquet::Type::UNDEFINED:
+        default:
+            throw std::invalid_argument("Invalid parquet::Type value");
+    }
+}
+
+parquet::Type::type dbpa_utils::ExternalTypeToParquet(dbps::external::Type::type external_type) {
+    // The enums have identical values, so we can do a direct cast
+    switch (external_type) {
+        case dbps::external::Type::BOOLEAN:
+            return parquet::Type::BOOLEAN;
+        case dbps::external::Type::INT32:
+            return parquet::Type::INT32;
+        case dbps::external::Type::INT64:
+            return parquet::Type::INT64;
+        case dbps::external::Type::INT96:
+            return parquet::Type::INT96;
+        case dbps::external::Type::FLOAT:
+            return parquet::Type::FLOAT;
+        case dbps::external::Type::DOUBLE:
+            return parquet::Type::DOUBLE;
+        case dbps::external::Type::BYTE_ARRAY:
+            return parquet::Type::BYTE_ARRAY;
+        case dbps::external::Type::FIXED_LEN_BYTE_ARRAY:
+            return parquet::Type::FIXED_LEN_BYTE_ARRAY;
+        default:
+            throw std::invalid_argument("Invalid dbps::external::Type value");
+    }
+}
+
+dbps::external::CompressionCodec::type dbpa_utils::ArrowCompressionToExternal(::arrow::Compression::type arrow_compression) {
+    switch (arrow_compression) {
+        case ::arrow::Compression::UNCOMPRESSED:
+            return dbps::external::CompressionCodec::UNCOMPRESSED;
+        case ::arrow::Compression::SNAPPY:
+            return dbps::external::CompressionCodec::SNAPPY;
+        case ::arrow::Compression::GZIP:
+            return dbps::external::CompressionCodec::GZIP;
+        case ::arrow::Compression::LZO:
+            return dbps::external::CompressionCodec::LZO;
+        case ::arrow::Compression::BROTLI:
+            return dbps::external::CompressionCodec::BROTLI;
+        case ::arrow::Compression::LZ4:
+            return dbps::external::CompressionCodec::LZ4;
+        case ::arrow::Compression::ZSTD:
+            return dbps::external::CompressionCodec::ZSTD;
+        default:
+            throw std::invalid_argument("Invalid arrow::Compression value");
+    }
+}
+
+::arrow::Compression::type dbpa_utils::ExternalCompressionToArrow(dbps::external::CompressionCodec::type external_compression) {
+    switch (external_compression) {
+        case dbps::external::CompressionCodec::UNCOMPRESSED:
+            return ::arrow::Compression::UNCOMPRESSED;
+        case dbps::external::CompressionCodec::SNAPPY:
+            return ::arrow::Compression::SNAPPY;
+        case dbps::external::CompressionCodec::GZIP:
+            return ::arrow::Compression::GZIP;
+        case dbps::external::CompressionCodec::LZO:
+            return ::arrow::Compression::LZO;
+        case dbps::external::CompressionCodec::BROTLI:
+            return ::arrow::Compression::BROTLI;
+        case dbps::external::CompressionCodec::LZ4:
+            return ::arrow::Compression::LZ4;
+        case dbps::external::CompressionCodec::ZSTD:
+            return ::arrow::Compression::ZSTD;
+        default:
+            throw std::invalid_argument("Invalid dbps::external::CompressionCodec value");
+    }
+}
+
+} // namespace parquet::encryption::external

--- a/cpp/src/parquet/encryption/external/dbpa_utils.h
+++ b/cpp/src/parquet/encryption/external/dbpa_utils.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <stdexcept>
+
+#include "parquet/encryption/external/dbpa_interface.h"
+#include "parquet/types.h"
+#include "arrow/type_fwd.h" // For arrow::Compression
+
+namespace parquet::encryption::external {
+
+/**
+ * Utility class for translating between Parquet/Arrow enums and dbps::external enums.
+ * 
+ * This class provides methods to convert between:
+ * - parquet::Type and dbps::external::Type
+ * - arrow::Compression and dbps::external::CompressionCodec
+ */
+class dbpa_utils {
+public:
+    /**
+     * Convert parquet::Type to dbps::external::Type
+     * 
+     * @param parquet_type The parquet type to convert
+     * @return The corresponding dbps::external::Type
+     */
+    static dbps::external::Type::type ParquetTypeToExternal(parquet::Type::type parquet_type);
+    
+    /**
+     * Convert dbps::external::Type to parquet::Type
+     * 
+     * @param external_type The dbps::external type to convert
+     * @return The corresponding parquet::Type
+     */
+    static parquet::Type::type ExternalTypeToParquet(dbps::external::Type::type external_type);
+    
+    /**
+     * Convert arrow::Compression to dbps::external::CompressionCodec
+     * 
+     * @param arrow_compression The Arrow compression type to convert
+     * @return The corresponding dbps::external::CompressionCodec
+     * @throws std::invalid_argument if the Arrow compression type cannot be mapped
+     */
+    static dbps::external::CompressionCodec::type ArrowCompressionToExternal(::arrow::Compression::type arrow_compression);
+    
+    /**
+     * Convert dbps::external::CompressionCodec to arrow::Compression
+     * 
+     * @param external_compression The dbps::external compression type to convert
+     * @return The corresponding arrow::Compression
+     * @throws std::invalid_argument if the external compression type cannot be mapped
+     */
+    static ::arrow::Compression::type ExternalCompressionToArrow(dbps::external::CompressionCodec::type external_compression);
+};
+
+} // namespace parquet::encryption::external

--- a/cpp/src/parquet/encryption/external/loadable_encryptor_utils.cc
+++ b/cpp/src/parquet/encryption/external/loadable_encryptor_utils.cc
@@ -20,6 +20,7 @@ namespace parquet::encryption::external {
 // This needs to match the return type of the create_new_instance function in the shared library.
 typedef DataBatchProtectionAgentInterface* (*create_encryptor_t)();
 
+//TODO: this should be private
 std::unique_ptr<DataBatchProtectionAgentInterface> CreateInstance(void* library_handle) {
   auto symbol_result = arrow::internal::GetSymbol(library_handle, "create_new_instance");
   if (!symbol_result.ok()) {
@@ -46,7 +47,6 @@ std::unique_ptr<DataBatchProtectionAgentInterface> CreateInstance(void* library_
 
   return instance_ptr;
 } // CreateInstance()
-
 
 std::unique_ptr<DataBatchProtectionAgentInterface> LoadableEncryptorUtils::LoadFromLibrary(const std::string& library_path) {
   //TODO: remove this.


### PR DESCRIPTION
### Rationale for this change
In this work, we're wiring the shared library (aka DLL) -loaded DBPAgent instance into both `ExternalEncryptorImpl` and `ExternalDecryptorImpl` (`EEI` and `EDI`, respectively). We're using the miniApp branch for this. 

As part of this change, the previous implementations of `EEI` and `EDI` are being over-written.

As a reminder - this particular PR will never be merged into `dev_phase2` nor into `main` - an equivalent change will be made once the refactoring work happening in `dev_phase2` is complete.

### What changes are included in this PR?
- Addition of `dbpa_utils.h` and `dbpa_utils.cc` as utils to help translate concepts between the Arrow and DBPA namespace.
- Heavily modified `ExternalEncryptorImpl` and `ExternalDecryptorImpl` (inside `encryption_internal.cc` and `encryption_internal.h`). 
  - In particular, we modified
    - Constructors
    - Implementation of the `::Make` method
    - Implementations of `::Encrypt()` `::Decrypt()` `CiphertextLength()` and `PlaintextLength()`
    - Eliminated the underlying usage of `AESEncryptor`/`AESDecryptor`
  - We did not modify
    - The `EncryptorInterface` and `DecryptorInterface` definitions (again, this is the mini-App. We left them as-is).  

### Are these changes tested?
- Mostly. 
  -  The encryption workflow works (verified using the miniApp). 
  - Existing unit tests pass
 - The Decryption workflow is untested, but that's because a larger change in the Python->Cython->C++ change is required (coming in a later PR).

### Related
This implements
- https://github.com/protegrity/DataBatchProtectionService/issues/42
- https://github.com/protegrity/DataBatchProtectionService/issues/58

But in both cases leaves the Executor outside of the implementation. Executor for both will be picked up in a later task: 
https://github.com/protegrity/DataBatchProtectionService/issues/73


