### PR TITLE
Refactoring common encryption utility functions out of encryption_int…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ java/.mvn/.develocity/
 # rat
 filtered_rat.txt
 rat.txt
+
+python/sample.parquet

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -37,7 +37,7 @@
 #include "arrow/util/thread_pool.h"
 #include "parquet/arrow/reader.h"
 #include "parquet/encryption/crypto_factory.h"
-#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/encryption_utils.h"
 #include "parquet/encryption/kms_client.h"
 #include "parquet/encryption/test_in_memory_kms.h"
 

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -239,6 +239,7 @@ endif()
 if(PARQUET_REQUIRE_ENCRYPTION)
   list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS ${ARROW_OPENSSL_LIBS})
   set(PARQUET_SRCS ${PARQUET_SRCS} encryption/encryption_internal.cc
+                   encryption/encryption_utils.cc
                    encryption/openssl_internal.cc)
   # Encryption key management
   set(PARQUET_SRCS

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -47,7 +47,7 @@
 #include "arrow/util/unreachable.h"
 #include "parquet/column_page.h"
 #include "parquet/encoding.h"
-#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/encryption_utils.h"
 #include "parquet/encryption/internal_file_decryptor.h"
 #include "parquet/level_comparison.h"
 #include "parquet/level_conversion.h"

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -47,7 +47,7 @@
 #include "arrow/visit_array_inline.h"
 #include "parquet/column_page.h"
 #include "parquet/encoding.h"
-#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/encryption_utils.h"
 #include "parquet/encryption/internal_file_encryptor.h"
 #include "parquet/level_conversion.h"
 #include "parquet/metadata.h"

--- a/cpp/src/parquet/encryption/crypto_factory.cc
+++ b/cpp/src/parquet/encryption/crypto_factory.cc
@@ -21,7 +21,7 @@
 #include "arrow/util/string.h"
 
 #include "parquet/encryption/crypto_factory.h"
-#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/encryption_utils.h"
 #include "parquet/encryption/file_key_unwrapper.h"
 #include "parquet/encryption/file_system_key_material_store.h"
 #include "parquet/encryption/key_toolkit_internal.h"

--- a/cpp/src/parquet/encryption/encryption.cc
+++ b/cpp/src/parquet/encryption/encryption.cc
@@ -25,7 +25,7 @@
 
 #include "arrow/util/logging_internal.h"
 #include "arrow/util/utf8.h"
-#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/encryption_utils.h"
 
 namespace parquet {
 

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -17,8 +17,6 @@
 
 #include "parquet/encryption/encryption_internal.h"
 
-#include <openssl/aes.h>
-#include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 
@@ -26,9 +24,8 @@
 #include <iostream>
 #include <memory>
 #include <sstream>
-#include <string>
-#include <vector>
 
+#include "parquet/encryption/encryption_utils.h"
 #include "parquet/encryption/openssl_internal.h"
 #include "parquet/exception.h"
 
@@ -701,85 +698,6 @@ int32_t AesDecryptor::AesDecryptorImpl::Decrypt(span<const uint8_t> ciphertext,
 
   return CtrDecrypt(ciphertext, key, plaintext);
 }
-
-static std::string ShortToBytesLe(int16_t input) {
-  int8_t output[2];
-  memset(output, 0, 2);
-  output[1] = static_cast<int8_t>(0xff & (input >> 8));
-  output[0] = static_cast<int8_t>(0xff & (input));
-
-  return std::string(reinterpret_cast<char const*>(output), 2);
-}
-
-static void CheckPageOrdinal(int32_t page_ordinal) {
-  if (ARROW_PREDICT_FALSE(page_ordinal > std::numeric_limits<int16_t>::max())) {
-    throw ParquetException("Encrypted Parquet files can't have more than " +
-                           std::to_string(std::numeric_limits<int16_t>::max()) +
-                           " pages per chunk: got " + std::to_string(page_ordinal));
-  }
-}
-
-std::string CreateModuleAad(const std::string& file_aad, int8_t module_type,
-                            int16_t row_group_ordinal, int16_t column_ordinal,
-                            int32_t page_ordinal) {
-  CheckPageOrdinal(page_ordinal);
-  const int16_t page_ordinal_short = static_cast<int16_t>(page_ordinal);
-  int8_t type_ordinal_bytes[1];
-  type_ordinal_bytes[0] = module_type;
-  std::string type_ordinal_bytes_str(reinterpret_cast<char const*>(type_ordinal_bytes),
-                                     1);
-  if (kFooter == module_type) {
-    std::string result = file_aad + type_ordinal_bytes_str;
-    return result;
-  }
-  std::string row_group_ordinal_bytes = ShortToBytesLe(row_group_ordinal);
-  std::string column_ordinal_bytes = ShortToBytesLe(column_ordinal);
-  if (kDataPage != module_type && kDataPageHeader != module_type) {
-    std::ostringstream out;
-    out << file_aad << type_ordinal_bytes_str << row_group_ordinal_bytes
-        << column_ordinal_bytes;
-    return out.str();
-  }
-  std::string page_ordinal_bytes = ShortToBytesLe(page_ordinal_short);
-  std::ostringstream out;
-  out << file_aad << type_ordinal_bytes_str << row_group_ordinal_bytes
-      << column_ordinal_bytes << page_ordinal_bytes;
-  return out.str();
-}
-
-std::string CreateFooterAad(const std::string& aad_prefix_bytes) {
-  return CreateModuleAad(aad_prefix_bytes, kFooter, static_cast<int16_t>(-1),
-                         static_cast<int16_t>(-1), static_cast<int16_t>(-1));
-}
-
-// Update last two bytes with new page ordinal (instead of creating new page AAD
-// from scratch)
-void QuickUpdatePageAad(int32_t new_page_ordinal, std::string* AAD) {
-  CheckPageOrdinal(new_page_ordinal);
-  const std::string page_ordinal_bytes =
-      ShortToBytesLe(static_cast<int16_t>(new_page_ordinal));
-  std::memcpy(AAD->data() + AAD->length() - 2, page_ordinal_bytes.data(), 2);
-}
-
-void RandBytes(unsigned char* buf, size_t num) {
-  if (num > static_cast<size_t>(std::numeric_limits<int>::max())) {
-    std::stringstream ss;
-    ss << "Length " << num << " for RandBytes overflows int";
-    throw ParquetException(ss.str());
-  }
-  openssl::EnsureInitialized();
-  int status = RAND_bytes(buf, static_cast<int>(num));
-  if (status != 1) {
-    const auto error_code = ERR_get_error();
-    char buffer[256];
-    ERR_error_string_n(error_code, buffer, sizeof(buffer));
-    std::stringstream ss;
-    ss << "Failed to generate random bytes: " << buffer;
-    throw ParquetException(ss.str());
-  }
-}
-
-void EnsureBackendInitialized() { openssl::EnsureInitialized(); }
 
 #undef ENCRYPT_INIT
 #undef DECRYPT_INIT

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -29,21 +29,6 @@ using parquet::ParquetCipher;
 
 namespace parquet::encryption {
 
-constexpr int32_t kGcmTagLength = 16;
-constexpr int32_t kNonceLength = 12;
-
-// Module types
-constexpr int8_t kFooter = 0;
-constexpr int8_t kColumnMetaData = 1;
-constexpr int8_t kDataPage = 2;
-constexpr int8_t kDictionaryPage = 3;
-constexpr int8_t kDataPageHeader = 4;
-constexpr int8_t kDictionaryPageHeader = 5;
-constexpr int8_t kColumnIndex = 6;
-constexpr int8_t kOffsetIndex = 7;
-constexpr int8_t kBloomFilterHeader = 8;
-constexpr int8_t kBloomFilterBitset = 9;
-
 /// Performs AES encryption operations with GCM or CTR ciphers.
 class PARQUET_EXPORT AesEncryptor {
  public:
@@ -117,25 +102,5 @@ class PARQUET_EXPORT AesDecryptor {
   class AesDecryptorImpl;
   std::unique_ptr<AesDecryptorImpl> impl_;
 };
-
-std::string CreateModuleAad(const std::string& file_aad, int8_t module_type,
-                            int16_t row_group_ordinal, int16_t column_ordinal,
-                            int32_t page_ordinal);
-
-std::string CreateFooterAad(const std::string& aad_prefix_bytes);
-
-// Update last two bytes of page (or page header) module AAD
-void QuickUpdatePageAad(int32_t new_page_ordinal, std::string* AAD);
-
-// Wraps OpenSSL RAND_bytes function
-void RandBytes(unsigned char* buf, size_t num);
-
-// Ensure OpenSSL is initialized.
-//
-// This is only necessary in specific situations since OpenSSL otherwise
-// initializes itself automatically. For example, under Valgrind, a memory
-// leak will be reported if OpenSSL is initialized for the first time from
-// a worker thread; calling this function from the main thread prevents this.
-void EnsureBackendInitialized();
 
 }  // namespace parquet::encryption

--- a/cpp/src/parquet/encryption/encryption_utils.cc
+++ b/cpp/src/parquet/encryption/encryption_utils.cc
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/encryption/encryption_utils.h"
+#include <openssl/err.h>
+#include <openssl/rand.h>
+#include "parquet/encryption/openssl_internal.h"
+#include "parquet/exception.h"
+
+namespace parquet::encryption {
+
+static std::string ShortToBytesLe(int16_t input) {
+  int8_t output[2];
+  memset(output, 0, 2);
+  output[1] = static_cast<int8_t>(0xff & (input >> 8));
+  output[0] = static_cast<int8_t>(0xff & (input));
+
+  return std::string(reinterpret_cast<char const*>(output), 2);
+}
+    
+static void CheckPageOrdinal(int32_t page_ordinal) {
+  if (ARROW_PREDICT_FALSE(page_ordinal > std::numeric_limits<int16_t>::max())) {
+    throw ParquetException("Encrypted Parquet files can't have more than " +
+                            std::to_string(std::numeric_limits<int16_t>::max()) +
+                            " pages per chunk: got " + std::to_string(page_ordinal));
+    }
+}
+    
+std::string CreateModuleAad(const std::string& file_aad, int8_t module_type,
+                            int16_t row_group_ordinal, int16_t column_ordinal,
+                            int32_t page_ordinal) {
+  CheckPageOrdinal(page_ordinal);
+  const int16_t page_ordinal_short = static_cast<int16_t>(page_ordinal);
+  int8_t type_ordinal_bytes[1];
+  type_ordinal_bytes[0] = module_type;
+  std::string type_ordinal_bytes_str(reinterpret_cast<char const*>(type_ordinal_bytes), 1);
+  if (kFooter == module_type) {
+    std::string result = file_aad + type_ordinal_bytes_str;
+    return result;
+  }
+  std::string row_group_ordinal_bytes = ShortToBytesLe(row_group_ordinal);
+  std::string column_ordinal_bytes = ShortToBytesLe(column_ordinal);
+  if (kDataPage != module_type && kDataPageHeader != module_type) {
+    std::ostringstream out;
+    out << file_aad << type_ordinal_bytes_str << row_group_ordinal_bytes
+        << column_ordinal_bytes;
+    return out.str();
+  }
+  std::string page_ordinal_bytes = ShortToBytesLe(page_ordinal_short);
+  std::ostringstream out;
+  out << file_aad << type_ordinal_bytes_str << row_group_ordinal_bytes
+      << column_ordinal_bytes << page_ordinal_bytes;
+  return out.str();
+}
+    
+std::string CreateFooterAad(const std::string& aad_prefix_bytes) {
+  return CreateModuleAad(aad_prefix_bytes, kFooter, static_cast<int16_t>(-1),
+                         static_cast<int16_t>(-1), static_cast<int16_t>(-1));
+}
+    
+// Update last two bytes with new page ordinal (instead of creating new page AAD from scratch)
+void QuickUpdatePageAad(int32_t new_page_ordinal, std::string* AAD) {
+  CheckPageOrdinal(new_page_ordinal);
+  const std::string page_ordinal_bytes =
+    ShortToBytesLe(static_cast<int16_t>(new_page_ordinal));
+  std::memcpy(AAD->data() + AAD->length() - 2, page_ordinal_bytes.data(), 2);
+}
+    
+void RandBytes(unsigned char* buf, size_t num) {
+  if (num > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    std::stringstream ss;
+    ss << "Length " << num << " for RandBytes overflows int";
+    throw ParquetException(ss.str());
+  }
+  openssl::EnsureInitialized();
+  int status = RAND_bytes(buf, static_cast<int>(num));
+  if (status != 1) {
+    const auto error_code = ERR_get_error();
+    char buffer[256];
+    ERR_error_string_n(error_code, buffer, sizeof(buffer));
+    std::stringstream ss;
+    ss << "Failed to generate random bytes: " << buffer;
+    throw ParquetException(ss.str());
+  }
+}
+    
+void EnsureBackendInitialized() { openssl::EnsureInitialized(); }
+
+} // namespace parquet::encryption

--- a/cpp/src/parquet/encryption/encryption_utils.h
+++ b/cpp/src/parquet/encryption/encryption_utils.h
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace parquet::encryption {
+
+constexpr int32_t kGcmTagLength = 16;
+constexpr int32_t kNonceLength = 12;
+
+// Module types
+constexpr int8_t kFooter = 0;
+constexpr int8_t kColumnMetaData = 1;
+constexpr int8_t kDataPage = 2;
+constexpr int8_t kDictionaryPage = 3;
+constexpr int8_t kDataPageHeader = 4;
+constexpr int8_t kDictionaryPageHeader = 5;
+constexpr int8_t kColumnIndex = 6;
+constexpr int8_t kOffsetIndex = 7;
+constexpr int8_t kBloomFilterHeader = 8;
+constexpr int8_t kBloomFilterBitset = 9;
+
+std::string CreateModuleAad(const std::string& file_aad, int8_t module_type,
+    int16_t row_group_ordinal, int16_t column_ordinal,
+    int32_t page_ordinal);
+
+std::string CreateFooterAad(const std::string& aad_prefix_bytes);
+
+// Update last two bytes of page (or page header) module AAD
+void QuickUpdatePageAad(int32_t new_page_ordinal, std::string* AAD);
+
+// Wraps OpenSSL RAND_bytes function
+void RandBytes(unsigned char* buf, size_t num);
+
+// Ensure OpenSSL is initialized.
+//
+// This is only necessary in specific situations since OpenSSL otherwise
+// initializes itself automatically. For example, under Valgrind, a memory
+// leak will be reported if OpenSSL is initialized for the first time from
+// a worker thread; calling this function from the main thread prevents this.
+void EnsureBackendInitialized();
+
+} // namespace parquet::encryption

--- a/cpp/src/parquet/encryption/file_key_wrapper.cc
+++ b/cpp/src/parquet/encryption/file_key_wrapper.cc
@@ -16,7 +16,7 @@
 // under the License.
 
 #include "parquet/encryption/file_key_wrapper.h"
-#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/encryption_utils.h"
 #include "parquet/encryption/key_material.h"
 #include "parquet/encryption/key_metadata.h"
 #include "parquet/encryption/key_toolkit_internal.h"

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -20,6 +20,7 @@
 #include "arrow/util/logging.h"
 #include "parquet/encryption/encryption.h"
 #include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/encryption_utils.h"
 #include "parquet/metadata.h"
 
 namespace parquet {

--- a/cpp/src/parquet/encryption/internal_file_encryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.cc
@@ -18,6 +18,7 @@
 #include "parquet/encryption/internal_file_encryptor.h"
 #include "parquet/encryption/encryption.h"
 #include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/encryption_utils.h"
 
 namespace parquet {
 

--- a/cpp/src/parquet/encryption/internal_file_encryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.h
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "parquet/encryption/encryption.h"
+#include "parquet/encryption/encryption_internal.h"
 #include "parquet/metadata.h"
 
 namespace parquet {

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -40,7 +40,7 @@
 #include "parquet/bloom_filter_reader.h"
 #include "parquet/column_reader.h"
 #include "parquet/column_scanner.h"
-#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/encryption_utils.h"
 #include "parquet/encryption/internal_file_decryptor.h"
 #include "parquet/exception.h"
 #include "parquet/file_writer.h"

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -26,7 +26,6 @@
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging_internal.h"
 #include "parquet/column_writer.h"
-#include "parquet/encryption/encryption_internal.h"
 #include "parquet/encryption/internal_file_encryptor.h"
 #include "parquet/exception.h"
 #include "parquet/page_index.h"

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -33,6 +33,7 @@
 #include "arrow/util/logging_internal.h"
 #include "arrow/util/pcg_random.h"
 #include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/encryption_utils.h"
 #include "parquet/encryption/internal_file_decryptor.h"
 #include "parquet/exception.h"
 #include "parquet/schema.h"

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -17,7 +17,7 @@
 
 #include "parquet/page_index.h"
 #include "parquet/encoding.h"
-#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/encryption_utils.h"
 #include "parquet/encryption/internal_file_decryptor.h"
 #include "parquet/encryption/internal_file_encryptor.h"
 #include "parquet/exception.h"


### PR DESCRIPTION
Preparing for the AesEncryptor and AesDecryptor refactor.

Currently these are defined in encryption_internal.h and encryptor_internal.cc

Since Arrow assumes these are the only encryptor/decryptor pair available, there are some common utility functions within that file.

Taking those util functions out of there in preparation for the next step, which is making AesEncryptor and AesDecryptor subclasses of the more general EncryptorInterface.

Verified all tests pass.