### PR TITLE
Refactor aes encryptor

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -238,7 +238,7 @@ endif()
 
 if(PARQUET_REQUIRE_ENCRYPTION)
   list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS ${ARROW_OPENSSL_LIBS})
-  set(PARQUET_SRCS ${PARQUET_SRCS} encryption/encryption_internal.cc
+  set(PARQUET_SRCS ${PARQUET_SRCS} encryption/aes_encryption.cc
                    encryption/encryption_utils.cc
                    encryption/openssl_internal.cc)
   # Encryption key management

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -255,7 +255,7 @@ if(PARQUET_REQUIRE_ENCRYPTION)
       encryption/key_toolkit_internal.cc
       encryption/local_wrap_kms_client.cc)
 else()
-  set(PARQUET_SRCS ${PARQUET_SRCS} encryption/encryption_internal_nossl.cc)
+  set(PARQUET_SRCS ${PARQUET_SRCS} encryption/aes_encryption_nossl.cc)
 endif()
 
 if(NOT PARQUET_MINIMAL_DEPENDENCY)
@@ -410,7 +410,7 @@ add_parquet_test(arrow-internals-test SOURCES arrow/path_internal_test.cc
 if(PARQUET_REQUIRE_ENCRYPTION)
   add_parquet_test(encryption-test
                    SOURCES
-                   encryption/encryption_internal_test.cc
+                   encryption/aes_encryption_test.cc
                    encryption/write_configurations_test.cc
                    encryption/read_configurations_test.cc
                    encryption/properties_test.cc

--- a/cpp/src/parquet/encryption/aes_encryption.cc
+++ b/cpp/src/parquet/encryption/aes_encryption.cc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/aes_encryption.h"
 
 #include <openssl/evp.h>
 #include <openssl/rand.h>

--- a/cpp/src/parquet/encryption/aes_encryption.h
+++ b/cpp/src/parquet/encryption/aes_encryption.h
@@ -18,11 +18,8 @@
 #pragma once
 
 #include <memory>
-#include <string>
-#include <vector>
 
 #include "arrow/util/span.h"
-#include "parquet/properties.h"
 #include "parquet/types.h"
 
 using parquet::ParquetCipher;

--- a/cpp/src/parquet/encryption/aes_encryption_nossl.cc
+++ b/cpp/src/parquet/encryption/aes_encryption_nossl.cc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/aes_encryption.h"
 #include "parquet/exception.h"
 
 namespace parquet::encryption {

--- a/cpp/src/parquet/encryption/aes_encryption_test.cc
+++ b/cpp/src/parquet/encryption/aes_encryption_test.cc
@@ -17,7 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/aes_encryption.h"
+#include "parquet/encryption/encryption.h"
 
 namespace parquet::encryption::test {
 

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -18,8 +18,8 @@
 #include "parquet/encryption/internal_file_decryptor.h"
 
 #include "arrow/util/logging.h"
+#include "parquet/encryption/aes_encryption.h"
 #include "parquet/encryption/encryption.h"
-#include "parquet/encryption/encryption_internal.h"
 #include "parquet/encryption/encryption_utils.h"
 #include "parquet/metadata.h"
 

--- a/cpp/src/parquet/encryption/internal_file_encryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.cc
@@ -16,8 +16,9 @@
 // under the License.
 
 #include "parquet/encryption/internal_file_encryptor.h"
+
+#include "parquet/encryption/aes_encryption.h"
 #include "parquet/encryption/encryption.h"
-#include "parquet/encryption/encryption_internal.h"
 #include "parquet/encryption/encryption_utils.h"
 
 namespace parquet {

--- a/cpp/src/parquet/encryption/internal_file_encryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.h
@@ -21,8 +21,8 @@
 #include <memory>
 #include <string>
 
+#include "parquet/encryption/aes_encryption.h"
 #include "parquet/encryption/encryption.h"
-#include "parquet/encryption/encryption_internal.h"
 #include "parquet/metadata.h"
 
 namespace parquet {

--- a/cpp/src/parquet/encryption/key_toolkit_internal.cc
+++ b/cpp/src/parquet/encryption/key_toolkit_internal.cc
@@ -17,7 +17,8 @@
 
 #include "arrow/util/base64.h"
 
-#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/aes_encryption.h"
+#include "parquet/encryption/encryption_utils.h"
 #include "parquet/encryption/key_toolkit_internal.h"
 
 namespace parquet::encryption::internal {

--- a/cpp/src/parquet/encryption/key_toolkit_internal.cc
+++ b/cpp/src/parquet/encryption/key_toolkit_internal.cc
@@ -17,8 +17,8 @@
 
 #include "arrow/util/base64.h"
 
+#include "parquet/encryption/encryption.h"
 #include "parquet/encryption/aes_encryption.h"
-#include "parquet/encryption/encryption_utils.h"
 #include "parquet/encryption/key_toolkit_internal.h"
 
 namespace parquet::encryption::internal {

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -32,7 +32,7 @@
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging_internal.h"
 #include "arrow/util/pcg_random.h"
-#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/aes_encryption.h"
 #include "parquet/encryption/encryption_utils.h"
 #include "parquet/encryption/internal_file_decryptor.h"
 #include "parquet/exception.h"


### PR DESCRIPTION
Continuing with the AesEncryptor refactor.

In this next step I rename everything related to encryption_internal as aes_encryption.

Updating all the includes, tests and CMake files.

Verified all encryption unit tests work:
parquet-encryption-key-management-test
parquet-encryption-test

This removes a lot of confusion, as there are encryption_internal and internal_file_encryptor files. 

In the next PR I can make the intended change, which is to have the AesEncryptors inherit from the new EncryptorInterface.