### PR TITLE
[miniApp] Python/Cython modifications to enable decryption workflow from App

### DIFF
--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -439,21 +439,20 @@ cdef class CryptoFactory(_Weakrefable):
     def file_decryption_properties(
             self,
             KmsConnectionConfig kms_connection_config,
-            DecryptionConfiguration decryption_config=None):
-        """Create file decryption properties.
+            DecryptionConfiguration decryption_config = None):
+        """
+        Get file decryption properties.
 
         Parameters
         ----------
         kms_connection_config : KmsConnectionConfig
-            Configuration of connection to KMS
-
-        decryption_config : DecryptionConfiguration, default None
-            Configuration of the decryption, such as cache timeout.
-            Can be None.
+            KMS connection configuration.
+        decryption_config : DecryptionConfiguration, optional
+            Decryption configuration.
 
         Returns
         -------
-        file_decryption_properties : FileDecryptionProperties
+        FileDecryptionProperties
             File decryption properties.
         """
         cdef:
@@ -469,6 +468,45 @@ cdef class CryptoFactory(_Weakrefable):
                 self.factory.get().SafeGetFileDecryptionProperties(
                     deref(kms_connection_config.unwrap().get()),
                     c_decryption_config)
+        file_decryption_properties = GetResultValue(
+            c_file_decryption_properties)
+        return FileDecryptionProperties.wrap(file_decryption_properties)
+
+    def external_file_decryption_properties(
+            self,
+            KmsConnectionConfig kms_connection_config,
+            DecryptionConfiguration decryption_config,
+            ExternalEncryptionConfiguration external_encryption_config,
+            ExternalConnectionConfiguration external_connection_config):
+        """
+        Get external file decryption properties.
+
+        Parameters
+        ----------
+        kms_connection_config : KmsConnectionConfig
+            KMS connection configuration.
+        decryption_config : DecryptionConfiguration
+            Decryption configuration.
+        external_encryption_config : ExternalEncryptionConfiguration
+            External encryption configuration.
+        external_connection_config : ExternalConnectionConfiguration
+            External connection configuration.
+
+        Returns
+        -------
+        FileDecryptionProperties
+            File decryption properties.
+        """
+        cdef:
+            CResult[shared_ptr[CFileDecryptionProperties]] \
+                c_file_decryption_properties
+        with nogil:
+            c_file_decryption_properties = \
+                self.factory.get().SafeGetExternalFileDecryptionProperties(
+                    deref(kms_connection_config.unwrap().get()),
+                    deref(decryption_config.unwrap().get()),
+                    deref(external_encryption_config.unwrap().get()),
+                    deref(external_connection_config.unwrap().get()))
         file_decryption_properties = GetResultValue(
             c_file_decryption_properties)
         return FileDecryptionProperties.wrap(file_decryption_properties)

--- a/python/pyarrow/includes/libparquet_encryption.pxd
+++ b/python/pyarrow/includes/libparquet_encryption.pxd
@@ -159,3 +159,9 @@ cdef extern from "arrow/python/parquet_encryption.h" \
             SafeGetFileDecryptionProperties(
             const CKmsConnectionConfig& kms_connection_config,
             const CDecryptionConfiguration& decryption_config)
+        CResult[shared_ptr[CFileDecryptionProperties]] \
+            SafeGetExternalFileDecryptionProperties(
+            const CKmsConnectionConfig& kms_connection_config,
+            const CDecryptionConfiguration& decryption_config,
+            const CExternalEncryptionConfiguration& external_encryption_config,
+            const CExternalConnectionConfiguration& external_connection_config)

--- a/python/pyarrow/src/arrow/python/parquet_encryption.cc
+++ b/python/pyarrow/src/arrow/python/parquet_encryption.cc
@@ -106,6 +106,20 @@ PyCryptoFactory::SafeGetFileDecryptionProperties(
       this->GetFileDecryptionProperties(kms_connection_config, decryption_config));
 }
 
+arrow::Result<std::shared_ptr<::parquet::FileDecryptionProperties>>
+PyCryptoFactory::SafeGetExternalFileDecryptionProperties(
+    const ::parquet::encryption::KmsConnectionConfig& kms_connection_config,
+    const ::parquet::encryption::DecryptionConfiguration& decryption_config,
+    const ::parquet::encryption::ExternalEncryptionConfiguration& external_encryption_config,
+    const ::parquet::encryption::ExternalConnectionConfiguration& external_connection_config) {
+  PARQUET_CATCH_AND_RETURN(
+      this->GetExternalFileDecryptionProperties(
+          kms_connection_config,
+          decryption_config,
+          external_encryption_config,
+          external_connection_config));
+}
+
 }  // namespace encryption
 }  // namespace parquet
 }  // namespace py

--- a/python/pyarrow/src/arrow/python/parquet_encryption.h
+++ b/python/pyarrow/src/arrow/python/parquet_encryption.h
@@ -132,6 +132,17 @@ class ARROW_PYTHON_PARQUET_ENCRYPTION_EXPORT PyCryptoFactory
   SafeGetFileDecryptionProperties(
       const ::parquet::encryption::KmsConnectionConfig& kms_connection_config,
       const ::parquet::encryption::DecryptionConfiguration& decryption_config);
+
+  /// The returned FileDecryptionProperties object will use the cache inside this
+  /// CryptoFactory object, so please keep this
+  /// CryptoFactory object alive along with the returned
+  /// FileDecryptionProperties object.
+  arrow::Result<std::shared_ptr<::parquet::FileDecryptionProperties>>
+  SafeGetExternalFileDecryptionProperties(
+      const ::parquet::encryption::KmsConnectionConfig& kms_connection_config,
+      const ::parquet::encryption::DecryptionConfiguration& decryption_config,
+      const ::parquet::encryption::ExternalEncryptionConfiguration& external_encryption_config,
+      const ::parquet::encryption::ExternalConnectionConfiguration& external_connection_config);
 };
 
 }  // namespace encryption


### PR DESCRIPTION
In this PR, we extend the Python+Cython code to enable the Decryption workflow for the miniApp.
Most of this code will not make it into `protegrity/main` nor into `dev_phase2`.

This code was mostly auto-generated by an LLM.