### PR TITLE
Fixing compiler warning/error around int precision loss

### DIFF
--- a/cpp/src/parquet/encryption/internal_file_encryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.cc
@@ -151,7 +151,7 @@ encryption::EncryptorInterface* InternalFileEncryptor::GetDataEncryptor(
         algorithm, column_chunk_metadata,
         dynamic_cast<ExternalFileEncryptionProperties*>(properties_));
   }
-  return aes_encryptor_factory_.GetDataAesEncryptor(algorithm, key_size);
+  return aes_encryptor_factory_.GetDataAesEncryptor(algorithm, static_cast<int32_t>(key_size));
 }
 
 }  // namespace parquet


### PR DESCRIPTION
@cristekdatum is reporting a local build error that also makes some actions fail with:
dev-phase2/cpp/src/parquet/encryption/internal_file_encryptor.cc:154:64: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int32_t' (aka 'int') [-Werror,-Wshorten-64-to-32]
  return aes_encryptor_factory_.GetDataAesEncryptor(algorithm, key_size);

My local build works, but adding an explicit cast to fix others.