### PR TITLE
Extracting keyid from key metadata

### DIFF
--- a/cpp/src/parquet/encryption/external_dbpa_encryption.cc
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "parquet/encryption/external_dbpa_encryption.h"
+#include "parquet/encryption/key_metadata.h"
 
 /// TODO(sbrenes): Add proper implementation. Right now we are just going to return
 /// the plaintext as the ciphertext.
@@ -97,7 +98,14 @@ ExternalDBPAEncryptorAdapter* ExternalDBPAEncryptorAdapterFactory::GetEncryptor(
     auto encoding_type = column_chunk_metadata->properties()->encoding(column_path);
     auto app_context = external_file_encryption_properties->app_context();
     auto connection_config_for_algorithm = connection_config.at(algorithm);
-    auto key_id = column_encryption_properties->key_metadata();
+
+    std::string key_id;
+    try {
+      auto key_metadata = KeyMetadata::Parse(column_encryption_properties->key_metadata());
+      key_id = key_metadata.key_material().master_key_id();
+    } catch (const ParquetException& e) {
+      key_id = column_encryption_properties->key_metadata();
+    }
 
     encryptor_cache_[column_path->ToDotString()] = ExternalDBPAEncryptorAdapter::Make(
         algorithm, column_path->ToDotString(), key_id, data_type, compression_type,
@@ -188,10 +196,17 @@ std::unique_ptr<DecryptorInterface> ExternalDBPADecryptorAdapterFactory::GetDecr
     auto encoding_types = column_chunk_metadata->encodings();
     auto app_context = external_file_decryption_properties->app_context();
     auto connection_config_for_algorithm = connection_config.at(algorithm);
-    auto key_metadata =crypto_metadata->key_metadata();
+
+    std::string key_id;
+    try {
+      auto key_metadata = KeyMetadata::Parse(crypto_metadata->key_metadata());
+      key_id = key_metadata.key_material().master_key_id();
+    } catch (const ParquetException& e) {
+      key_id = crypto_metadata->key_metadata();
+    }
 
     return ExternalDBPADecryptorAdapter::Make(
-        algorithm, column_path->ToDotString(), key_metadata, data_type, compression_type,
+        algorithm, column_path->ToDotString(), key_id, data_type, compression_type,
         encoding_types, app_context, connection_config_for_algorithm);
  }
 


### PR DESCRIPTION
Extract the key id (which is what ExternalDBPAAdapters use) from the key metadata.

In CryptoFactory, we currently always try to resolve the keys with a KMS. This will construct a key information string that includes wrapped keys, metadata, master keys, etc. 

The real key id is left in the master key id field. Extract this to send the correct expected value to DBPA.

In the future, we need to decide if we'll always try to resolve this key with KMS or if we want different behavior.