### PR TITLE
Modifying how the External*PropertiesBuilders in tests

### DIFF
--- a/cpp/src/parquet/encryption/properties_test.cc
+++ b/cpp/src/parquet/encryption/properties_test.cc
@@ -440,12 +440,12 @@ TEST(TestExternalFileDecryptionProperties, SuperClassFieldsSetCorrectly) {
   std::shared_ptr<parquet::DecryptionKeyRetriever> kr1 =
       std::static_pointer_cast<parquet::StringKeyIdRetriever>(string_kr1);
   
-  parquet::ExternalFileDecryptionProperties::Builder* builder =
-      parquet::ExternalFileDecryptionProperties::Builder()
-          .footer_key(kFooterEncryptionKey)
-          ->plaintext_files_allowed()
-          ->key_retriever(kr1);
-  std::shared_ptr<parquet::ExternalFileDecryptionProperties> props = builder->build_external();
+
+  auto builder = parquet::ExternalFileDecryptionProperties::Builder();
+  builder.footer_key(kFooterEncryptionKey);
+  builder.plaintext_files_allowed();
+  builder.key_retriever(kr1);
+  std::shared_ptr<parquet::ExternalFileDecryptionProperties> props = builder.build_external();
 
   ASSERT_EQ(true, props->plaintext_files_allowed());
   ASSERT_EQ(kFooterEncryptionKey, props->footer_key());
@@ -474,13 +474,12 @@ TEST(TestExternalFileDecryptionProperties, SetExternalContextAndConfig) {
   inner_config["config_file"] = "path/to/config/file";
   connection_config[ParquetCipher::AES_GCM_CTR_V1] = inner_config;
 
-  ExternalFileDecryptionProperties::Builder builder;
+  auto builder = parquet::ExternalFileDecryptionProperties::Builder();
+  builder.footer_key(kFooterEncryptionKey);
   builder.app_context(app_context);
   builder.connection_config(connection_config);
-    
   std::shared_ptr<parquet::ExternalFileDecryptionProperties> props = builder.build_external();
   
-
   ASSERT_EQ(false, props->app_context().empty());
   ASSERT_EQ(app_context, props->app_context());
   ASSERT_EQ(false, props->connection_config().size() == 0);


### PR DESCRIPTION
Modifying how the `External*PropertiesBuilders` are used to prevent issues with eager de-allocation of the builder (due to it being considered a temporary object). This only affects the tests today.

Further explanation below (original code to help illustrate)

```
[443]  parquet::ExternalFileDecryptionProperties::Builder* builder =
[444]      parquet::ExternalFileDecryptionProperties::Builder()
[445]          .footer_key(kFooterEncryptionKey)
[446]          ->plaintext_files_allowed()
[447]          ->key_retriever(kr1);
[448]  std::shared_ptr<parquet::ExternalFileDecryptionProperties> props = builder->build_external();
```
The `builder` instance generated in line 443 is considered by the C++ compiler a "temporary object". There is no guarantee that temporary objects will survive the expression which created them (i.e. lines 443-447 in this case). For this reason, at the time that the `builder` is used in line 448, the compiler may have de-allocated it from memory. This was observed to cause issues (because of accessing de-allocated memory) while running the tests on some systems (in this case, inside the dev Docker image). 

The changes to the code eliminate the creation of `builder` as a temporary object.

Additional references (each with their own degree of being confusing :) ):

- https://en.cppreference.com/w/cpp/language/lifetime.html
- https://lesleylai.info/en/temporaries
- https://stackoverflow.com/questions/2506793/what-is-the-lifetime-of-temporary-function-arguments/2506800#2506800