### PR TITLE
Adding parquet/encryption/external/dbpa_library_wrapper.*

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -241,7 +241,9 @@ if(PARQUET_REQUIRE_ENCRYPTION)
   set(PARQUET_SRCS ${PARQUET_SRCS} encryption/aes_encryption.cc
                    encryption/encryption_utils.cc
                    encryption/external_dbpa_encryption.cc
-                   encryption/openssl_internal.cc)
+                   encryption/openssl_internal.cc
+                   encryption/external/dbpa_library_wrapper.cc
+                   )
   # Encryption key management
   set(PARQUET_SRCS
       ${PARQUET_SRCS}

--- a/cpp/src/parquet/encryption/CMakeLists.txt
+++ b/cpp/src/parquet/encryption/CMakeLists.txt
@@ -17,3 +17,12 @@
 
 # Headers: public api
 arrow_install_all_headers("parquet/encryption")
+
+if(ARROW_TESTING)
+  
+  # Add test for DBPALibraryWrapper
+  add_parquet_test(dbpa-library-wrapper-test
+                   SOURCES external/dbpa_library_wrapper_test.cc
+                   LABELS "parquet-tests" "encryption-tests")
+  
+endif()

--- a/cpp/src/parquet/encryption/external/dbpa_library_wrapper.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_library_wrapper.cc
@@ -1,0 +1,70 @@
+//TODO: figure out the licensing.
+
+#include "parquet/encryption/external/dbpa_library_wrapper.h"
+#include "parquet/encryption/external/third_party/dbpa_interface.h"
+
+#include <stdexcept>
+#include <functional>
+
+#include <iostream>
+
+#include "arrow/util/io_util.h"
+
+namespace parquet::encryption::external {
+
+// Default implementation for handle closing function
+void DefaultSharedLibraryClosingFn(void* library_handle) {
+  auto status = arrow::internal::CloseDynamicLibrary(library_handle);
+  if (!status.ok()) {
+    std::cerr << "Error closing library: " << status.message() << std::endl;
+  }
+}
+
+DBPALibraryWrapper::DBPALibraryWrapper(
+    std::unique_ptr<DataBatchProtectionAgentInterface> agent,
+    void* library_handle,
+    std::function<void(void*)> handle_closing_fn)
+    : wrapped_agent_(std::move(agent)), 
+      library_handle_(library_handle),
+      handle_closing_fn_(std::move(handle_closing_fn)) {
+  // Ensure the wrapped agent is not null
+  if (!wrapped_agent_) {
+    throw std::invalid_argument("DBPAWrapper: Cannot create wrapper with null agent");
+  }
+  if (!library_handle_) {
+    throw std::invalid_argument("DBPAWrapper: Cannot create wrapper with null library handle");
+  }
+  if (!handle_closing_fn_) {
+    throw std::invalid_argument("DBPAWrapper: Cannot create wrapper with null handle closing function");
+  }
+
+  std::cout << "DBPALibraryWrapper::DBPALibraryWrapper" << std::endl;
+  std::cout << "  wrapped_agent_ = " << (wrapped_agent_ ? "valid" : "null") << " (address: " << static_cast<void*>(wrapped_agent_.get()) << ")" << std::endl;
+  std::cout << "  library_handle_ = " << library_handle_ << std::endl;
+}
+
+// DBPALibraryWrapper destructor
+// This is the main reason for the decorator/wrapper.
+// This will (a) destroy the wrapped agent, and (b) close the shared library.
+// While the wrapped_agent_ would automatically be destroyed when this object is destroyed
+// we need to explicitly destroy **before** we are able to close the shared library.
+// Doing it in a different order, may cause issues, as by unloading the library may cause the class
+// definition to be unloaded before the destructor completes, and that is likely to cause issues 
+// (such as a segfault).
+DBPALibraryWrapper::~DBPALibraryWrapper() {
+
+  std::cout << "DBPALibraryWrapper::~DBPALibraryWrapper" << std::endl;
+  std::cout << "  wrapped_agent_ = " << (wrapped_agent_ ? "valid" : "null") << " (address: " << static_cast<void*>(wrapped_agent_.get()) << ")" << std::endl;
+  std::cout << "  library_handle_ = " << library_handle_ << std::endl;
+
+  // Explicitly destroy the wrapped agent first
+  if (wrapped_agent_) {
+    DataBatchProtectionAgentInterface* wrapped_agent = wrapped_agent_.release();
+    delete wrapped_agent;
+  }
+  
+  // Now we can close the shared library using the provided function
+  handle_closing_fn_(library_handle_);
+  library_handle_ = nullptr;
+} //DBPALibraryWrapper::~DBPALibraryWrapper()
+}  // namespace parquet::encryption::external

--- a/cpp/src/parquet/encryption/external/dbpa_library_wrapper.h
+++ b/cpp/src/parquet/encryption/external/dbpa_library_wrapper.h
@@ -1,0 +1,82 @@
+//TODO: figure out the licensing.
+
+#pragma once
+
+#include <memory>
+#include <functional>
+
+#include "parquet/encryption/external/third_party/dbpa_interface.h"
+#include "parquet/encryption/external/third_party/span.hpp"
+
+template <typename T>
+using span = tcb::span<T>;
+
+namespace parquet::encryption::external {
+
+using dbps::external::DataBatchProtectionAgentInterface;
+using dbps::external::EncryptionResult;
+using dbps::external::DecryptionResult;
+using dbps::external::Type;
+using dbps::external::CompressionCodec;  
+
+// Default implementation for shared library closing function
+// This is passed into the constructor of DBPALibraryWrapper, 
+// and is used as the default function to close the shared library.
+void DefaultSharedLibraryClosingFn(void* library_handle);
+
+// Decorator/Wrapper class for the DataBatchProtectionAgentInterface
+// Its main purpose is to close the shared library when Arrow is about to destroy 
+// an instance of an DBPAgent
+//
+// In the constructor we allow to pass a function that will be used to close the shared library.
+// This simplifies testing, as we can use a mock function to avoid actually closing the shared library.
+class DBPALibraryWrapper : public DataBatchProtectionAgentInterface {
+ private:
+  std::unique_ptr<DataBatchProtectionAgentInterface> wrapped_agent_;
+  void* library_handle_;
+  std::function<void(void*)> handle_closing_fn_;
+
+ public:
+  // Constructor that takes ownership of the wrapped agent
+  explicit DBPALibraryWrapper(
+      std::unique_ptr<DataBatchProtectionAgentInterface> agent,
+      void* library_handle,
+      std::function<void(void*)> handle_closing_fn = &DefaultSharedLibraryClosingFn);
+
+  // Destructor
+  // This is the main reason for the decorator/wrapper.
+  // This will (a) destroy the wrapped agent, and (b) close the shared library.
+  // While the wrapped_agent_ would automatically be destroyed when this object is destroyed
+  // we need to explicitly destroy **before** we are able to close the shared library.
+  // Doing it in a different order, may cause issues, as by unloading the library may cause the class
+  // definition to be unloaded before the destructor completes, and that is likely to cause issues 
+  // (such as a segfault).
+  ~DBPALibraryWrapper();
+
+  // Decorator implementation of init method
+  inline void init(
+      std::string column_name,
+      std::map<std::string, std::string> connection_config,
+      std::string app_context,
+      std::string column_key_id,
+      Type::type data_type,
+      CompressionCodec::type compression_type) override {
+    wrapped_agent_->init(std::move(column_name), std::move(connection_config),
+                        std::move(app_context), std::move(column_key_id),
+                        data_type, compression_type);
+  }
+
+  // Decorator implementation of Encrypt method - inlined for performance
+  inline std::unique_ptr<EncryptionResult> Encrypt(
+      span<const uint8_t> plaintext) override {
+    return wrapped_agent_->Encrypt(plaintext);
+  }
+
+  // Decorator implementation of Decrypt method - inlined for performance
+  inline std::unique_ptr<DecryptionResult> Decrypt(
+      span<const uint8_t> ciphertext) override {
+    return wrapped_agent_->Decrypt(ciphertext);
+  }
+};
+
+}  // namespace parquet::encryption::external

--- a/cpp/src/parquet/encryption/external/dbpa_library_wrapper_test.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_library_wrapper_test.cc
@@ -1,0 +1,975 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+#include <functional>
+#include <map>
+
+#include "gtest/gtest.h"
+#include "parquet/encryption/external/third_party/dbpa_interface.h"
+#include "parquet/encryption/external/dbpa_library_wrapper.h"
+
+#include "parquet/test_util.h"
+#include "parquet/encryption/external/third_party/span.hpp"
+
+template <typename T>
+using span = tcb::span<T>;
+
+namespace parquet::encryption::external::test {
+
+using dbps::external::EncryptionResult;
+using dbps::external::DecryptionResult;
+using dbps::external::Type;
+using dbps::external::CompressionCodec;
+  
+// Simple implementation of EncryptionResult for testing
+class TestEncryptionResult : public EncryptionResult {
+public:
+    TestEncryptionResult(std::vector<uint8_t> data, bool success = true, 
+                        std::string error_msg = "", 
+                        std::map<std::string, std::string> error_fields = {})
+        : ciphertext_data_(std::move(data)), success_(success), 
+          error_message_(std::move(error_msg)), error_fields_(std::move(error_fields)) {}
+
+    span<const uint8_t> ciphertext() const override {
+        return span<const uint8_t>(ciphertext_data_.data(), ciphertext_data_.size());
+    }
+
+    std::size_t size() const override { return ciphertext_data_.size(); }
+    bool success() const override { return success_; }
+    const std::string& error_message() const override { return error_message_; }
+    const std::map<std::string, std::string>& error_fields() const override { return error_fields_; }
+
+private:
+    std::vector<uint8_t> ciphertext_data_;
+    bool success_;
+    std::string error_message_;
+    std::map<std::string, std::string> error_fields_;
+};
+
+// Simple implementation of DecryptionResult for testing
+class TestDecryptionResult : public DecryptionResult {
+public:
+    TestDecryptionResult(std::vector<uint8_t> data, bool success = true, 
+                        std::string error_msg = "", 
+                        std::map<std::string, std::string> error_fields = {})
+        : plaintext_data_(std::move(data)), success_(success), 
+          error_message_(std::move(error_msg)), error_fields_(std::move(error_fields)) {}
+
+    span<const uint8_t> plaintext() const override {
+        return span<const uint8_t>(plaintext_data_.data(), plaintext_data_.size());
+    }
+
+    std::size_t size() const override { return plaintext_data_.size(); }
+    bool success() const override { return success_; }
+    const std::string& error_message() const override { return error_message_; }
+    const std::map<std::string, std::string>& error_fields() const override { return error_fields_; }
+
+private:
+    std::vector<uint8_t> plaintext_data_;
+    bool success_;
+    std::string error_message_;
+    std::map<std::string, std::string> error_fields_;
+};
+
+// Companion object to track the order of destruction events
+class DestructionOrderTracker {
+ public:
+  DestructionOrderTracker() : sequence_counter_(0) {}
+  
+  // Record an event with a sequence number
+  void RecordEvent(const std::string& event_name) {
+    events_.emplace_back(event_name, ++sequence_counter_);
+  }
+  
+  // Get the sequence number for a specific event
+  int GetEventSequence(const std::string& event_name) const {
+    for (const auto& event : events_) {
+      if (event.first == event_name) {
+        return event.second;
+      }
+    }
+    return -1; // Event not found
+  }
+  
+  // Verify that first_event occurred before second_event
+  bool VerifyOrder(const std::string& first_event, const std::string& second_event) const {
+    int first_seq = GetEventSequence(first_event);
+    int second_seq = GetEventSequence(second_event);
+    
+    if (first_seq == -1 || second_seq == -1) {
+      return false; // One or both events not recorded
+    }
+    
+    return first_seq < second_seq;
+  }
+  
+  // Get all recorded events in order
+  const std::vector<std::pair<std::string, int>>& GetEvents() const {
+    return events_;
+  }
+  
+  // Clear all recorded events
+  void Clear() {
+    events_.clear();
+    sequence_counter_ = 0;
+  }
+  
+  // Check if an event was recorded
+  bool WasEventRecorded(const std::string& event_name) const {
+    return GetEventSequence(event_name) != -1;
+  }
+
+ private:
+  std::vector<std::pair<std::string, int>> events_;
+  int sequence_counter_;
+}; //DestructionOrderTracker
+
+// Companion object to hold mock state that persists after mock instance destruction
+class MockCompanionDBPA {
+ public:
+  MockCompanionDBPA(std::shared_ptr<DestructionOrderTracker> order_tracker = nullptr) 
+      : encrypt_called_(false), 
+        decrypt_called_(false),
+        init_called_(false),
+        destructor_called_(false),
+        encrypt_count_(0),
+        decrypt_count_(0),
+        init_count_(0),
+        order_tracker_(order_tracker ? order_tracker : std::make_shared<DestructionOrderTracker>()) {}
+  
+  // Test helper methods
+  bool WasEncryptCalled() const { return encrypt_called_; }
+  bool WasDecryptCalled() const { return decrypt_called_; }
+  bool WasInitCalled() const { return init_called_; }
+  bool WasDestructorCalled() const { return destructor_called_; }
+  int GetEncryptCount() const { return encrypt_count_; }
+  int GetDecryptCount() const { return decrypt_count_; }
+  int GetInitCount() const { return init_count_; }
+  const std::vector<uint8_t>& GetEncryptPlaintext() const { return encrypt_plaintext_; }
+  const std::vector<uint8_t>& GetDecryptCiphertext() const { return decrypt_ciphertext_; }
+  size_t GetEncryptCiphertextSize() const { return encrypt_ciphertext_size_; }
+  std::shared_ptr<DestructionOrderTracker> GetOrderTracker() const { return order_tracker_; }
+
+  // Init tracking methods
+  const std::string& GetInitColumnName() const { return init_column_name_; }
+  const std::map<std::string, std::string>& GetInitConnectionConfig() const { return init_connection_config_; }
+  const std::string& GetInitAppContext() const { return init_app_context_; }
+  const std::string& GetInitColumnKeyId() const { return init_column_key_id_; }
+  Type::type GetInitDataType() const { return init_data_type_; }
+  CompressionCodec::type GetInitCompressionType() const { return init_compression_type_; }
+
+  // State update methods (called by the mock instance)
+  void SetEncryptCalled(bool called) { encrypt_called_ = called; }
+  void SetDecryptCalled(bool called) { decrypt_called_ = called; }
+  void SetInitCalled(bool called) { init_called_ = called; }
+  void SetDestructorCalled(bool called) { 
+    destructor_called_ = called; 
+    if (called) {
+      order_tracker_->RecordEvent("agent_destructor");
+    }
+  }
+  void IncrementEncryptCount() { encrypt_count_++; }
+  void IncrementDecryptCount() { decrypt_count_++; }
+  void IncrementInitCount() { init_count_++; }
+  void SetEncryptPlaintext(const std::vector<uint8_t>& plaintext) { encrypt_plaintext_ = plaintext; }
+  void SetDecryptCiphertext(const std::vector<uint8_t>& ciphertext) { decrypt_ciphertext_ = ciphertext; }
+  void SetEncryptCiphertextSize(size_t size) { encrypt_ciphertext_size_ = size; }
+  
+  // Init parameter tracking
+  void SetInitParameters(
+      std::string column_name,
+      std::map<std::string, std::string> connection_config,
+      std::string app_context,
+      std::string column_key_id,
+      Type::type data_type,
+      CompressionCodec::type compression_type) {
+    init_column_name_ = std::move(column_name);
+    init_connection_config_ = std::move(connection_config);
+    init_app_context_ = std::move(app_context);
+    init_column_key_id_ = std::move(column_key_id);
+    init_data_type_ = data_type;
+    init_compression_type_ = compression_type;
+  }
+
+ private:
+  bool encrypt_called_;
+  bool decrypt_called_;
+  bool init_called_;
+  bool destructor_called_;
+  int encrypt_count_;
+  int decrypt_count_;
+  int init_count_;
+  std::vector<uint8_t> encrypt_plaintext_;
+  std::vector<uint8_t> decrypt_ciphertext_;
+  size_t encrypt_ciphertext_size_;
+  std::shared_ptr<DestructionOrderTracker> order_tracker_;
+  
+  // Init parameters
+  std::string init_column_name_;
+  std::map<std::string, std::string> init_connection_config_;
+  std::string init_app_context_;
+  std::string init_column_key_id_;
+  Type::type init_data_type_;
+  CompressionCodec::type init_compression_type_;
+}; //MockCompanionDBPA
+
+// Companion object to track shared library handle management operations
+class SharedLibHandleManagementCompanion {
+ public:
+  SharedLibHandleManagementCompanion(std::shared_ptr<DestructionOrderTracker> order_tracker = nullptr) 
+      : handle_close_called_(false), 
+        handle_close_count_(0),
+        last_closed_handle_(nullptr),
+        order_tracker_(order_tracker ? order_tracker : std::make_shared<DestructionOrderTracker>()) {}
+  
+  // Test helper methods
+  bool WasHandleCloseCalled() const { return handle_close_called_; }
+  int GetHandleCloseCount() const { return handle_close_count_; }
+  void* GetLastClosedHandle() const { return last_closed_handle_; }
+  std::shared_ptr<DestructionOrderTracker> GetOrderTracker() const { return order_tracker_; }
+  
+  // State update methods
+  void SetHandleCloseCalled(bool called) { handle_close_called_ = called; }
+  void IncrementHandleCloseCount() { handle_close_count_++; }
+  void SetLastClosedHandle(void* handle) { last_closed_handle_ = handle; }
+  
+  // Create a closure that captures this companion object
+  // and returns a function that can be used to close the shared library handle
+  std::function<void(void*)> CreateHandleClosingFunction() {
+    return [this](void* library_handle) {
+      this->SetHandleCloseCalled(true);
+      this->IncrementHandleCloseCount();
+      this->SetLastClosedHandle(library_handle);
+      this->order_tracker_->RecordEvent("handle_close");
+    };
+  }
+
+ private:
+  bool handle_close_called_;
+  int handle_close_count_;
+  void* last_closed_handle_;
+  std::shared_ptr<DestructionOrderTracker> order_tracker_;
+}; //SharedLibHandleManagementCompanion
+
+// Mock implementation of DataBatchProtectionAgentInterface for testing delegation
+class MockDataBatchProtectionAgent : public DataBatchProtectionAgentInterface {
+ public:
+  explicit MockDataBatchProtectionAgent(std::shared_ptr<MockCompanionDBPA> companion = nullptr) 
+      : companion_(companion ? companion : std::make_shared<MockCompanionDBPA>()) {}
+  
+  ~MockDataBatchProtectionAgent() override {
+    companion_->SetDestructorCalled(true);
+  }
+  
+  void init(
+      std::string column_name,
+      std::map<std::string, std::string> connection_config,
+      std::string app_context,
+      std::string column_key_id,
+      Type::type data_type,
+      CompressionCodec::type compression_type) override {
+    companion_->SetInitCalled(true);
+    companion_->IncrementInitCount();
+    companion_->SetInitParameters(
+        std::move(column_name), 
+        std::move(connection_config),
+        std::move(app_context),
+        std::move(column_key_id),
+        data_type,
+        compression_type);
+  }
+
+  std::unique_ptr<EncryptionResult> Encrypt(
+      span<const uint8_t> plaintext) override {
+    companion_->SetEncryptCalled(true);
+    companion_->IncrementEncryptCount();
+    companion_->SetEncryptPlaintext(std::vector<uint8_t>(plaintext.begin(), plaintext.end()));
+    companion_->SetEncryptCiphertextSize(plaintext.size());
+    
+    // Create a simple mock encryption result
+    std::vector<uint8_t> ciphertext_data(plaintext.begin(), plaintext.end());
+    return std::make_unique<TestEncryptionResult>(std::move(ciphertext_data));
+  }
+
+  std::unique_ptr<DecryptionResult> Decrypt(
+      span<const uint8_t> ciphertext) override {
+    companion_->SetDecryptCalled(true);
+    companion_->IncrementDecryptCount();
+    companion_->SetDecryptCiphertext(std::vector<uint8_t>(ciphertext.begin(), ciphertext.end()));
+    
+    // Create a simple mock decryption result
+    std::vector<uint8_t> plaintext_data(ciphertext.begin(), ciphertext.end());
+    return std::make_unique<TestDecryptionResult>(std::move(plaintext_data));
+  }
+
+  // Getter for the companion object
+  std::shared_ptr<MockCompanionDBPA> GetCompanion() const { return companion_; }
+
+ private:
+  std::shared_ptr<MockCompanionDBPA> companion_;
+};
+
+// Test fixture for DBPALibraryWrapper tests
+class DBPALibraryWrapperTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Create test data
+    test_plaintext_ = "Hello, World!";
+    test_ciphertext_.resize(test_plaintext_.size());
+    
+    // Create shared destruction order tracker
+    destruction_order_tracker_ = std::make_shared<DestructionOrderTracker>();
+    
+    // Create companion objects with shared order tracker
+    mock_companion_ = std::make_shared<MockCompanionDBPA>(destruction_order_tracker_);
+    handle_companion_ = std::make_shared<SharedLibHandleManagementCompanion>(destruction_order_tracker_);
+    
+    // Create mock agent
+    mock_agent_ = std::make_unique<MockDataBatchProtectionAgent>(mock_companion_);
+    mock_agent_ptr_ = mock_agent_.get();
+  }
+
+  void TearDown() override {
+    // mock_companion_ and handle_companion_ remain valid for assertions even after mock_agent_ is destroyed
+    mock_agent_.reset();
+  }
+
+  // Helper method to create a wrapper with mock agent and handle management tracking
+  std::unique_ptr<DBPALibraryWrapper> CreateWrapper() {
+    return CreateWrapperWithAgent(std::move(mock_agent_));
+  }
+
+  // Helper method to create a wrapper with custom agent and handle management tracking
+  std::unique_ptr<DBPALibraryWrapper> CreateWrapperWithAgent(
+      std::unique_ptr<MockDataBatchProtectionAgent> agent) {
+    void* dummy_handle = reinterpret_cast<void*>(0x12345678);
+    
+    // Use the existing handle companion from the test fixture
+    return std::make_unique<DBPALibraryWrapper>(
+        std::move(agent), dummy_handle, handle_companion_->CreateHandleClosingFunction());
+  }
+
+  // Helper method to create wrapper with custom handle closing function
+  std::unique_ptr<DBPALibraryWrapper> CreateWrapperWithCustomClosing(
+      std::function<void(void*)> handle_closing_fn) {
+    void* dummy_handle = reinterpret_cast<void*>(0x12345678);
+    
+    return std::make_unique<DBPALibraryWrapper>(
+        std::move(mock_agent_), dummy_handle, handle_closing_fn);
+  }
+
+  std::string test_plaintext_;
+  std::vector<uint8_t> test_ciphertext_;
+  std::shared_ptr<DestructionOrderTracker> destruction_order_tracker_;
+  std::shared_ptr<MockCompanionDBPA> mock_companion_;
+  std::shared_ptr<SharedLibHandleManagementCompanion> handle_companion_;
+  std::unique_ptr<MockDataBatchProtectionAgent> mock_agent_;
+  MockDataBatchProtectionAgent* mock_agent_ptr_;
+};
+
+// ============================================================================
+// CONSTRUCTOR TESTS
+// ============================================================================
+
+TEST_F(DBPALibraryWrapperTest, ConstructorValidParameters) {
+  auto mock_agent = std::make_unique<MockDataBatchProtectionAgent>();
+  void* dummy_handle = reinterpret_cast<void*>(0x12345678);
+  
+  EXPECT_NO_THROW({
+    DBPALibraryWrapper wrapper(std::move(mock_agent), dummy_handle, handle_companion_->CreateHandleClosingFunction());
+  });
+}
+
+TEST_F(DBPALibraryWrapperTest, ConstructorValidParametersWithDefaultClosing) {
+  auto mock_agent = std::make_unique<MockDataBatchProtectionAgent>();
+  void* dummy_handle = reinterpret_cast<void*>(0x12345678);
+  
+  EXPECT_NO_THROW({
+    DBPALibraryWrapper wrapper(std::move(mock_agent), dummy_handle, handle_companion_->CreateHandleClosingFunction());
+  });
+}
+
+TEST_F(DBPALibraryWrapperTest, ConstructorNullAgent) {
+  void* dummy_handle = reinterpret_cast<void*>(0x12345678);
+  
+  // Test with custom function
+  EXPECT_THROW({
+    DBPALibraryWrapper wrapper(nullptr, dummy_handle, handle_companion_->CreateHandleClosingFunction());
+  }, std::invalid_argument);
+} 
+
+TEST_F(DBPALibraryWrapperTest, ConstructorNullLibraryHandle) {
+  auto mock_agent = std::make_unique<MockDataBatchProtectionAgent>();
+  void* dummy_handle = reinterpret_cast<void*>(0x12345678);
+
+  // Test with custom function
+  EXPECT_THROW({
+    DBPALibraryWrapper wrapper(std::move(mock_agent), dummy_handle, nullptr);
+  }, std::invalid_argument);
+}
+
+// ============================================================================
+// HANDLE CLOSING FUNCTION TESTS
+// ============================================================================
+
+TEST_F(DBPALibraryWrapperTest, HandleClosingFunctionCalled) {
+  void* dummy_handle = reinterpret_cast<void*>(0x12345678);
+  
+  // Create wrapper in a scope to trigger destructor
+  {
+    auto wrapper = CreateWrapper();
+    
+    // Verify handle closing hasn't been called yet
+    EXPECT_FALSE(handle_companion_->WasHandleCloseCalled());
+    EXPECT_EQ(handle_companion_->GetHandleCloseCount(), 0);
+  }
+  
+  // After wrapper destruction, handle closing should have been called
+  EXPECT_TRUE(handle_companion_->WasHandleCloseCalled());
+  EXPECT_EQ(handle_companion_->GetHandleCloseCount(), 1);
+  EXPECT_EQ(handle_companion_->GetLastClosedHandle(), dummy_handle);
+}
+
+TEST_F(DBPALibraryWrapperTest, CustomHandleClosingFunction) {
+  bool custom_function_called = false;
+  void* custom_last_handle = nullptr;
+  
+  auto custom_closing_fn = [&custom_function_called, &custom_last_handle](void* handle) {
+    custom_function_called = true;
+    custom_last_handle = handle;
+  };
+  
+  void* dummy_handle = reinterpret_cast<void*>(0x87654321);
+  
+  // Create wrapper with custom closing function
+  {
+    auto mock_agent = std::make_unique<MockDataBatchProtectionAgent>();
+    DBPALibraryWrapper wrapper(std::move(mock_agent), dummy_handle, custom_closing_fn);
+  }
+  
+  // Verify custom function was called
+  EXPECT_TRUE(custom_function_called);
+  EXPECT_EQ(custom_last_handle, dummy_handle);
+  
+  // Verify our handle companion wasn't called
+  EXPECT_FALSE(handle_companion_->WasHandleCloseCalled());
+  EXPECT_EQ(handle_companion_->GetHandleCloseCount(), 0);
+}
+
+// ============================================================================
+// DELEGATION FUNCTIONALITY TESTS
+// ============================================================================
+
+TEST_F(DBPALibraryWrapperTest, InitDelegation) {
+  auto wrapper = CreateWrapper();
+  
+  // Test data for init parameters
+  std::string column_name = "test_column";
+  std::map<std::string, std::string> connection_config = {
+    {"host", "localhost"},
+    {"port", "5432"},
+    {"database", "testdb"}
+  };
+  std::string app_context = "test_app_context";
+  std::string column_key_id = "test_key_id";
+  Type::type data_type = Type::INT32;
+  CompressionCodec::type compression_type = CompressionCodec::SNAPPY;
+  
+  // Call init through wrapper
+  wrapper->init(column_name, connection_config, app_context, column_key_id, data_type, compression_type);
+  
+  // Verify the mock agent was called
+  EXPECT_TRUE(mock_companion_->WasInitCalled());
+  EXPECT_EQ(mock_companion_->GetInitCount(), 1);
+  
+  // Verify the correct parameters were passed to the mock
+  EXPECT_EQ(mock_companion_->GetInitColumnName(), column_name);
+  EXPECT_EQ(mock_companion_->GetInitConnectionConfig(), connection_config);
+  EXPECT_EQ(mock_companion_->GetInitAppContext(), app_context);
+  EXPECT_EQ(mock_companion_->GetInitColumnKeyId(), column_key_id);
+  EXPECT_EQ(mock_companion_->GetInitDataType(), data_type);
+  EXPECT_EQ(mock_companion_->GetInitCompressionType(), compression_type);
+}
+
+TEST_F(DBPALibraryWrapperTest, InitDelegationWithEmptyParameters) {
+  auto wrapper = CreateWrapper();
+  
+  // Test init with empty parameters
+  std::string empty_column_name = "";
+  std::map<std::string, std::string> empty_connection_config = {};
+  std::string empty_app_context = "";
+  std::string empty_column_key_id = "";
+  Type::type data_type = Type::BYTE_ARRAY;
+  CompressionCodec::type compression_type = CompressionCodec::UNCOMPRESSED;
+  
+  // Call init through wrapper
+  wrapper->init(empty_column_name, empty_connection_config, empty_app_context, empty_column_key_id, data_type, compression_type);
+  
+  // Verify the mock agent was called
+  EXPECT_TRUE(mock_companion_->WasInitCalled());
+  EXPECT_EQ(mock_companion_->GetInitCount(), 1);
+  
+  // Verify the empty parameters were passed correctly
+  EXPECT_EQ(mock_companion_->GetInitColumnName(), empty_column_name);
+  EXPECT_EQ(mock_companion_->GetInitConnectionConfig(), empty_connection_config);
+  EXPECT_EQ(mock_companion_->GetInitAppContext(), empty_app_context);
+  EXPECT_EQ(mock_companion_->GetInitColumnKeyId(), empty_column_key_id);
+  EXPECT_EQ(mock_companion_->GetInitDataType(), data_type);
+  EXPECT_EQ(mock_companion_->GetInitCompressionType(), compression_type);
+}
+
+TEST_F(DBPALibraryWrapperTest, EncryptDelegation) {
+  auto wrapper = CreateWrapper();
+  
+  // Convert test data to spans
+  span<const uint8_t> plaintext_span(
+      reinterpret_cast<const uint8_t*>(test_plaintext_.data()),
+      test_plaintext_.size());
+  span<uint8_t> ciphertext_span(test_ciphertext_.data(), test_ciphertext_.size());
+  
+  // Call encrypt through wrapper
+  auto result = wrapper->Encrypt(plaintext_span);
+  
+  // Verify the mock agent was called
+  EXPECT_TRUE(mock_companion_->WasEncryptCalled());
+  EXPECT_EQ(mock_companion_->GetEncryptCount(), 1);
+  
+  // Verify the correct plaintext was passed to the mock
+  auto mock_plaintext = mock_companion_->GetEncryptPlaintext();
+  std::string mock_plaintext_str(mock_plaintext.begin(), mock_plaintext.end());
+  EXPECT_EQ(mock_plaintext_str, test_plaintext_);
+  
+  // Verify the correct ciphertext size was passed
+  EXPECT_EQ(mock_companion_->GetEncryptCiphertextSize(), test_ciphertext_.size());
+  
+  // Verify result is not null
+  EXPECT_NE(result, nullptr);
+}
+
+TEST_F(DBPALibraryWrapperTest, DecryptDelegation) {
+  auto wrapper = CreateWrapper();
+  
+  // Convert test data to spans
+  span<const uint8_t> ciphertext_span(
+      reinterpret_cast<const uint8_t*>(test_plaintext_.data()),
+      test_plaintext_.size());
+  
+  // Call decrypt through wrapper
+  auto result = wrapper->Decrypt(ciphertext_span);
+  
+  // Verify the mock agent was called
+  EXPECT_TRUE(mock_companion_->WasDecryptCalled());
+  EXPECT_EQ(mock_companion_->GetDecryptCount(), 1);
+  
+  // Verify the correct ciphertext was passed to the mock
+  auto mock_ciphertext = mock_companion_->GetDecryptCiphertext();
+  std::string mock_ciphertext_str(mock_ciphertext.begin(), mock_ciphertext.end());
+  EXPECT_EQ(mock_ciphertext_str, test_plaintext_);
+  
+  // Verify result is not null
+  EXPECT_NE(result, nullptr);
+}
+
+TEST_F(DBPALibraryWrapperTest, MultipleEncryptDelegations) {
+  auto wrapper = CreateWrapper();
+  
+  // Perform multiple encrypt operations
+  for (int i = 0; i < 5; ++i) {
+    std::string plaintext = "Test " + std::to_string(i);
+    std::vector<uint8_t> ciphertext(plaintext.size());
+    
+    span<const uint8_t> plaintext_span(
+        reinterpret_cast<const uint8_t*>(plaintext.data()),
+        plaintext.size());
+    
+    auto result = wrapper->Encrypt(plaintext_span);
+    EXPECT_NE(result, nullptr);
+  }
+  
+  // Verify the mock agent was called the correct number of times
+  EXPECT_TRUE(mock_companion_->WasEncryptCalled());
+  EXPECT_EQ(mock_companion_->GetEncryptCount(), 5);
+}
+
+TEST_F(DBPALibraryWrapperTest, MultipleDecryptDelegations) {
+  auto wrapper = CreateWrapper();
+  
+  // Perform multiple decrypt operations
+  for (int i = 0; i < 3; ++i) {
+    std::string ciphertext = "Test " + std::to_string(i);
+    
+    span<const uint8_t> ciphertext_span(
+        reinterpret_cast<const uint8_t*>(ciphertext.data()),
+        ciphertext.size());
+    
+    auto result = wrapper->Decrypt(ciphertext_span);
+    EXPECT_NE(result, nullptr);
+  }
+  
+  // Verify the mock agent was called the correct number of times
+  EXPECT_TRUE(mock_companion_->WasDecryptCalled());
+  EXPECT_EQ(mock_companion_->GetDecryptCount(), 3);
+}
+
+TEST_F(DBPALibraryWrapperTest, MixedOperationsDelegation) {
+  auto wrapper = CreateWrapper();
+  
+  // Perform mixed encrypt and decrypt operations
+  std::vector<std::string> test_data = {"Hello", "World", "Test", "Data"};
+  int call_count = test_data.size();
+  
+  for (const auto& data : test_data) {
+    // Encrypt
+    span<const uint8_t> plaintext_span(
+        reinterpret_cast<const uint8_t*>(data.data()),
+        data.size());
+    
+    auto encrypt_result = wrapper->Encrypt(plaintext_span);
+    EXPECT_NE(encrypt_result, nullptr);
+    
+    // Decrypt using the ciphertext from the encryption result
+    auto ciphertext_span = encrypt_result->ciphertext();
+    auto decrypt_result = wrapper->Decrypt(ciphertext_span);
+    EXPECT_NE(decrypt_result, nullptr);
+  }
+  
+  // Verify both operations were called
+  EXPECT_TRUE(mock_companion_->WasEncryptCalled());
+  EXPECT_TRUE(mock_companion_->WasDecryptCalled());
+  EXPECT_EQ(mock_companion_->GetEncryptCount(), call_count);
+  EXPECT_EQ(mock_companion_->GetDecryptCount(), call_count);
+}
+
+TEST_F(DBPALibraryWrapperTest, InitWithEncryptDecryptOperations) {
+  auto wrapper = CreateWrapper();
+  
+  // First, initialize the wrapper
+  std::string column_name = "test_column";
+  std::map<std::string, std::string> connection_config = {
+    {"host", "localhost"},
+    {"port", "5432"}
+  };
+  std::string app_context = "test_app";
+  std::string column_key_id = "test_key";
+  Type::type data_type = Type::INT32;
+  CompressionCodec::type compression_type = CompressionCodec::SNAPPY;
+  
+  wrapper->init(column_name, connection_config, app_context, column_key_id, data_type, compression_type);
+  
+  // Verify init was called
+  EXPECT_TRUE(mock_companion_->WasInitCalled());
+  EXPECT_EQ(mock_companion_->GetInitCount(), 1);
+  
+  // Then perform encrypt/decrypt operations
+  std::string test_data = "Test data after init";
+  span<const uint8_t> plaintext_span(
+      reinterpret_cast<const uint8_t*>(test_data.data()),
+      test_data.size());
+  
+  auto encrypt_result = wrapper->Encrypt(plaintext_span);
+  EXPECT_NE(encrypt_result, nullptr);
+  
+  auto ciphertext_span = encrypt_result->ciphertext();
+  auto decrypt_result = wrapper->Decrypt(ciphertext_span);
+  EXPECT_NE(decrypt_result, nullptr);
+  
+  // Verify all operations were called
+  EXPECT_TRUE(mock_companion_->WasEncryptCalled());
+  EXPECT_TRUE(mock_companion_->WasDecryptCalled());
+  EXPECT_EQ(mock_companion_->GetEncryptCount(), 1);
+  EXPECT_EQ(mock_companion_->GetDecryptCount(), 1);
+  
+  // Verify init parameters are still accessible
+  EXPECT_EQ(mock_companion_->GetInitColumnName(), column_name);
+  EXPECT_EQ(mock_companion_->GetInitConnectionConfig(), connection_config);
+  EXPECT_EQ(mock_companion_->GetInitAppContext(), app_context);
+  EXPECT_EQ(mock_companion_->GetInitColumnKeyId(), column_key_id);
+  EXPECT_EQ(mock_companion_->GetInitDataType(), data_type);
+  EXPECT_EQ(mock_companion_->GetInitCompressionType(), compression_type);
+}
+
+TEST_F(DBPALibraryWrapperTest, DelegationWithEmptyData) {
+  auto wrapper = CreateWrapper();
+  
+  // Test encryption with empty data
+  std::vector<uint8_t> empty_plaintext;
+  
+  span<const uint8_t> plaintext_span(empty_plaintext);
+  
+  auto encrypt_result = wrapper->Encrypt(plaintext_span);
+  EXPECT_NE(encrypt_result, nullptr);
+  EXPECT_TRUE(mock_companion_->WasEncryptCalled());
+  
+  // Test decryption with empty data
+  auto ciphertext_span = encrypt_result->ciphertext();
+  auto decrypt_result = wrapper->Decrypt(ciphertext_span);
+  EXPECT_NE(decrypt_result, nullptr);
+  EXPECT_TRUE(mock_companion_->WasDecryptCalled());
+}
+
+TEST_F(DBPALibraryWrapperTest, DelegationWithNullData) {
+  auto wrapper = CreateWrapper();
+  
+  // Test encryption with null data pointers but valid spans
+  // This tests that the wrapper properly delegates even with null data
+  span<const uint8_t> null_plaintext_span(nullptr, size_t{0});
+  
+  auto encrypt_result = wrapper->Encrypt(null_plaintext_span);
+  EXPECT_NE(encrypt_result, nullptr);
+  EXPECT_TRUE(mock_companion_->WasEncryptCalled());
+  
+  // Test decryption with null data pointer but valid span
+  span<const uint8_t> null_decrypt_span(nullptr, size_t{0});
+  auto decrypt_result = wrapper->Decrypt(null_decrypt_span);
+  EXPECT_NE(decrypt_result, nullptr);
+  EXPECT_TRUE(mock_companion_->WasDecryptCalled());
+  
+  // Verify the mock agent received the correct data (empty vectors)
+  auto mock_plaintext = mock_companion_->GetEncryptPlaintext();
+  auto mock_ciphertext = mock_companion_->GetDecryptCiphertext();
+  EXPECT_EQ(mock_plaintext.size(), 0);
+  EXPECT_EQ(mock_ciphertext.size(), 0);
+}
+
+// ============================================================================
+// DESTRUCTOR FUNCTIONALITY TESTS
+// ============================================================================
+
+TEST_F(DBPALibraryWrapperTest, DestructorBasicBehavior) {
+  void* dummy_handle = reinterpret_cast<void*>(0x12345678);
+  
+  // Create wrapper in a scope to test destructor
+  {
+    auto wrapper = CreateWrapper();
+    
+    // Perform some operations to ensure the wrapper is used
+    std::vector<uint8_t> plaintext = {1, 2, 3, 4, 5};
+    
+    span<const uint8_t> plaintext_span(plaintext.data(), plaintext.size());
+    
+    auto result = wrapper->Encrypt(plaintext_span);
+    EXPECT_NE(result, nullptr);
+    
+    // Verify handle closing hasn't been called yet
+    EXPECT_FALSE(handle_companion_->WasHandleCloseCalled());
+    EXPECT_EQ(handle_companion_->GetHandleCloseCount(), 0);
+  }
+  
+  // At this point, the wrapper should have been destroyed and handle closed
+  EXPECT_TRUE(handle_companion_->WasHandleCloseCalled());
+  EXPECT_EQ(handle_companion_->GetHandleCloseCount(), 1);
+  EXPECT_EQ(handle_companion_->GetLastClosedHandle(), dummy_handle);
+}
+
+TEST_F(DBPALibraryWrapperTest, DestructorWithMultipleOperations) {
+  void* dummy_handle = reinterpret_cast<void*>(0x12345678);
+  
+  // Create wrapper in a scope to test destructor
+  {
+    auto wrapper = CreateWrapper();
+    
+    // Perform multiple operations
+    for (int i = 0; i < 10; ++i) {
+      std::string plaintext = "Test " + std::to_string(i);
+      std::vector<uint8_t> ciphertext(plaintext.size());
+      
+      span<const uint8_t> plaintext_span(
+          reinterpret_cast<const uint8_t*>(plaintext.data()),
+          plaintext.size());
+      
+      auto encrypt_result = wrapper->Encrypt(plaintext_span);
+      EXPECT_NE(encrypt_result, nullptr);
+      
+      auto ciphertext_span = encrypt_result->ciphertext();
+      auto decrypt_result = wrapper->Decrypt(ciphertext_span);
+      EXPECT_NE(decrypt_result, nullptr);
+    }
+    
+    // Verify operations completed but handle not closed yet
+    EXPECT_FALSE(handle_companion_->WasHandleCloseCalled());
+  }
+
+  // Verify the wrapper was destroyed properly and handle was closed
+  EXPECT_TRUE(handle_companion_->WasHandleCloseCalled());
+  EXPECT_EQ(handle_companion_->GetHandleCloseCount(), 1);
+  EXPECT_EQ(handle_companion_->GetLastClosedHandle(), dummy_handle);
+}
+
+TEST_F(DBPALibraryWrapperTest, DestructorOrderVerification) {
+  // Clear any previous events from the shared order tracker
+  destruction_order_tracker_->Clear();
+  
+  // Create a custom mock agent that tracks destruction order
+      auto custom_companion = std::make_shared<MockCompanionDBPA>(destruction_order_tracker_);
+  auto custom_agent = std::make_unique<MockDataBatchProtectionAgent>(custom_companion);
+  
+  void* dummy_handle = reinterpret_cast<void*>(0x12345678);
+  
+  // Create wrapper in a scope
+  {
+    auto wrapper = CreateWrapperWithAgent(std::move(custom_agent));
+    
+    // Perform some operations
+    std::vector<uint8_t> plaintext = {1, 2, 3};
+    
+    span<const uint8_t> plaintext_span(plaintext.data(), plaintext.size());
+    
+    auto result = wrapper->Encrypt(plaintext_span);
+    EXPECT_NE(result, nullptr);
+    
+    // Verify neither destructor nor handle closing has been called yet
+    EXPECT_FALSE(custom_companion->WasDestructorCalled());
+    EXPECT_FALSE(handle_companion_->WasHandleCloseCalled());
+    EXPECT_FALSE(destruction_order_tracker_->WasEventRecorded("handle_close"));
+    EXPECT_FALSE(destruction_order_tracker_->WasEventRecorded("agent_destructor"));
+  }
+  
+  // Verify both the custom agent was destroyed and handle was closed
+  EXPECT_TRUE(custom_companion->WasDestructorCalled());
+  EXPECT_TRUE(handle_companion_->WasHandleCloseCalled());
+  EXPECT_EQ(handle_companion_->GetHandleCloseCount(), 1);
+  EXPECT_EQ(handle_companion_->GetLastClosedHandle(), dummy_handle);
+  
+  // Verify the order of destruction: handle_close should be called BEFORE agent_destructor
+  EXPECT_TRUE(destruction_order_tracker_->WasEventRecorded("agent_destructor"));
+  EXPECT_TRUE(destruction_order_tracker_->WasEventRecorded("handle_close"));
+  EXPECT_TRUE(destruction_order_tracker_->VerifyOrder("agent_destructor", "handle_close"));  
+}
+
+TEST_F(DBPALibraryWrapperTest, DestructionOrderTrackerFunctionality) {
+  // Test the destruction order tracker functionality independently
+  auto tracker = std::make_shared<DestructionOrderTracker>();
+  
+  // Record events in a specific order
+  tracker->RecordEvent("first");
+  tracker->RecordEvent("second");
+  tracker->RecordEvent("third");
+  
+  // Verify order tracking
+  EXPECT_TRUE(tracker->VerifyOrder("first", "second"));
+  EXPECT_TRUE(tracker->VerifyOrder("second", "third"));
+  EXPECT_TRUE(tracker->VerifyOrder("first", "third"));
+  
+  // Verify reverse order is false
+  EXPECT_FALSE(tracker->VerifyOrder("second", "first"));
+  EXPECT_FALSE(tracker->VerifyOrder("third", "second"));
+  EXPECT_FALSE(tracker->VerifyOrder("third", "first"));
+  
+  // Verify sequence numbers
+  EXPECT_EQ(tracker->GetEventSequence("first"), 1);
+  EXPECT_EQ(tracker->GetEventSequence("second"), 2);
+  EXPECT_EQ(tracker->GetEventSequence("third"), 3);
+  
+  // Verify event recording
+  EXPECT_TRUE(tracker->WasEventRecorded("first"));
+  EXPECT_TRUE(tracker->WasEventRecorded("second"));
+  EXPECT_TRUE(tracker->WasEventRecorded("third"));
+  EXPECT_FALSE(tracker->WasEventRecorded("nonexistent"));
+}
+
+// ============================================================================
+// INTERFACE COMPLIANCE TESTS
+// ============================================================================
+
+TEST_F(DBPALibraryWrapperTest, InterfaceCompliancePolymorphic) {
+  auto wrapper = CreateWrapper();
+  
+  // Verify the wrapper can be used polymorphically
+  DataBatchProtectionAgentInterface* interface_ptr = wrapper.get();
+  EXPECT_NE(interface_ptr, nullptr);
+  
+  // Test polymorphic init call
+  std::string column_name = "polymorphic_column";
+  std::map<std::string, std::string> connection_config = {{"test", "value"}};
+  std::string app_context = "polymorphic_context";
+  std::string column_key_id = "polymorphic_key";
+  Type::type data_type = Type::INT64;
+  CompressionCodec::type compression_type = CompressionCodec::GZIP;
+  
+  interface_ptr->init(column_name, connection_config, app_context, column_key_id, data_type, compression_type);
+  
+  // Verify init was called through the interface
+  EXPECT_TRUE(mock_companion_->WasInitCalled());
+  EXPECT_EQ(mock_companion_->GetInitCount(), 1);
+  EXPECT_EQ(mock_companion_->GetInitColumnName(), column_name);
+  EXPECT_EQ(mock_companion_->GetInitDataType(), data_type);
+  EXPECT_EQ(mock_companion_->GetInitCompressionType(), compression_type);
+  
+  // Test polymorphic encrypt/decrypt calls
+  std::vector<uint8_t> plaintext = {1, 2, 3};
+  
+  span<const uint8_t> plaintext_span(plaintext.data(), plaintext.size());
+  
+  auto encrypt_result = interface_ptr->Encrypt(plaintext_span);
+  EXPECT_NE(encrypt_result, nullptr);
+  
+  auto ciphertext_span = encrypt_result->ciphertext();
+  auto decrypt_result = interface_ptr->Decrypt(ciphertext_span);
+  EXPECT_NE(decrypt_result, nullptr);
+  
+  // Verify the mock agent was called through the interface
+  EXPECT_TRUE(mock_companion_->WasEncryptCalled());
+  EXPECT_TRUE(mock_companion_->WasDecryptCalled());
+}
+
+// ============================================================================
+// EDGE CASE TESTS
+// ============================================================================
+
+TEST_F(DBPALibraryWrapperTest, EdgeCaseZeroSizeSpans) {
+  auto wrapper = CreateWrapper();
+  
+  // Test with zero-size spans
+  std::vector<uint8_t> empty_data;
+  
+  span<const uint8_t> empty_plaintext_span(empty_data);
+  
+  auto encrypt_result = wrapper->Encrypt(empty_plaintext_span);
+  EXPECT_NE(encrypt_result, nullptr);
+  
+  auto ciphertext_span = encrypt_result->ciphertext();
+  auto decrypt_result = wrapper->Decrypt(ciphertext_span);
+  EXPECT_NE(decrypt_result, nullptr);
+  
+  EXPECT_TRUE(mock_companion_->WasEncryptCalled());
+  EXPECT_TRUE(mock_companion_->WasDecryptCalled());
+}
+
+TEST_F(DBPALibraryWrapperTest, EdgeCaseSingleByteData) {
+  auto wrapper = CreateWrapper();
+  
+  // Test with single byte data
+  std::vector<uint8_t> single_byte = {0x42};
+  
+  span<const uint8_t> plaintext_span(single_byte.data(), single_byte.size());
+  
+  auto encrypt_result = wrapper->Encrypt(plaintext_span);
+  EXPECT_NE(encrypt_result, nullptr);
+  
+  auto ciphertext_span = encrypt_result->ciphertext();
+  auto decrypt_result = wrapper->Decrypt(ciphertext_span);
+  EXPECT_NE(decrypt_result, nullptr);
+  
+  EXPECT_TRUE(mock_companion_->WasEncryptCalled());
+  EXPECT_TRUE(mock_companion_->WasDecryptCalled());
+}
+
+}  // namespace parquet::encryption::external::test 


### PR DESCRIPTION
`DBPALibraryWrapper` works as a decorator to ensure that `DataBatchProtectionAgent` instances coming from the shared library (*.so) are properly released. The decorator forwards most methods in `DataBatchProtectionAgentInterface` and only decorates the destructor.

This work is part of a series of PRs created to merge the "DLL Loading" work into `dev_phase2`. 
This work was already reviewed when "DLL Loading" was written against `dev-miniapp`. 

Existing unit tests and integration tests (Parquet- and Parquet-encryption related) pass. 
New unit test passes.

