### PR TITLE
Adding LoadableEncryptorUtils

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -243,6 +243,7 @@ if(PARQUET_REQUIRE_ENCRYPTION)
                    encryption/external_dbpa_encryption.cc
                    encryption/openssl_internal.cc
                    encryption/external/dbpa_library_wrapper.cc
+                   encryption/external/loadable_encryptor_utils.cc
                    )
   # Encryption key management
   set(PARQUET_SRCS

--- a/cpp/src/parquet/encryption/CMakeLists.txt
+++ b/cpp/src/parquet/encryption/CMakeLists.txt
@@ -19,10 +19,26 @@
 arrow_install_all_headers("parquet/encryption")
 
 if(ARROW_TESTING)
+  # Add library for DBPATestAgent
+  add_library(DBPATestAgent SHARED
+             external/dbpa_test_agent.cc)
+
+  # DBPATestAgent configuration
+  target_link_libraries(DBPATestAgent PUBLIC
+                        arrow_shared)
+
+  set_target_properties(DBPATestAgent PROPERTIES OUTPUT_NAME "DBPATestAgent")
   
+  # Add test for LoadableEncryptorUtils
+  # (depends on DBPATestAgent)
+  add_parquet_test(loadable-encryptor-utils-test
+                   SOURCES external/loadable_encryptor_utils_test.cc
+                   LABELS "parquet-tests" "encryption-tests")
+
   # Add test for DBPALibraryWrapper
   add_parquet_test(dbpa-library-wrapper-test
                    SOURCES external/dbpa_library_wrapper_test.cc
                    LABELS "parquet-tests" "encryption-tests")
-  
+
+
 endif()

--- a/cpp/src/parquet/encryption/external/dbpa_test_agent.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_test_agent.cc
@@ -1,0 +1,114 @@
+//TODO: figure out the licensing.
+
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <span>
+#include <vector>
+
+#include "parquet/exception.h"
+#include "parquet/encryption/external/dbpa_test_agent.h"
+#include "parquet/encryption/external/third_party/dbpa_interface.h"
+#include "parquet/encryption/external/third_party/span.hpp"
+
+template <typename T>
+using span = tcb::span<T>;
+using dbps::external::EncryptionResult;
+using dbps::external::DecryptionResult;
+
+namespace parquet::encryption::external {
+
+// Concrete implementation of EncryptionResult for testing
+class TestEncryptionResult : public EncryptionResult {
+public:
+    TestEncryptionResult(std::vector<uint8_t> data, bool success = true, 
+                        std::string error_msg = "", 
+                        std::map<std::string, std::string> error_fields = {})
+        : ciphertext_data_(std::move(data)), success_(success), 
+          error_message_(std::move(error_msg)), error_fields_(std::move(error_fields)) {}
+
+    span<const uint8_t> ciphertext() const override {
+        return span<const uint8_t>(ciphertext_data_.data(), ciphertext_data_.size());
+    }
+
+    std::size_t size() const override { return static_cast<int>(ciphertext_data_.size()); }
+    bool success() const override { return success_; }
+    const std::string& error_message() const override { return error_message_; }
+    const std::map<std::string, std::string>& error_fields() const override { return error_fields_; }
+
+private:
+    std::vector<uint8_t> ciphertext_data_;
+    bool success_;
+    std::string error_message_;
+    std::map<std::string, std::string> error_fields_;
+};
+
+// Concrete implementation of DecryptionResult for testing
+class TestDecryptionResult : public DecryptionResult {
+public:
+    TestDecryptionResult(std::vector<uint8_t> data, bool success = true, 
+                        std::string error_msg = "", 
+                        std::map<std::string, std::string> error_fields = {})
+        : plaintext_data_(std::move(data)), success_(success), 
+          error_message_(std::move(error_msg)), error_fields_(std::move(error_fields)) {}
+
+    span<const uint8_t> plaintext() const override {
+        return span<const uint8_t>(plaintext_data_.data(), plaintext_data_.size());
+    }
+
+    std::size_t size() const override { return plaintext_data_.size(); }
+    bool success() const override { return success_; }
+    const std::string& error_message() const override { return error_message_; }
+    const std::map<std::string, std::string>& error_fields() const override { return error_fields_; }
+
+private:
+    std::vector<uint8_t> plaintext_data_;
+    bool success_;
+    std::string error_message_;
+    std::map<std::string, std::string> error_fields_;
+};
+
+DBPATestAgent::DBPATestAgent() {
+}
+
+std::unique_ptr<EncryptionResult> DBPATestAgent::Encrypt(
+    span<const uint8_t> plaintext) {
+  
+  // Simple XOR encryption for testing purposes
+  // In a real implementation, this would use proper encryption
+  std::vector<uint8_t> ciphertext_data(plaintext.size());
+  
+  for (size_t i = 0; i < plaintext.size(); ++i) {
+    ciphertext_data[i] = plaintext[i] ^ 0xAA; // Simple XOR with 0xAA
+  }
+
+  return std::make_unique<TestEncryptionResult>(std::move(ciphertext_data));
+}
+
+std::unique_ptr<DecryptionResult> DBPATestAgent::Decrypt(
+    span<const uint8_t> ciphertext) {
+  
+  // Simple XOR decryption for testing purposes
+  // In a real implementation, this would perform actual decryption
+  std::vector<uint8_t> plaintext_data(ciphertext.size());
+  
+  for (size_t i = 0; i < ciphertext.size(); ++i) {
+    plaintext_data[i] = ciphertext[i] ^ 0xAA; // Simple XOR with 0xAA
+  }
+
+  return std::make_unique<TestDecryptionResult>(std::move(plaintext_data));
+}
+
+DBPATestAgent::~DBPATestAgent() {
+}
+
+// Export function for creating new instances from shared library
+extern "C" {
+  DataBatchProtectionAgentInterface* create_new_instance() {
+    return new parquet::encryption::external::DBPATestAgent();
+  }
+}
+
+}  // namespace parquet::encryption::external

--- a/cpp/src/parquet/encryption/external/dbpa_test_agent.h
+++ b/cpp/src/parquet/encryption/external/dbpa_test_agent.h
@@ -1,0 +1,48 @@
+//TODO: figure out the licensing.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "parquet/encryption/external/third_party/dbpa_interface.h"
+#include "parquet/encryption/external/third_party/span.hpp"
+
+template <typename T>
+using span = tcb::span<T>;
+
+using dbps::external::DataBatchProtectionAgentInterface;
+using dbps::external::EncryptionResult;
+using dbps::external::DecryptionResult;
+using dbps::external::Type;
+using dbps::external::CompressionCodec;
+
+namespace parquet::encryption::external {
+
+// Implementation of the DataBatchProtectionAgentInterface for testing purposes.
+// It is used to test library wrapper/loading code.
+// Will never be used in production.
+class DBPATestAgent : public DataBatchProtectionAgentInterface {
+ public:
+  explicit DBPATestAgent();
+
+  void init(
+      std::string column_name,
+      std::map<std::string, std::string> connection_config,
+      std::string app_context,
+      std::string column_key_id,
+      Type::type data_type,
+      CompressionCodec::type compression_type) override {
+    // init() intentionally left blank
+  }
+
+  std::unique_ptr<EncryptionResult> Encrypt(
+      span<const uint8_t> plaintext) override;
+
+  std::unique_ptr<DecryptionResult> Decrypt(
+      span<const uint8_t> ciphertext) override;
+
+  ~DBPATestAgent();
+};
+
+}  // namespace parquet::encryption::external 

--- a/cpp/src/parquet/encryption/external/loadable_encryptor_utils.cc
+++ b/cpp/src/parquet/encryption/external/loadable_encryptor_utils.cc
@@ -1,0 +1,77 @@
+//TODO: figure out the licensing.
+
+#include "parquet/encryption/external/loadable_encryptor_utils.h"
+#include "parquet/encryption/external/third_party/dbpa_interface.h"
+#include "parquet/encryption/external/dbpa_library_wrapper.h"
+
+#include "arrow/util/io_util.h" //utils for loading shared libraries
+#include "arrow/result.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <memory>
+
+using ::arrow::Result;
+
+namespace parquet::encryption::external {
+
+// Function pointer type for creating encryptor instances
+// This needs to match the return type of the create_new_instance function in the shared library.
+typedef DataBatchProtectionAgentInterface* (*create_encryptor_t)();
+
+//TODO: this should be private
+std::unique_ptr<DataBatchProtectionAgentInterface> CreateInstance(void* library_handle) {
+  auto symbol_result = arrow::internal::GetSymbol(library_handle, "create_new_instance");
+  if (!symbol_result.ok()) {
+    std::cerr << "Error: Cannot load symbol 'create_new_instance()': " << symbol_result.status().message() << std::endl;
+    auto status = arrow::internal::CloseDynamicLibrary(library_handle);
+
+    throw std::runtime_error("Failed to load symbol 'create_new_instance()': " + symbol_result.status().message());
+  }
+  
+  //create_instance_fn is a function pointer to the create_new_instance function in the shared library.
+  create_encryptor_t create_instance_fn = reinterpret_cast<create_encryptor_t>(symbol_result.ValueOrDie());
+
+  // at this point, we have the create_instance function pointer (from the shared library)
+  // so we can create a new instance of the DataBatchProtectionAgentInterface
+  DataBatchProtectionAgentInterface* instance = create_instance_fn();
+
+  if (instance == nullptr) {
+    std::cerr << "Error: Cannot create instance of DataBatchProtectionAgentInterface" << std::endl;
+    auto status = arrow::internal::CloseDynamicLibrary(library_handle);
+    throw std::runtime_error("Failed to create instance of DataBatchProtectionAgentInterface");
+  }
+
+  auto instance_ptr = std::unique_ptr<DataBatchProtectionAgentInterface>(instance);
+
+  return instance_ptr;
+} // CreateInstance()
+
+std::unique_ptr<DataBatchProtectionAgentInterface> LoadableEncryptorUtils::LoadFromLibrary(const std::string& library_path) {
+  //TODO: remove this.
+  std::cout << "Inside LoadableEncryptorUtils::LoadFromLibrary" << std::endl;
+
+  if (library_path.empty()) {
+    throw std::invalid_argument("LoadableEncryptorUtils::LoadFromLibrary: No library path provided");
+  }
+
+  auto library_handle_result = arrow::internal::LoadDynamicLibrary(library_path.c_str());;
+  if (!library_handle_result.ok()) {
+    throw std::runtime_error("Failed to load library: " + library_handle_result.status().message());
+  }
+  
+  void* library_handle = library_handle_result.ValueOrDie();
+  auto agent_instance = CreateInstance(library_handle);
+
+  //wrap the agent in a DBPALibraryWrapper
+  auto wrapped_agent = std::make_unique<DBPALibraryWrapper>(
+    std::move(agent_instance), 
+    library_handle);
+
+  return wrapped_agent;
+}
+
+} // namespace parquet::encryption::external 
+
+

--- a/cpp/src/parquet/encryption/external/loadable_encryptor_utils.h
+++ b/cpp/src/parquet/encryption/external/loadable_encryptor_utils.h
@@ -1,0 +1,22 @@
+//TODO: figure out the licensing.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "parquet/platform.h"
+#include "parquet/encryption/external/third_party/dbpa_interface.h"
+
+using dbps::external::DataBatchProtectionAgentInterface;
+
+namespace parquet::encryption::external {
+
+class PARQUET_EXPORT LoadableEncryptorUtils {
+ public:
+  //Will load the shared library and instantiate the DataBatchProtectionAgentInterface 
+  // provided by the shared library. The instance will be wrapped in a DBPALibraryWrapper.
+  static std::unique_ptr<DataBatchProtectionAgentInterface> LoadFromLibrary(const std::string& library_path);
+};
+
+}  // namespace parquet::encryption::external 

--- a/cpp/src/parquet/encryption/external/loadable_encryptor_utils_test.cc
+++ b/cpp/src/parquet/encryption/external/loadable_encryptor_utils_test.cc
@@ -1,0 +1,183 @@
+//TODO: figure out the licensing.
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <filesystem>
+
+#include "gtest/gtest.h"
+#include "parquet/encryption/external/loadable_encryptor_utils.h"
+#include "parquet/encryption/external/third_party/dbpa_interface.h"
+#include "parquet/encryption/external/dbpa_library_wrapper.h"
+//#include "arrow/util/span.h"
+//#include "parquet/test_util.h"
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#elif defined(__linux__)
+#include <unistd.h>
+#include <linux/limits.h>
+#elif defined(_WIN32)
+#include <windows.h>
+#endif
+
+namespace parquet::encryption::external::test {
+
+// Test fixture for LoadableEncryptorUtils tests
+class LoadableEncryptorUtilsTest : public ::testing::Test {
+  public:
+    std::string library_path_;
+
+  protected:
+    void SetUp() override {
+      // Get the path to the DBPATestAgent shared library
+      // This assumes the library is built 
+      library_path_ = GetTestLibraryPath();
+    }
+
+// Helper function to get the directory where the executable is located
+// used within GetTestLibraryPath to determine the path to the test library (*.so)
+std::string GetExecutableDirectory() {
+  #ifdef __APPLE__
+    char path[PATH_MAX];
+    uint32_t size = sizeof(path);
+    if (_NSGetExecutablePath(path, &size) == 0) {
+      return std::filesystem::path(path).parent_path().string();
+    }
+  #elif defined(__linux__)
+    char path[PATH_MAX];
+    ssize_t len = readlink("/proc/self/exe", path, sizeof(path) - 1);
+    if (len != -1) {
+      path[len] = '\0';
+      return std::filesystem::path(path).parent_path().string();
+    }
+  #elif defined(_WIN32)
+    char path[MAX_PATH];
+    if (GetModuleFileNameA(NULL, path, MAX_PATH) != 0) {
+      return std::filesystem::path(path).parent_path().string();
+    }
+  #endif
+    // Fallback to current working directory if we can't determine executable path
+    return std::filesystem::current_path().string();
+  }
+
+  // Helper method to get the path to the test library
+  std::string GetTestLibraryPath() {
+    // Check for environment variable to override the executable directory
+    const char* cwd_override = std::getenv("PARQUET_TEST_LIBRARY_CWD");
+    std::string base_path;
+    
+    if (cwd_override && cwd_override[0]) {
+      base_path = std::string(cwd_override);
+    } else {
+      // Get the directory where the executable is located
+      base_path = GetExecutableDirectory();
+    }
+
+    std::vector<std::string> possible_filenames = {
+      "libDBPATestAgent.so",
+      "libDBPATestAgent.dylib",
+      "DBPATestAgent.dll"
+    };
+
+    std::vector<std::string> possible_directories = {
+      GetExecutableDirectory() + "/",
+      base_path + "/"
+      "./",
+      ""
+    };
+
+    for (const auto& filename : possible_filenames) {
+      for (const auto& directory : possible_directories) {
+        std::string path = directory + filename;
+        if (std::filesystem::exists(path)) {
+          return path;
+        }
+      }
+    }
+
+    throw std::runtime_error("Could not find library");
+  }
+};
+
+// ============================================================================
+// SUCCESS TESTS
+// ============================================================================
+
+TEST_F(LoadableEncryptorUtilsTest, LoadValidLibrary) {
+  // Test loading the library
+  std::unique_ptr<DataBatchProtectionAgentInterface> agent;
+  
+  try {
+    agent = LoadableEncryptorUtils::LoadFromLibrary(library_path_);
+    ASSERT_NE(agent, nullptr) << "Agent should be successfully loaded";
+  } catch (const std::runtime_error& e) {
+    // Library doesn't exist or failed to load - this is expected in some build environments
+    GTEST_SKIP() << "Library not available: " << e.what();
+  }
+}
+
+TEST_F(LoadableEncryptorUtilsTest, MultipleLoads) {
+  // Load multiple agents
+  std::unique_ptr<DataBatchProtectionAgentInterface> agent1, agent2, agent3;
+  
+  try {
+    agent1 = LoadableEncryptorUtils::LoadFromLibrary(library_path_);
+    agent2 = LoadableEncryptorUtils::LoadFromLibrary(library_path_);
+    agent3 = LoadableEncryptorUtils::LoadFromLibrary(library_path_);
+    
+    ASSERT_NE(agent1, nullptr) << "First agent should be successfully loaded";
+    ASSERT_NE(agent2, nullptr) << "Second agent should be successfully loaded";
+    ASSERT_NE(agent3, nullptr) << "Third agent should be successfully loaded";
+
+    // Verify that all instances are different from each other
+    ASSERT_NE(agent1.get(), agent2.get()) << "First and second agents should be different instances";
+    ASSERT_NE(agent1.get(), agent3.get()) << "First and third agents should be different instances";
+    ASSERT_NE(agent2.get(), agent3.get()) << "Second and third agents should be different instances";
+    
+  } catch (const std::runtime_error& e) {
+    // Library doesn't exist or failed to load - this is expected in some build environments
+    GTEST_SKIP() << "Library not available: " << e.what();
+  }
+}
+
+TEST_F(LoadableEncryptorUtilsTest, ReturnsDBPALibraryWrapper) {
+  // Test that LoadFromLibrary returns an instance of DBPALibraryWrapper
+  std::unique_ptr<DataBatchProtectionAgentInterface> agent;
+  
+  try {
+    agent = LoadableEncryptorUtils::LoadFromLibrary(library_path_);
+    ASSERT_NE(agent, nullptr) << "Agent should be successfully loaded";
+    
+    // Verify that the returned instance is of type DBPALibraryWrapper
+    DBPALibraryWrapper* wrapper = dynamic_cast<DBPALibraryWrapper*>(agent.get());
+    EXPECT_NE(wrapper, nullptr) << "Returned instance should be of type DBPALibraryWrapper";    
+  } catch (const std::runtime_error& e) {
+    // Library doesn't exist or failed to load - this is expected in some build environments
+    GTEST_SKIP() << "Library not available: " << e.what();
+  }
+}
+
+// ============================================================================
+// ERROR HANDLING TESTS
+// ============================================================================
+
+TEST_F(LoadableEncryptorUtilsTest, EmptyLibraryPath) {
+  EXPECT_THROW({
+    LoadableEncryptorUtils::LoadFromLibrary("");
+  }, std::invalid_argument);
+}
+
+TEST_F(LoadableEncryptorUtilsTest, NonexistentLibrary) {
+  EXPECT_THROW({
+    LoadableEncryptorUtils::LoadFromLibrary("./nonexistent_library.so");
+  }, std::runtime_error);
+}
+
+TEST_F(LoadableEncryptorUtilsTest, InvalidLibraryPath) {
+  EXPECT_THROW({
+    LoadableEncryptorUtils::LoadFromLibrary("/invalid/path/to/library.so");
+  }, std::runtime_error);
+}
+
+}  // namespace parquet::encryption::external::test 


### PR DESCRIPTION
Adding LoadableEncryptorUtils - an util class for loading DBPA Instances from DLLs

This work includes the addition of `dbpa_test_agent.*` - a "dummy" DBPA implementation (XOR-based) which is build into a shared library and used exclusively for unit testing purposes.

This work is part of a series of PRs created to merge the "DLL Loading" work into `dev_phase2`. 
This work was already reviewed when "DLL Loading" was written against `dev-miniapp`. 

Existing Parquet and Parquet-encryption related unit and integration tests pass.
The newly added unit tests passes.
