### PR TITLE
Adding external/dbpa_utils.* for translating enum values between the Arrow and DBPS namespaces

### DIFF
--- a/cpp/src/parquet/encryption/external/dbpa_utils.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_utils.cc
@@ -1,0 +1,101 @@
+//TODO: figure out licensing.
+//https://github.com/protegrity/arrow/issues/112
+
+#include "parquet/encryption/external/dbpa_utils.h"
+
+#include <stdexcept>
+
+namespace parquet::encryption::external {
+
+dbps::external::Type::type dbpa_utils::ParquetTypeToExternal(parquet::Type::type parquet_type) {
+    // The enums have identical values, so we can do a direct cast
+    switch (parquet_type) {
+        case parquet::Type::BOOLEAN:
+            return dbps::external::Type::BOOLEAN;
+        case parquet::Type::INT32:
+            return dbps::external::Type::INT32;
+        case parquet::Type::INT64:
+            return dbps::external::Type::INT64;
+        case parquet::Type::INT96:
+            return dbps::external::Type::INT96;
+        case parquet::Type::FLOAT:
+            return dbps::external::Type::FLOAT;
+        case parquet::Type::DOUBLE:
+            return dbps::external::Type::DOUBLE;
+        case parquet::Type::BYTE_ARRAY:
+            return dbps::external::Type::BYTE_ARRAY;
+        case parquet::Type::FIXED_LEN_BYTE_ARRAY:
+            return dbps::external::Type::FIXED_LEN_BYTE_ARRAY;
+        case parquet::Type::UNDEFINED:
+        default:
+            throw std::invalid_argument("Invalid parquet::Type value");
+    }
+}
+
+parquet::Type::type dbpa_utils::ExternalTypeToParquet(dbps::external::Type::type external_type) {
+    // The enums have identical values, so we can do a direct cast
+    switch (external_type) {
+        case dbps::external::Type::BOOLEAN:
+            return parquet::Type::BOOLEAN;
+        case dbps::external::Type::INT32:
+            return parquet::Type::INT32;
+        case dbps::external::Type::INT64:
+            return parquet::Type::INT64;
+        case dbps::external::Type::INT96:
+            return parquet::Type::INT96;
+        case dbps::external::Type::FLOAT:
+            return parquet::Type::FLOAT;
+        case dbps::external::Type::DOUBLE:
+            return parquet::Type::DOUBLE;
+        case dbps::external::Type::BYTE_ARRAY:
+            return parquet::Type::BYTE_ARRAY;
+        case dbps::external::Type::FIXED_LEN_BYTE_ARRAY:
+            return parquet::Type::FIXED_LEN_BYTE_ARRAY;
+        default:
+            throw std::invalid_argument("Invalid dbps::external::Type value");
+    }
+}
+
+dbps::external::CompressionCodec::type dbpa_utils::ArrowCompressionToExternal(::arrow::Compression::type arrow_compression) {
+    switch (arrow_compression) {
+        case ::arrow::Compression::UNCOMPRESSED:
+            return dbps::external::CompressionCodec::UNCOMPRESSED;
+        case ::arrow::Compression::SNAPPY:
+            return dbps::external::CompressionCodec::SNAPPY;
+        case ::arrow::Compression::GZIP:
+            return dbps::external::CompressionCodec::GZIP;
+        case ::arrow::Compression::LZO:
+            return dbps::external::CompressionCodec::LZO;
+        case ::arrow::Compression::BROTLI:
+            return dbps::external::CompressionCodec::BROTLI;
+        case ::arrow::Compression::LZ4:
+            return dbps::external::CompressionCodec::LZ4;
+        case ::arrow::Compression::ZSTD:
+            return dbps::external::CompressionCodec::ZSTD;
+        default:
+            throw std::invalid_argument("Invalid arrow::Compression value");
+    }
+}
+
+::arrow::Compression::type dbpa_utils::ExternalCompressionToArrow(dbps::external::CompressionCodec::type external_compression) {
+    switch (external_compression) {
+        case dbps::external::CompressionCodec::UNCOMPRESSED:
+            return ::arrow::Compression::UNCOMPRESSED;
+        case dbps::external::CompressionCodec::SNAPPY:
+            return ::arrow::Compression::SNAPPY;
+        case dbps::external::CompressionCodec::GZIP:
+            return ::arrow::Compression::GZIP;
+        case dbps::external::CompressionCodec::LZO:
+            return ::arrow::Compression::LZO;
+        case dbps::external::CompressionCodec::BROTLI:
+            return ::arrow::Compression::BROTLI;
+        case dbps::external::CompressionCodec::LZ4:
+            return ::arrow::Compression::LZ4;
+        case dbps::external::CompressionCodec::ZSTD:
+            return ::arrow::Compression::ZSTD;
+        default:
+            throw std::invalid_argument("Invalid dbps::external::CompressionCodec value");
+    }
+}
+
+} // namespace parquet::encryption::external

--- a/cpp/src/parquet/encryption/external/dbpa_utils.h
+++ b/cpp/src/parquet/encryption/external/dbpa_utils.h
@@ -1,0 +1,58 @@
+// TODO: Figure out licensing.
+// https://github.com/protegrity/arrow/issues/112
+
+#pragma once
+
+#include <stdexcept>
+
+#include "parquet/encryption/external/borrowed/dbpa_interface.h"
+#include "parquet/types.h"
+#include "arrow/type_fwd.h" // For arrow::Compression
+
+namespace parquet::encryption::external {
+
+/**
+ * Utility class for translating between Parquet/Arrow enums and dbps::external enums.
+ * 
+ * This class provides methods to convert between:
+ * - parquet::Type and dbps::external::Type
+ * - arrow::Compression and dbps::external::CompressionCodec
+ */
+class dbpa_utils {
+public:
+    /**
+     * Convert parquet::Type to dbps::external::Type
+     * 
+     * @param parquet_type The parquet type to convert
+     * @return The corresponding dbps::external::Type
+     */
+    static dbps::external::Type::type ParquetTypeToExternal(parquet::Type::type parquet_type);
+    
+    /**
+     * Convert dbps::external::Type to parquet::Type
+     * 
+     * @param external_type The dbps::external type to convert
+     * @return The corresponding parquet::Type
+     */
+    static parquet::Type::type ExternalTypeToParquet(dbps::external::Type::type external_type);
+    
+    /**
+     * Convert arrow::Compression to dbps::external::CompressionCodec
+     * 
+     * @param arrow_compression The Arrow compression type to convert
+     * @return The corresponding dbps::external::CompressionCodec
+     * @throws std::invalid_argument if the Arrow compression type cannot be mapped
+     */
+    static dbps::external::CompressionCodec::type ArrowCompressionToExternal(::arrow::Compression::type arrow_compression);
+    
+    /**
+     * Convert dbps::external::CompressionCodec to arrow::Compression
+     * 
+     * @param external_compression The dbps::external compression type to convert
+     * @return The corresponding arrow::Compression
+     * @throws std::invalid_argument if the external compression type cannot be mapped
+     */
+    static ::arrow::Compression::type ExternalCompressionToArrow(dbps::external::CompressionCodec::type external_compression);
+};
+
+} // namespace parquet::encryption::external


### PR DESCRIPTION
Adding `parquet/encryption/external/dbpa_utils.*` for translating enum values between the Arrow and DBPS namespaces

This code is to be used by the new implementation of `ExternalDBPAEncryptorAdapter` and `ExternalDBPADecryptorAdapter` to generate new DBPA instances.

Existing tests pass. Not sure that writing tests for the limited functionality of the new code makes sense (given that it's simple translation).

