### PR TITLE
Modifying ExternalDBPAEncryptor/DecryptorAdapter to obtain agent instance from shared lib (DLL)

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -239,10 +239,11 @@ endif()
 if(PARQUET_REQUIRE_ENCRYPTION)
   list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS ${ARROW_OPENSSL_LIBS})
   set(PARQUET_SRCS ${PARQUET_SRCS} encryption/aes_encryption.cc
+                   encryption/openssl_internal.cc
                    encryption/encryption_utils.cc
                    encryption/external_dbpa_encryption.cc
-                   encryption/openssl_internal.cc
                    encryption/external/dbpa_library_wrapper.cc
+                   encryption/external/dbpa_utils.cc
                    encryption/external/loadable_encryptor_utils.cc
                    )
   # Encryption key management

--- a/cpp/src/parquet/encryption/external/dbpa_utils.h
+++ b/cpp/src/parquet/encryption/external/dbpa_utils.h
@@ -5,7 +5,7 @@
 
 #include <stdexcept>
 
-#include "parquet/encryption/external/borrowed/dbpa_interface.h"
+#include "parquet/encryption/external/third_party/dbpa_interface.h"
 #include "parquet/types.h"
 #include "arrow/type_fwd.h" // For arrow::Compression
 

--- a/cpp/src/parquet/encryption/external_dbpa_encryption.h
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption.h
@@ -5,6 +5,8 @@
 #include <map>
 #include <vector>
 
+#include "parquet/encryption/external/third_party/dbpa_interface.h"
+
 #include "parquet/encryption/encryptor_interface.h"
 #include "parquet/encryption/decryptor_interface.h"
 #include "parquet/metadata.h"
@@ -46,7 +48,7 @@ class ExternalDBPAEncryptorAdapter : public EncryptorInterface {
                               ::arrow::util::span<uint8_t> encrypted_footer) override;
  
   private:   
-    int32_t CallExternalDBPA(
+    int32_t InvokeExternalEncrypt(
       ::arrow::util::span<const uint8_t> plaintext, ::arrow::util::span<uint8_t> ciphertext);
     
     ParquetCipher::type algorithm_;
@@ -57,6 +59,9 @@ class ExternalDBPAEncryptorAdapter : public EncryptorInterface {
     Encoding::type encoding_type_;
     std::string app_context_;
     std::map<std::string, std::string> connection_config_;
+    
+    std::unique_ptr<dbps::external::DataBatchProtectionAgentInterface> agent_instance_;
+    bool agent_initialized_ = false;
 };
 
 /// Factory for ExternalDBPAEncryptorAdapter instances. The cache exists while the write
@@ -104,7 +109,7 @@ class ExternalDBPADecryptorAdapter : public DecryptorInterface {
                   ::arrow::util::span<uint8_t> plaintext) override;
 
   private:   
-    int32_t CallExternalDBPA(
+    int32_t InvokeExternalDecrypt(
       ::arrow::util::span<const uint8_t> ciphertext, ::arrow::util::span<uint8_t> plaintext);
     
     ParquetCipher::type algorithm_;
@@ -116,6 +121,9 @@ class ExternalDBPADecryptorAdapter : public DecryptorInterface {
     std::vector<Encoding::type> encoding_types_;
     std::string app_context_;
     std::map<std::string, std::string> connection_config_;
+
+    std::unique_ptr<dbps::external::DataBatchProtectionAgentInterface> agent_instance_;
+    bool agent_initialized_ = false;
 };
 
 /// Factory for ExternalDBPADecryptorAdapter instances. No cache exists for decryptors.

--- a/cpp/src/parquet/encryption/read_configurations_test.cc
+++ b/cpp/src/parquet/encryption/read_configurations_test.cc
@@ -184,6 +184,7 @@ class TestDecryptionConfiguration
     file_decryption_builder_5.key_retriever(kr5);
     file_decryption_builder_5.connection_config({
       {parquet::ParquetCipher::EXTERNAL_DBPA_V1, {
+          {"agent_library_path", "libDBPATestAgent.so"},
           {"file_path", "/tmp/test"},
           {"other_config", "value"}
       }}

--- a/cpp/src/parquet/encryption/write_configurations_test.cc
+++ b/cpp/src/parquet/encryption/write_configurations_test.cc
@@ -244,6 +244,7 @@ TEST_F(TestEncryptionConfiguration, EncryptWithPerColumnEncryption) {
                             ->algorithm(parquet::ParquetCipher::AES_GCM_V1)
                             ->connection_config({
                                 {parquet::ParquetCipher::EXTERNAL_DBPA_V1, {
+                                    {"agent_library_path", "libDBPATestAgent.so"},
                                     {"file_path", "/tmp/test"},
                                     {"other_config", "value"}
                                 }}


### PR DESCRIPTION
Modifying ExternalDBPAEncryptor/DecryptorAdapter to obtain agent instance from shared lib (DLL)

This is the last piece which connects together the base work in Arrow (`dev_phase2`), and DLL-based agent loading. 

Both `ExternalDBPAEncryptorAdapter` and `ExternalDBPADecryptorAdapter` have been modified to abandon the simple, pass-through encryption/decryption, and to make use of the DLL-loaded agent (which must be specific in the `connection_config` object passed in. The modifications include (a) looking for the DLL-file name in the properties, (b) instantiating a new agent from the DLL, and (c) forwarding the encrypt/decrypt operations to the DLL-based agent.


**Testing**
- Tests inside `external_dbpa_encryption_tests.cc` had to be modified to account for the need of DLL. For these tests, we're making use of `libDBPATestAgent.so`, which is built out of `external/dbpa_test_agent.*` (and used in a few different test scenarios).
- Newly modified tests pass.
- All existing Parquet (`ctest -L parquet`) tests pass. 
- All other tests were unaffected.
- Manually verified that the end-to-end workflow in `base_app.py` completes succesfully.

**Notes**
- A similar change was performed in the `dev-miniApp` codebase: https://github.com/protegrity/arrow/pull/68, however bear in mind that the structure of encryptors/decryptors is/was quite different in the miniApp
- There will be another PR with some modifications to `base_app.py` (it needs to account for DLL-based agent loading)