### PR TITLE
Updating to latest version of dbpa_interface.h

### DIFF
--- a/cpp/src/parquet/encryption/external/third_party/dbpa_interface.h
+++ b/cpp/src/parquet/encryption/external/third_party/dbpa_interface.h
@@ -8,30 +8,37 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <stdexcept>
 #include "span.hpp"
 #include "enums.h"
 
-#ifndef DBPS_EXPORT
-#define DBPS_EXPORT
-#endif
+template <typename T>
+using span = tcb::span<T>;
 
 // TODO: this file was copied from
 // https://github.com/protegrity/DataBatchProtectionService
 // we need to find a better way to share it between repos.
 // https://github.com/protegrity/arrow/issues/110
 
-namespace dbps::external {
+#ifndef DBPS_EXPORT
+#define DBPS_EXPORT
+#endif
 
-template <typename T>
-using span = tcb::span<T>;
+class DBPS_EXPORT DBPSException : public std::runtime_error {
+public:
+    explicit DBPSException(const std::string& message) : std::runtime_error(message) {}
+};
+
+namespace dbps::external {
 
 /*
  * DataBatchProtectionAgentInterface, EncryptionResult and DecryptionResult implementation contracts:
  * - While handle to EncryptionResult/DecryptionResult exists, ciphertext()/plaintext() is guaranteed to return valid data
  * - Read operations are not destructive. Multiple calls return the same data
  * - Destructor must dispose of internal memory (either by delegation or cleanup)
- * - No throwing exceptions. Errors reported via success() flag and error methods.
  * - Library users must check size() to ensure the actual size of the returned payload.
+ * - Exceptions on init(): init() may throw DBPSException for initialization errors (e.g., invalid parameters, server connection failures)
+ * - Exceptions on Encrypt() and Decrypt(): Encrypt/Decrypt do not throw exceptions. Errors reported via success() flag and error methods.
  */
 
 class DBPS_EXPORT EncryptionResult {
@@ -100,7 +107,7 @@ public:
 
     virtual ~DataBatchProtectionAgentInterface() = default;
 
-private:
+protected:
     std::string column_name_;
     std::map<std::string, std::string> connection_config_;
     std::string app_context_;  // includes user_id

--- a/cpp/src/parquet/encryption/external_dbpa_encryption.cc
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption.cc
@@ -55,6 +55,8 @@ std::unique_ptr<dbps::external::DataBatchProtectionAgentInterface> LoadAndInitia
   std::cout << "[DEBUG] Initializing agent instance" << std::endl;
 
   // Step 3: Initialize the agent.
+  //TODO: this may throw an exception.
+  //We'll need to handle it in the executor.
   agent_instance->init(
     /*column_name*/ column_name,
     /*connection_config*/ connection_config,
@@ -69,10 +71,10 @@ std::unique_ptr<dbps::external::DataBatchProtectionAgentInterface> LoadAndInitia
   return agent_instance;
 }
 
-//this is  private constructor, invoked from Make()
+//this is a private constructor, invoked from Make()
+//at this point, the agent_instance is assumed to be initialized.
 ExternalDBPAEncryptorAdapter::ExternalDBPAEncryptorAdapter(std::unique_ptr<DataBatchProtectionAgentInterface> agent_instance)
   : agent_instance_(std::move(agent_instance)) {
-    agent_initialized_ = true;
 }
   
 std::unique_ptr<ExternalDBPAEncryptorAdapter> ExternalDBPAEncryptorAdapter::Make(
@@ -148,10 +150,6 @@ int32_t ExternalDBPAEncryptorAdapter::InvokeExternalEncrypt(
         std::cout << "  [" << cfg_key << "]: [" << cfg_value << "]" << std::endl;
       }
   
-      if (!agent_initialized_) {
-        throw ParquetException("Underlying DBPA Agent was not initialized");
-      }
-
       std::cout << "[DEBUG] Calling agent_instance_->Encrypt..." << std::endl;
       std::unique_ptr<EncryptionResult> result = agent_instance_->Encrypt(plaintext);
   
@@ -225,9 +223,9 @@ ExternalDBPAEncryptorAdapter* ExternalDBPAEncryptorAdapterFactory::GetEncryptor(
 }
 
 //private constructor, invoked from Make()
+//at this point, the agent_instance is assumed to be initialized.
 ExternalDBPADecryptorAdapter::ExternalDBPADecryptorAdapter(std::unique_ptr<DataBatchProtectionAgentInterface> agent_instance)
   : agent_instance_(std::move(agent_instance)) {
-    agent_initialized_ = true;
 }
 
 std::unique_ptr<ExternalDBPADecryptorAdapter> ExternalDBPADecryptorAdapter::Make(
@@ -305,10 +303,6 @@ int32_t ExternalDBPADecryptorAdapter::InvokeExternalDecrypt(
         std::cout << "  [" << key << "]: [" << value << "]" << std::endl;
       }
   
-      if (!agent_initialized_) {
-        throw ParquetException("Underlying DBPA Agent was not initialized");
-      }
-
       std::cout << "[DEBUG] Calling agent_instance_->Decrypt..." << std::endl;
       std::unique_ptr<DecryptionResult> result = agent_instance_->Decrypt(ciphertext);
       

--- a/cpp/src/parquet/encryption/external_dbpa_encryption.h
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption.h
@@ -45,6 +45,8 @@ class ExternalDBPAEncryptorAdapter : public EncryptorInterface {
                               ::arrow::util::span<uint8_t> encrypted_footer) override;
  
  private:
+    //agent_instance is assumed to be initialized at the time of construction. 
+    //no initialization nor checks to verify that it is initialized are performed.
     ExternalDBPAEncryptorAdapter(std::unique_ptr<DataBatchProtectionAgentInterface> agent_instance);
 
     int32_t InvokeExternalEncrypt(
@@ -60,7 +62,6 @@ class ExternalDBPAEncryptorAdapter : public EncryptorInterface {
     std::map<std::string, std::string> connection_config_;
     
     std::unique_ptr<dbps::external::DataBatchProtectionAgentInterface> agent_instance_;
-    bool agent_initialized_ = false;
 };
 
 /// Factory for ExternalDBPAEncryptorAdapter instances. The cache exists while the write
@@ -108,7 +109,9 @@ class ExternalDBPADecryptorAdapter : public DecryptorInterface {
                   ::arrow::util::span<uint8_t> plaintext) override;
 
   private:
-    ExternalDBPADecryptorAdapter(std::unique_ptr<DataBatchProtectionAgentInterface> agent_instance_);
+    //agent_instance is assumed to be initialized at the time of construction. 
+    //no initialization nor checks to verify that it is initialized are performed.
+    ExternalDBPADecryptorAdapter(std::unique_ptr<DataBatchProtectionAgentInterface> agent_instance);
     
     int32_t InvokeExternalDecrypt(
       ::arrow::util::span<const uint8_t> ciphertext, ::arrow::util::span<uint8_t> plaintext);
@@ -124,7 +127,6 @@ class ExternalDBPADecryptorAdapter : public DecryptorInterface {
     std::map<std::string, std::string> connection_config_;
 
     std::unique_ptr<dbps::external::DataBatchProtectionAgentInterface> agent_instance_;
-    bool agent_initialized_ = false;
 };
 
 /// Factory for ExternalDBPADecryptorAdapter instances. No cache exists for decryptors.


### PR DESCRIPTION
Updating to latest version of dbpa_interface.h

As part of this change we're also modifying `ExternalDBPAEncryptorAdapter` and `ExternalDBPADecryptorAdapter` to assume that if an instance of DBPAgent is passed, that it will be initialized.

The initialization of the agent instance occurs in the `External...Adapter::Make()` method, which is the builder method. Once an instance is successfully created and initialized, it is passed to the constructor. If failed to initialize, then DBPAgent::Init() will throw an exception. 

In a later change, the Executor will be capturing the exceptions in `::init()` and reporting them up the calling chain.

**Testing**
- Existing tests pass (via `ctest -L parquet`)
- Manual testing verifies that happy and un-happy paths work. 

Will need to add a test to validate that an failure in DBPAgent::Init() will realize in an exception and failure to instantiate the Encryptor/Decryptor. That will be coming in a later PR.