### PR TITLE
Testing improvements: locating shared library (DLL) file for tests.

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -419,6 +419,7 @@ if(PARQUET_REQUIRE_ENCRYPTION)
                    encryption/external_dbpa_encryption_test.cc
                    encryption/write_configurations_test.cc
                    encryption/read_configurations_test.cc
+                   encryption/external/test_utils.cc
                    encryption/properties_test.cc
                    encryption/crypto_factory_test.cc
                    encryption/test_encryption_util.cc

--- a/cpp/src/parquet/encryption/CMakeLists.txt
+++ b/cpp/src/parquet/encryption/CMakeLists.txt
@@ -33,6 +33,7 @@ if(ARROW_TESTING)
   # (depends on DBPATestAgent)
   add_parquet_test(loadable-encryptor-utils-test
                    SOURCES external/loadable_encryptor_utils_test.cc
+                           external/test_utils.cc
                    LABELS "parquet-tests" "encryption-tests")
 
   # Add test for DBPALibraryWrapper

--- a/cpp/src/parquet/encryption/external/loadable_encryptor_utils_test.cc
+++ b/cpp/src/parquet/encryption/external/loadable_encryptor_utils_test.cc
@@ -9,17 +9,8 @@
 #include "parquet/encryption/external/loadable_encryptor_utils.h"
 #include "parquet/encryption/external/third_party/dbpa_interface.h"
 #include "parquet/encryption/external/dbpa_library_wrapper.h"
-//#include "arrow/util/span.h"
-//#include "parquet/test_util.h"
+#include "parquet/encryption/external/test_utils.h"
 
-#ifdef __APPLE__
-#include <mach-o/dyld.h>
-#elif defined(__linux__)
-#include <unistd.h>
-#include <linux/limits.h>
-#elif defined(_WIN32)
-#include <windows.h>
-#endif
 
 namespace parquet::encryption::external::test {
 
@@ -32,72 +23,8 @@ class LoadableEncryptorUtilsTest : public ::testing::Test {
     void SetUp() override {
       // Get the path to the DBPATestAgent shared library
       // This assumes the library is built 
-      library_path_ = GetTestLibraryPath();
+      library_path_ = TestUtils::GetTestLibraryPath();
     }
-
-// Helper function to get the directory where the executable is located
-// used within GetTestLibraryPath to determine the path to the test library (*.so)
-std::string GetExecutableDirectory() {
-  #ifdef __APPLE__
-    char path[PATH_MAX];
-    uint32_t size = sizeof(path);
-    if (_NSGetExecutablePath(path, &size) == 0) {
-      return std::filesystem::path(path).parent_path().string();
-    }
-  #elif defined(__linux__)
-    char path[PATH_MAX];
-    ssize_t len = readlink("/proc/self/exe", path, sizeof(path) - 1);
-    if (len != -1) {
-      path[len] = '\0';
-      return std::filesystem::path(path).parent_path().string();
-    }
-  #elif defined(_WIN32)
-    char path[MAX_PATH];
-    if (GetModuleFileNameA(NULL, path, MAX_PATH) != 0) {
-      return std::filesystem::path(path).parent_path().string();
-    }
-  #endif
-    // Fallback to current working directory if we can't determine executable path
-    return std::filesystem::current_path().string();
-  }
-
-  // Helper method to get the path to the test library
-  std::string GetTestLibraryPath() {
-    // Check for environment variable to override the executable directory
-    const char* cwd_override = std::getenv("PARQUET_TEST_LIBRARY_CWD");
-    std::string base_path;
-    
-    if (cwd_override && cwd_override[0]) {
-      base_path = std::string(cwd_override);
-    } else {
-      // Get the directory where the executable is located
-      base_path = GetExecutableDirectory();
-    }
-
-    std::vector<std::string> possible_filenames = {
-      "libDBPATestAgent.so",
-      "libDBPATestAgent.dylib",
-      "DBPATestAgent.dll"
-    };
-
-    std::vector<std::string> possible_directories = {
-      GetExecutableDirectory() + "/",
-      base_path + "/"
-      "./",
-      ""
-    };
-
-    for (const auto& filename : possible_filenames) {
-      for (const auto& directory : possible_directories) {
-        std::string path = directory + filename;
-        if (std::filesystem::exists(path)) {
-          return path;
-        }
-      }
-    }
-
-    throw std::runtime_error("Could not find library");
-  }
 };
 
 // ============================================================================

--- a/cpp/src/parquet/encryption/external/test_utils.cc
+++ b/cpp/src/parquet/encryption/external/test_utils.cc
@@ -1,0 +1,81 @@
+// TODO: figure out the licensing.
+
+#include "parquet/encryption/external/test_utils.h"
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#elif defined(__linux__)
+#include <unistd.h>
+#include <linux/limits.h>
+#elif defined(_WIN32)
+#include <windows.h>
+#endif
+
+namespace parquet::encryption::external::test {
+
+std::string TestUtils::GetExecutableDirectory() {
+#ifdef __APPLE__
+  char path[PATH_MAX];
+  uint32_t size = sizeof(path);
+  if (_NSGetExecutablePath(path, &size) == 0) {
+    return std::filesystem::path(path).parent_path().string();
+  }
+#elif defined(__linux__)
+  char path[PATH_MAX];
+  ssize_t len = readlink("/proc/self/exe", path, sizeof(path) - 1);
+  if (len != -1) {
+    path[len] = '\0';
+    return std::filesystem::path(path).parent_path().string();
+  }
+#elif defined(_WIN32)
+  char path[MAX_PATH];
+  if (GetModuleFileNameA(NULL, path, MAX_PATH) != 0) {
+    return std::filesystem::path(path).parent_path().string();
+  }
+#endif
+  // Fallback to current working directory if we can't determine executable path
+  return std::filesystem::current_path().string();
+}
+
+std::string TestUtils::GetTestLibraryPath() {
+  // Check for environment variable to override the executable directory
+  const char* cwd_override = std::getenv("PARQUET_TEST_LIBRARY_CWD");
+  std::string base_path;
+  
+  if (cwd_override && cwd_override[0]) {
+    base_path = std::string(cwd_override);
+  } else {
+    // Get the directory where the executable is located
+    base_path = GetExecutableDirectory();
+  }
+
+  std::vector<std::string> possible_filenames = {
+    "libDBPATestAgent.so",
+    "libDBPATestAgent.dylib",
+    "DBPATestAgent.dll"
+  };
+
+  std::vector<std::string> possible_directories = {
+    GetExecutableDirectory() + "/",
+    base_path + "/",
+    "./",
+    ""
+  };
+
+  for (const auto& filename : possible_filenames) {
+    for (const auto& directory : possible_directories) {
+      std::string path = directory + filename;
+      if (std::filesystem::exists(path)) {
+        return path;
+      }
+    }
+  }
+
+  throw std::runtime_error("Could not find library");
+}
+
+}  // namespace parquet::encryption::external::test

--- a/cpp/src/parquet/encryption/external/test_utils.h
+++ b/cpp/src/parquet/encryption/external/test_utils.h
@@ -1,0 +1,32 @@
+// TODO: figure out the licensing.
+
+#pragma once
+
+#include <string>
+
+namespace parquet::encryption::external::test {
+
+/**
+ * Utility class for test-related helper functions.
+ */
+class TestUtils {
+ public:
+  /**
+   * Get the directory where the executable is located.
+   * Used to determine the path to test libraries (*.so, *.dylib, *.dll).
+   * 
+   * @return The directory path where the executable is located
+   */
+  static std::string GetExecutableDirectory();
+
+  /**
+   * Get the path to the test library (DBPATestAgent).
+   * Searches for the library in various possible locations and filenames.
+   * 
+   * @return The full path to the test library
+   * @throws std::runtime_error if the library cannot be found
+   */
+  static std::string GetTestLibraryPath();
+};
+
+}  // namespace parquet::encryption::external::test

--- a/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
@@ -5,6 +5,7 @@
 
 #include "parquet/encryption/encryption.h"
 #include "parquet/encryption/external_dbpa_encryption.h"
+#include "parquet/encryption/external/test_utils.h"
 
 /// TODO(sbrenes): Add proper testing. Right now we are just going to test that the
 /// encryptor and decryptor are created and that the plaintext is returned as the ciphertext.
@@ -14,12 +15,15 @@ namespace parquet::encryption::test {
 class ExternalDBPAEncryptorAdapterTest : public ::testing::Test {
  protected:
   void SetUp() override {
+
+    // this library will use heuristics to load "libDBPATestAgent.so", needed for tests here.
+    std::string library_path = parquet::encryption::external::test::TestUtils::GetTestLibraryPath();
+
     app_context_ = 
       "{\"user_id\": \"abc123\", \"location\": {\"lat\": 9.7489, \"lon\": -83.7534}}";
     connection_config_ = {
-      {"lib_name", "dbpa_lib.so"},
       {"config_path", "path/to/file"}, 
-      {"agent_library_path", "libDBPATestAgent.so"}
+      {"agent_library_path", library_path}
     };
   }
 

--- a/cpp/src/parquet/encryption/read_configurations_test.cc
+++ b/cpp/src/parquet/encryption/read_configurations_test.cc
@@ -30,6 +30,8 @@
 #include "parquet/file_reader.h"
 #include "parquet/test_util.h"
 
+#include "parquet/encryption/external/test_utils.h"
+
 /*
  * This file contains a unit-test for reading encrypted Parquet files with
  * different decryption configurations.
@@ -171,6 +173,9 @@ class TestDecryptionConfiguration
     // columns.
     vector_of_decryption_configurations_.push_back(NULL);
 
+    // this library will use heuristics to load "libDBPATestAgent.so", needed for this test.
+    std::string library_path = parquet::encryption::external::test::TestUtils::GetTestLibraryPath();
+
     // Decryption configuration 5: External decryption configuration for use in per-column
     // encryption.   
     std::shared_ptr<parquet::StringKeyIdRetriever> string_kr5 =
@@ -184,7 +189,7 @@ class TestDecryptionConfiguration
     file_decryption_builder_5.key_retriever(kr5);
     file_decryption_builder_5.connection_config({
       {parquet::ParquetCipher::EXTERNAL_DBPA_V1, {
-          {"agent_library_path", "libDBPATestAgent.so"},
+          {"agent_library_path", library_path},
           {"file_path", "/tmp/test"},
           {"other_config", "value"}
       }}

--- a/cpp/src/parquet/encryption/write_configurations_test.cc
+++ b/cpp/src/parquet/encryption/write_configurations_test.cc
@@ -29,6 +29,8 @@
 #include "parquet/platform.h"
 #include "parquet/test_util.h"
 
+#include "parquet/encryption/external/test_utils.h"
+
 /*
  * This file contains unit-tests for writing encrypted Parquet files with
  * different encryption configurations.
@@ -227,6 +229,9 @@ TEST_F(TestEncryptionConfiguration, EncryptWithPerColumnEncryption) {
     std::map<std::string, std::shared_ptr<parquet::ColumnEncryptionProperties>>
         encryption_cols;
 
+    // this library will use heuristics to load "libDBPATestAgent.so", needed for this test.
+    std::string library_path = parquet::encryption::external::test::TestUtils::GetTestLibraryPath();
+
     parquet::ColumnEncryptionProperties::Builder col_builder_1(path_to_double_field_);
     col_builder_1.key(kColumnEncryptionKey1_)->key_id("kc1");
     col_builder_1.parquet_cipher(parquet::ParquetCipher::AES_GCM_V1);
@@ -244,7 +249,7 @@ TEST_F(TestEncryptionConfiguration, EncryptWithPerColumnEncryption) {
                             ->algorithm(parquet::ParquetCipher::AES_GCM_V1)
                             ->connection_config({
                                 {parquet::ParquetCipher::EXTERNAL_DBPA_V1, {
-                                    {"agent_library_path", "libDBPATestAgent.so"},
+                                    {"agent_library_path", library_path},
                                     {"file_path", "/tmp/test"},
                                     {"other_config", "value"}
                                 }}


### PR DESCRIPTION
Testing improvements: adding parquet/encryption/external/test_utils.* to help locate shared library file for tests.

This helps test execute successfully in some environments without the need to setting/modifying LD_LIBRARY_PATH with the location of the `libDBPATestAgent.so`, the shared library (DLL) needed by some tests.

No new tests were added. No functionality was modified. 

Verified that tests (`ctest -L parquet`) pass without the need to set LD_LIBRARY_PATH.