### PR TITLE
[do not merge] First pass of ColumnChunkMetadataInfo 

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -243,6 +243,7 @@ if(PARQUET_REQUIRE_ENCRYPTION)
                    encryption/encryption_utils.cc
                    encryption/external_dbpa_encryption.cc
                    encryption/external/dbpa_library_wrapper.cc
+                   encryption/column_chunk_properties.cc
                    encryption/external/dbpa_utils.cc
                    encryption/external/loadable_encryptor_utils.cc
                    )

--- a/cpp/src/parquet/encryption/column_chunk_properties.cc
+++ b/cpp/src/parquet/encryption/column_chunk_properties.cc
@@ -1,0 +1,89 @@
+// TODO: add license
+
+#include "parquet/encryption/column_chunk_properties.h"
+
+namespace parquet::encryption {
+
+ColumnChunkProperties::ColumnChunkProperties(
+    std::string column_path,
+    parquet::ParquetDataPageVersion page_version,
+    parquet::Type::type physical_type,
+    parquet::Encoding::type dictionary_page_encoding,
+    parquet::Encoding::type dictionary_index_encoding,
+    parquet::Encoding::type data_page_encoding,
+    ::arrow::Compression::type compression,
+    std::int64_t fixed_length_bytes
+) : column_path_(column_path),
+    page_version_(page_version), 
+    physical_type_(physical_type), 
+    dictionary_page_encoding_(dictionary_page_encoding), 
+    dictionary_index_encoding_(dictionary_index_encoding), 
+    data_page_encoding_(data_page_encoding), 
+    compression_(compression), 
+    fixed_length_bytes_(fixed_length_bytes) {}
+
+std::unique_ptr<ColumnChunkProperties> ColumnChunkProperties::MakeFromMetadata(const ColumnChunkMetaDataBuilder* column_chunk_metadata) {
+
+    //TODO: validation
+    auto column_path = column_chunk_metadata->descr()->path();
+    auto column_path_string = column_path->ToDotString();
+
+    //writer provided properties.
+    auto writer_properties = column_chunk_metadata->properties();
+    auto data_page_version = writer_properties->data_page_version();
+    auto dictionary_page_encoding = writer_properties->dictionary_page_encoding();
+    auto dictionary_index_encoding = writer_properties->dictionary_index_encoding();
+    auto data_page_encoding = writer_properties->encoding(column_path);
+    auto compression_type = writer_properties->compression(column_path);
+
+    //column metadata properties.
+    auto physical_type = column_chunk_metadata->descr()->physical_type();
+
+    //TODO: what's the difference between this and writer_properties->data_page_encoding()
+    //auto encoding_type = column_chunk_metadata->properties()->encoding(column_path);
+    auto fixed_length_bytes = column_chunk_metadata->descr()->type_length();
+
+    return std::make_unique<ColumnChunkProperties>(
+        /*column_path*/ column_path_string,
+        /*page_version*/ data_page_version, 
+        /*physical_type*/ physical_type, 
+        /*dictionary_page_encoding*/ dictionary_page_encoding, 
+        /*dictionary_index_encoding*/ dictionary_index_encoding, 
+        /*data_page_encoding*/ data_page_encoding, 
+        /*compression_type*/ compression_type, 
+        /*fixed_length_bytes*/ fixed_length_bytes);
+}
+
+std::string ColumnChunkProperties::GetColumnPath() {
+    return column_path_;
+}
+
+parquet::ParquetDataPageVersion ColumnChunkProperties::GetPageVersion() {
+    return page_version_;
+}
+
+parquet::Type::type ColumnChunkProperties::GetPhysicalType() {
+    return physical_type_;
+}
+
+parquet::Encoding::type ColumnChunkProperties::GetDictionaryPageEncoding() {
+    return dictionary_page_encoding_;
+}
+
+parquet::Encoding::type ColumnChunkProperties::GetDictionaryIndexEncoding() {
+    return dictionary_index_encoding_;
+}
+
+parquet::Encoding::type ColumnChunkProperties::GetDataPageEncoding() {
+    return data_page_encoding_;
+}
+
+::arrow::Compression::type ColumnChunkProperties::GetCompression() {
+    return compression_;
+}
+
+std::int64_t ColumnChunkProperties::GetFixedLengthBytes() {
+    return fixed_length_bytes_;
+}
+
+} // namespace parquet::encryption

--- a/cpp/src/parquet/encryption/column_chunk_properties.h
+++ b/cpp/src/parquet/encryption/column_chunk_properties.h
@@ -1,0 +1,51 @@
+// TODO: add license
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "parquet/metadata.h"
+
+namespace parquet::encryption {
+
+class ColumnChunkProperties {
+public:
+    ColumnChunkProperties(
+        std::string column_path,
+        parquet::ParquetDataPageVersion page_version,
+        parquet::Type::type physical_type,
+        parquet::Encoding::type dictionary_page_encoding,
+        parquet::Encoding::type dictionary_index_encoding,
+        parquet::Encoding::type data_page_encoding,
+        ::arrow::Compression::type compression,
+        std::int64_t fixed_length_bytes
+    );
+
+    static std::unique_ptr<ColumnChunkProperties> MakeFromMetadata(const ColumnChunkMetaDataBuilder* column_chunk_meta_data);
+
+    std::string GetColumnPath();
+    parquet::ParquetDataPageVersion GetPageVersion();
+    parquet::Type::type GetPhysicalType();
+    parquet::Encoding::type GetDictionaryPageEncoding();
+    parquet::Encoding::type GetDictionaryIndexEncoding();
+    parquet::Encoding::type GetDataPageEncoding();
+    ::arrow::Compression::type GetCompression();
+
+    //TODO: verify type.
+    std::int64_t GetFixedLengthBytes();
+
+    private:
+        std::string column_path_;
+        parquet::ParquetDataPageVersion page_version_;
+        parquet::Type::type physical_type_;
+        parquet::Encoding::type dictionary_page_encoding_;
+        parquet::Encoding::type dictionary_index_encoding_;
+        parquet::Encoding::type data_page_encoding_;
+        ::arrow::Compression::type compression_;
+        std::int64_t fixed_length_bytes_;
+}; //class ColumnChunkProperties
+
+} //namespace parquet::encryption
+
+

--- a/cpp/src/parquet/encryption/external_dbpa_encryption.h
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption.h
@@ -65,6 +65,17 @@ class ExternalDBPAEncryptorAdapter : public EncryptorInterface {
       std::map<std::string, std::string> connection_config,
       std::unique_ptr<DataBatchProtectionAgentInterface> agent_instance);
 
+    ///This is a second private constructor. It demonstrates how a lot of the 
+    //arguments required in the original constructor are available
+    //in the column_chunk_properties object.
+    ExternalDBPAEncryptorAdapter(
+      ParquetCipher::type algorithm, 
+      std::unique_ptr<ColumnChunkProperties> column_chunk_properties,
+      std::string key_id,
+      std::string app_context,
+      std::map<std::string, std::string> connection_config,
+      std::unique_ptr<DataBatchProtectionAgentInterface> agent_instance);
+
     int32_t InvokeExternalEncrypt(
       ::arrow::util::span<const uint8_t> plaintext, ::arrow::util::span<uint8_t> ciphertext);
     
@@ -78,6 +89,7 @@ class ExternalDBPAEncryptorAdapter : public EncryptorInterface {
     std::map<std::string, std::string> connection_config_;
     
     std::unique_ptr<dbps::external::DataBatchProtectionAgentInterface> agent_instance_;
+    std::unique_ptr<ColumnChunkProperties> column_chunk_properties_;
 };
 
 /// Factory for ExternalDBPAEncryptorAdapter instances. The cache exists while the write

--- a/cpp/src/parquet/encryption/external_dbpa_encryption.h
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption.h
@@ -10,6 +10,8 @@
 
 #include "parquet/encryption/encryptor_interface.h"
 #include "parquet/encryption/decryptor_interface.h"
+#include "parquet/encryption/column_chunk_properties.h"
+
 #include "parquet/metadata.h"
 #include "parquet/types.h"
 
@@ -25,6 +27,13 @@ class ExternalDBPAEncryptorAdapter : public EncryptorInterface {
       std::string key_id, Type::type data_type, Compression::type compression_type,
       Encoding::type encoding_type, std::string app_context,
       std::map<std::string, std::string> connection_config);
+
+  static std::unique_ptr<ExternalDBPAEncryptorAdapter> Make(
+        ParquetCipher::type algorithm,
+        std::unique_ptr<ColumnChunkProperties> column_chunk_metadata_info,
+        std::string key_id,
+        std::string app_context,
+        std::map<std::string, std::string> connection_config);
 
   ~ExternalDBPAEncryptorAdapter() = default;
 
@@ -76,7 +85,7 @@ class ExternalDBPAEncryptorAdapter : public EncryptorInterface {
 class ExternalDBPAEncryptorAdapterFactory {
   public:
     ExternalDBPAEncryptorAdapter* GetEncryptor(
-      ParquetCipher::type algorithm, const ColumnChunkMetaDataBuilder* column_chunk_metadata,
+      ParquetCipher::type algorithm, const ColumnChunkMetaDataBuilder* column_chunk_properties,
       ExternalFileEncryptionProperties* external_file_encryption_properties);
 
   private:


### PR DESCRIPTION
-- This PR is for discussion only.

First pass of ColumnChunkProperties - an utils class/data structure which captures several dimensions of column medatata.

- tests pass (`ctest -L parquet`)
- base_app.py works properly
- additional tests required.

