### PR TITLE
Defining DBPAExecutor

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -244,6 +244,7 @@ if(PARQUET_REQUIRE_ENCRYPTION)
                    encryption/external_dbpa_encryption.cc
                    encryption/external/dbpa_library_wrapper.cc
                    encryption/external/dbpa_enum_utils.cc
+                   encryption/external/dbpa_executor.cc
                    encryption/external/loadable_encryptor_utils.cc
                    )
   # Encryption key management

--- a/cpp/src/parquet/encryption/CMakeLists.txt
+++ b/cpp/src/parquet/encryption/CMakeLists.txt
@@ -45,4 +45,9 @@ if(ARROW_TESTING)
   add_parquet_test(dbpa-utils-test
                    SOURCES external/dbpa_enum_utils_test.cc
                    LABELS "parquet-tests" "encryption-tests")
+
+  # Add a test for dbpa_executor_test
+  add_parquet_test(dbpa-executor-test
+                   SOURCES external/dbpa_executor_test.cc
+                   LABELS "parquet-tests" "encryption-tests")
 endif()

--- a/cpp/src/parquet/encryption/external/dbpa_executor.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_executor.cc
@@ -1,0 +1,181 @@
+#include "parquet/encryption/external/dbpa_executor.h"
+#include "parquet/encryption/external/third_party/dbpa_interface.h"
+
+#include <stdexcept>
+#include <iostream>
+#include <future>
+#include <string>
+
+namespace parquet::encryption::external {
+
+
+/**
+  * Utility function to execute a wrapped operation with timeout using 
+  * pure C++ futures
+  * @tparam Func The function type to execute
+  * @tparam Args The argument types
+  * @param operation_name Name of the operation for error reporting
+  * @param timeout_milliseconds Timeout in milliseconds
+  * @param func The function to execute
+  * @param args The arguments to pass to the function
+  * @return The result of the function execution
+  */
+template<typename Func, typename... Args>
+auto ExecuteWithTimeout(const std::string& operation_name, 
+                      int64_t timeout_milliseconds, 
+                      Func&& func, 
+                      Args&&... args) -> decltype(func(args...)) {
+
+  // Get the return type of the function that we're executing
+  using ReturnType = decltype(func(args...));
+  
+  std::cout << "[DBPAExecutor] Starting " << operation_name << " operation with timeout " 
+            << timeout_milliseconds << " milliseconds" << std::endl;
+  
+  auto start_time = std::chrono::steady_clock::now();
+  
+  // Create a future to run the operation asynchronously
+  std::cout << "[DBPAExecutor] Creating async future for " << operation_name << std::endl;
+  auto future = std::async(std::launch::async, [&]() -> ReturnType {
+    std::cout << "[DBPAExecutor] Async task started for " << operation_name << std::endl;
+    try {
+      if constexpr (std::is_void_v<ReturnType>) {
+        func(args...);
+        std::cout << "[DBPAExecutor] Async task completed successfully for " << operation_name << std::endl;
+      } else {
+        auto result = func(args...);
+        std::cout << "[DBPAExecutor] Async task completed successfully for " << operation_name << std::endl;
+        return result;
+      }
+    } 
+    catch (const std::exception& e) {
+      std::cout << "[DBPAExecutor] Async task threw exception for " << operation_name 
+                << ": " << e.what() << std::endl;
+      throw; // Re-throw original exception
+    }  // TODO: are there exceptions which are not a sub-class of std::exception?
+    catch (...) {
+      std::cout << "[DBPAExecutor] Async task threw unknown exception for " << operation_name << std::endl;
+      throw; // Re-throw original exception
+    }
+  });
+  
+  std::cout << "[DBPAExecutor] Future created, waiting for " << operation_name 
+            << " with timeout " << timeout_milliseconds << " milliseconds" << std::endl;
+  
+  // Wait for the function to complete or timeout.
+  auto status = future.wait_for(std::chrono::milliseconds(timeout_milliseconds));
+  
+  auto end_time = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+  
+  if (status == std::future_status::timeout) {
+    std::cout << "[DBPAExecutor] TIMEOUT: " << operation_name << " exceeded " 
+              << timeout_milliseconds << " milliseconds (actual: " << duration.count() << "ms)" << std::endl;
+    throw DBPAExecutorTimeoutException(operation_name, timeout_milliseconds);
+  }
+  
+  std::cout << "[DBPAExecutor] Future completed for " << operation_name 
+            << " in " << duration.count() << "ms, retrieving result..." << std::endl;
+  
+  try {
+    // If any exceptions are thrown in the body of the function,
+    // they will be re-thrown by future.get() (unchanged, no wrapping)
+    // TODO: when/if logging is simplified, this block should also be simplified.
+    if constexpr (std::is_void_v<ReturnType>) {
+      future.get();
+      std::cout << "[DBPAExecutor] SUCCESS: " << operation_name << " completed successfully" << std::endl;
+    } else {
+      auto result = future.get();
+      std::cout << "[DBPAExecutor] SUCCESS: " << operation_name << " completed successfully" << std::endl;
+      return result;
+    }
+  } catch (const std::exception& e) {
+    std::cout << "[DBPAExecutor] EXCEPTION: " << operation_name << " failed with: " << e.what() << std::endl;
+    throw; // Re-throw original exception
+  } catch (...) {
+    std::cout << "[DBPAExecutor] UNKNOWN EXCEPTION: " << operation_name << " failed with unknown exception" << std::endl;
+    throw; // Re-throw original exception
+  }
+}
+ 
+DBPAExecutor::DBPAExecutor(std::unique_ptr<DataBatchProtectionAgentInterface> agent,
+                           int64_t init_timeout,
+                           int64_t encrypt_timeout,
+                           int64_t decrypt_timeout)
+    : wrapped_agent_(std::move(agent)),
+      init_timeout_milliseconds_(init_timeout),
+      encrypt_timeout_milliseconds_(encrypt_timeout),
+      decrypt_timeout_milliseconds_(decrypt_timeout) {
+  
+  // Ensure the wrapped agent is not null
+  if (!wrapped_agent_) {
+    std::cout << "[DBPAExecutor] ERROR: Cannot create executor with null agent" << std::endl;
+    throw std::invalid_argument("DBPAExecutor: Cannot create executor with null agent");
+  }
+
+  std::cout << "[DBPAExecutor] Constructor called with timeouts - init: " << init_timeout 
+            << "ms, encrypt: " << encrypt_timeout << "ms, decrypt: " << decrypt_timeout << "ms" << std::endl;
+  
+  // Validate timeout values
+  if (init_timeout_milliseconds_ <= 0 || encrypt_timeout_milliseconds_ <= 0 || decrypt_timeout_milliseconds_ <= 0) {
+    std::cout << "[DBPAExecutor] ERROR: Invalid timeout values - init: " << init_timeout_milliseconds_
+              << ", encrypt: " << encrypt_timeout_milliseconds_ 
+              << ", decrypt: " << decrypt_timeout_milliseconds_ << std::endl;
+    throw std::invalid_argument("DBPAExecutor: All timeout values must be positive");
+  }
+  
+  std::cout << "[DBPAExecutor] Constructor completed successfully" << std::endl;
+}
+
+void DBPAExecutor::init(
+    std::string column_name,
+    std::map<std::string, std::string> connection_config,
+    std::string app_context,
+    std::string column_key_id,
+    Type::type data_type,
+    CompressionCodec::type compression_type) {
+
+  std::cout << "[DBPAExecutor] init() called for column: " << column_name 
+            << ", key_id: " << column_key_id << std::endl;
+
+  ExecuteWithTimeout("init", init_timeout_milliseconds_, 
+                [this](std::string col_name, 
+                       std::map<std::string, std::string> conn_config,
+                       std::string app_ctx,
+                       std::string col_key_id,
+                       Type::type dt,
+                       CompressionCodec::type comp_type) {
+                  wrapped_agent_->init(std::move(col_name), std::move(conn_config),
+                                      std::move(app_ctx), std::move(col_key_id),
+                                      dt, comp_type);
+                },
+                std::move(column_name), std::move(connection_config),
+                std::move(app_context), std::move(column_key_id),
+                data_type, compression_type);
+}
+
+std::unique_ptr<EncryptionResult> DBPAExecutor::Encrypt(
+    span<const uint8_t> plaintext) {
+  
+  std::cout << "[DBPAExecutor] Encrypt() called with " << plaintext.size() << " bytes" << std::endl;
+  
+  return ExecuteWithTimeout("encrypt", encrypt_timeout_milliseconds_,
+                           [this](span<const uint8_t> pt) {
+                             return wrapped_agent_->Encrypt(pt);
+                           },
+                           plaintext);
+}
+
+std::unique_ptr<DecryptionResult> DBPAExecutor::Decrypt(
+    span<const uint8_t> ciphertext) {
+  
+  std::cout << "[DBPAExecutor] Decrypt() called with " << ciphertext.size() << " bytes" << std::endl;
+  
+  return ExecuteWithTimeout("decrypt", decrypt_timeout_milliseconds_,
+                           [this](span<const uint8_t> ct) {
+                             return wrapped_agent_->Decrypt(ct);
+                           },
+                           ciphertext);
+}
+
+}  // namespace parquet::encryption::external

--- a/cpp/src/parquet/encryption/external/dbpa_executor.h
+++ b/cpp/src/parquet/encryption/external/dbpa_executor.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <map>
+#include <exception>
+#include <stdexcept>
+
+#include "parquet/encryption/external/third_party/dbpa_interface.h"
+#include "parquet/encryption/external/third_party/span.hpp"
+
+template <typename T>
+using span = tcb::span<T>;
+
+namespace parquet::encryption::external {
+
+using dbps::external::DataBatchProtectionAgentInterface;
+using dbps::external::EncryptionResult;
+using dbps::external::DecryptionResult;
+using dbps::external::Type;
+using dbps::external::CompressionCodec;
+
+/**
+ * Exception thrown when a DBPA operation times out
+ */
+class DBPAExecutorTimeoutException : public std::runtime_error {
+public:
+    explicit DBPAExecutorTimeoutException(const std::string& operation, int64_t timeout_milliseconds)
+        : std::runtime_error("DBPAExecutor: " + operation + " operation timed out after " +
+                           std::to_string(timeout_milliseconds) + " milliseconds") {}
+};
+
+/**
+ * DBPAExecutor - A decorator for DataBatchProtectionAgentInterface with timeout support
+ * Original exceptions from wrapped agents are preserved and re-thrown unchanged.
+ */
+class DBPAExecutor : public DataBatchProtectionAgentInterface {
+ public:
+  /**
+   * Constructor that takes ownership of the wrapped agent with configurable timeouts
+   * @param agent The DataBatchProtectionAgentInterface instance to wrap
+   * @param init_timeout Timeout for init operations in milliseconds (default: 10000)
+   * @param encrypt_timeout Timeout for encrypt operations in milliseconds (default: 30000)
+   * @param decrypt_timeout Timeout for decrypt operations in milliseconds (default: 30000)
+   */
+  explicit DBPAExecutor(std::unique_ptr<DataBatchProtectionAgentInterface> agent,
+                       int64_t init_timeout = 10000,
+                       int64_t encrypt_timeout = 30000,
+                       int64_t decrypt_timeout = 30000);
+
+  /**
+   * Destructor
+   */
+  ~DBPAExecutor() override = default;
+
+  /**
+   * Initialize the agent with configuration parameters
+   * Executes with timeout - original exceptions preserved
+   * @throws DBPAExecutorTimeoutException if operation times out
+   * @throws Original exceptions from wrapped agent (unchanged!)
+   */
+  void init(
+      std::string column_name,
+      std::map<std::string, std::string> connection_config,
+      std::string app_context,
+      std::string column_key_id,
+      Type::type data_type,
+      CompressionCodec::type compression_type) override;
+
+  /**
+   * Encrypt the provided plaintext
+   * Executes with timeout - original exceptions preserved
+   * @param plaintext The data to encrypt
+   * @return Unique pointer to EncryptionResult
+   * @throws DBPAExecutorTimeoutException if operation times out
+   * @throws Original exceptions from wrapped agent (unchanged!)
+   */
+  std::unique_ptr<EncryptionResult> Encrypt(
+      span<const uint8_t> plaintext) override;
+
+  /**
+   * Decrypt the provided ciphertext
+   * Executes with timeout - original exceptions preserved
+   * @param ciphertext The data to decrypt
+   * @return Unique pointer to DecryptionResult
+   * @throws DBPAExecutorTimeoutException if operation times out
+   * @throws Original exceptions from wrapped agent (unchanged!)
+   */
+  std::unique_ptr<DecryptionResult> Decrypt(
+      span<const uint8_t> ciphertext) override;
+
+  private:
+    std::unique_ptr<DataBatchProtectionAgentInterface> wrapped_agent_;
+    int64_t init_timeout_milliseconds_;
+    int64_t encrypt_timeout_milliseconds_;
+    int64_t decrypt_timeout_milliseconds_;    
+}; // class DBPAExecutor
+
+}  // namespace parquet::encryption::external

--- a/cpp/src/parquet/encryption/external/dbpa_executor_test.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_executor_test.cc
@@ -1,0 +1,447 @@
+#include "parquet/encryption/external/dbpa_executor.h"
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <thread>
+#include <chrono>
+#include <vector>
+#include <map>
+#include <string>
+
+namespace parquet::encryption::external {
+
+// Concrete implementations for testing
+class TestEncryptionResult : public EncryptionResult {
+public:
+    TestEncryptionResult(std::vector<uint8_t> data, bool success = true, 
+                        std::string error_msg = "", 
+                        std::map<std::string, std::string> error_fields = {})
+        : ciphertext_data_(std::move(data)), success_(success), 
+          error_message_(std::move(error_msg)), error_fields_(std::move(error_fields)) {}
+
+    span<const uint8_t> ciphertext() const override {
+        return span<const uint8_t>(ciphertext_data_.data(), ciphertext_data_.size());
+    }
+
+    std::size_t size() const override { return ciphertext_data_.size(); }
+    bool success() const override { return success_; }
+    const std::string& error_message() const override { return error_message_; }
+    const std::map<std::string, std::string>& error_fields() const override { return error_fields_; }
+
+private:
+    std::vector<uint8_t> ciphertext_data_;
+    bool success_;
+    std::string error_message_;
+    std::map<std::string, std::string> error_fields_;
+};
+
+class TestDecryptionResult : public DecryptionResult {
+public:
+    TestDecryptionResult(std::vector<uint8_t> data, bool success = true, 
+                        std::string error_msg = "", 
+                        std::map<std::string, std::string> error_fields = {})
+        : plaintext_data_(std::move(data)), success_(success), 
+          error_message_(std::move(error_msg)), error_fields_(std::move(error_fields)) {}
+
+    span<const uint8_t> plaintext() const override {
+        return span<const uint8_t>(plaintext_data_.data(), plaintext_data_.size());
+    }
+
+    std::size_t size() const override { return plaintext_data_.size(); }
+    bool success() const override { return success_; }
+    const std::string& error_message() const override { return error_message_; }
+    const std::map<std::string, std::string>& error_fields() const override { return error_fields_; }
+
+private:
+    std::vector<uint8_t> plaintext_data_;
+    bool success_;
+    std::string error_message_;
+    std::map<std::string, std::string> error_fields_;
+};
+
+// Mock agent that tracks method calls and parameters for verification
+class MockDBPAAgent : public DataBatchProtectionAgentInterface {
+public:
+    // Track call counts
+    int init_call_count_ = 0;
+    int encrypt_call_count_ = 0;
+    int decrypt_call_count_ = 0;
+    
+    // Track parameters from last calls
+    std::string last_init_column_name_;
+    std::map<std::string, std::string> last_init_connection_config_;
+    std::string last_init_app_context_;
+    std::string last_init_column_key_id_;
+    Type::type last_init_data_type_;
+    CompressionCodec::type last_init_compression_type_;
+    
+    std::vector<uint8_t> last_encrypt_plaintext_;
+    std::vector<uint8_t> last_decrypt_ciphertext_;
+    
+    // Mock results
+    std::unique_ptr<TestEncryptionResult> mock_encrypt_result_;
+    std::unique_ptr<TestDecryptionResult> mock_decrypt_result_;
+    
+    // Control behavior
+    bool should_throw_on_init_ = false;
+    bool should_throw_on_encrypt_ = false;
+    bool should_throw_on_decrypt_ = false;
+    std::string throw_message_ = "Mock agent error";
+    
+    void init(std::string column_name,
+              std::map<std::string, std::string> connection_config,
+              std::string app_context,
+              std::string column_key_id,
+              Type::type data_type,
+              CompressionCodec::type compression_type) override {
+        init_call_count_++;
+        last_init_column_name_ = column_name;
+        last_init_connection_config_ = connection_config;
+        last_init_app_context_ = app_context;
+        last_init_column_key_id_ = column_key_id;
+        last_init_data_type_ = data_type;
+        last_init_compression_type_ = compression_type;
+        
+        if (should_throw_on_init_) {
+            throw std::runtime_error(throw_message_);
+        }
+    }
+    
+    std::unique_ptr<EncryptionResult> Encrypt(span<const uint8_t> plaintext) override {
+        encrypt_call_count_++;
+        last_encrypt_plaintext_.assign(plaintext.begin(), plaintext.end());
+        
+        if (should_throw_on_encrypt_) {
+            throw std::runtime_error(throw_message_);
+        }
+        
+        // Return a copy of the mock result if available
+        if (mock_encrypt_result_) {
+            // Create a new result with the same data
+            return std::make_unique<TestEncryptionResult>(*mock_encrypt_result_);
+        }
+        return nullptr;
+    }
+    
+    std::unique_ptr<DecryptionResult> Decrypt(span<const uint8_t> ciphertext) override {
+        decrypt_call_count_++;
+        last_decrypt_ciphertext_.assign(ciphertext.begin(), ciphertext.end());
+        
+        if (should_throw_on_decrypt_) {
+            throw std::runtime_error(throw_message_);
+        }
+        
+        // Return a copy of the mock result if available
+        if (mock_decrypt_result_) {
+            // Create a new result with the same data
+            return std::make_unique<TestDecryptionResult>(*mock_decrypt_result_);
+        }
+        return nullptr;
+    }
+    
+    // Helper methods for test setup
+    void ResetCallCounts() {
+        init_call_count_ = 0;
+        encrypt_call_count_ = 0;
+        decrypt_call_count_ = 0;
+    }
+    
+    void SetMockEncryptResult(std::unique_ptr<TestEncryptionResult> result) {
+        mock_encrypt_result_ = std::move(result);
+    }
+    
+    void SetMockDecryptResult(std::unique_ptr<TestDecryptionResult> result) {
+        mock_decrypt_result_ = std::move(result);
+    }
+};
+
+class DBPAExecutorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Create a mock agent to wrap
+    mock_agent_ = std::make_unique<MockDBPAAgent>();
+    mock_agent_ptr_ = mock_agent_.get(); // Keep raw pointer for verification
+    
+    // Create the executor that wraps the mock agent with custom timeouts
+    executor_ = std::make_unique<DBPAExecutor>(std::move(mock_agent_), 
+                                              1000,  // init timeout: 1 second
+                                              2000,  // encrypt timeout: 2 seconds  
+                                              2000); // decrypt timeout: 2 seconds
+  }
+
+  std::unique_ptr<DBPAExecutor> executor_;
+  std::unique_ptr<MockDBPAAgent> mock_agent_;
+  MockDBPAAgent* mock_agent_ptr_; // Raw pointer for verification
+};
+
+TEST_F(DBPAExecutorTest, ConstructorWithNullAgentThrows) {
+  EXPECT_THROW(DBPAExecutor(nullptr), std::invalid_argument);
+}
+
+TEST_F(DBPAExecutorTest, ConstructorWithInvalidTimeoutsThrows) {
+  auto test_agent = std::make_unique<MockDBPAAgent>();
+  
+  // Test negative timeout
+  EXPECT_THROW(DBPAExecutor(std::move(test_agent), -1, 1000, 1000), std::invalid_argument);
+  
+  // Test zero timeout
+  test_agent = std::make_unique<MockDBPAAgent>();
+  EXPECT_THROW(DBPAExecutor(std::move(test_agent), 0, 1000, 1000), std::invalid_argument);
+}
+
+TEST_F(DBPAExecutorTest, InitForwardsToWrappedAgent) {
+  std::string column_name = "test_column";
+  std::map<std::string, std::string> connection_config = {{"key", "value"}, {"server", "localhost"}};
+  std::string app_context = "test_context";
+  std::string column_key_id = "test_key_id";
+  Type::type data_type = Type::type::INT32;
+  CompressionCodec::type compression_type = CompressionCodec::type::UNCOMPRESSED;
+
+  // Reset call count before test
+  mock_agent_ptr_->ResetCallCounts();
+  
+  // Call init through executor
+  EXPECT_NO_THROW(executor_->init(column_name, connection_config, app_context,
+                                 column_key_id, data_type, compression_type));
+  
+  // Verify the mock agent was called exactly once
+  EXPECT_EQ(mock_agent_ptr_->init_call_count_, 1);
+  
+  // Verify all parameters were forwarded correctly
+  EXPECT_EQ(mock_agent_ptr_->last_init_column_name_, column_name);
+  EXPECT_EQ(mock_agent_ptr_->last_init_connection_config_, connection_config);
+  EXPECT_EQ(mock_agent_ptr_->last_init_app_context_, app_context);
+  EXPECT_EQ(mock_agent_ptr_->last_init_column_key_id_, column_key_id);
+  EXPECT_EQ(mock_agent_ptr_->last_init_data_type_, data_type);
+  EXPECT_EQ(mock_agent_ptr_->last_init_compression_type_, compression_type);
+}
+
+TEST_F(DBPAExecutorTest, EncryptForwardsToWrappedAgent) {
+  // Initialize the executor first
+  executor_->init("test_column", {}, "test_context", "test_key_id",
+                 Type::type::INT32, CompressionCodec::type::UNCOMPRESSED);
+
+  // Create test data
+  std::vector<uint8_t> plaintext = {1, 2, 3, 4, 5};
+  span<const uint8_t> plaintext_span(plaintext);
+
+  // Reset call count before test
+  mock_agent_ptr_->ResetCallCounts();
+  
+  // Encrypt should not throw and should return a result
+  auto result = executor_->Encrypt(plaintext_span);
+  
+  // Verify the mock agent was called exactly once
+  EXPECT_EQ(mock_agent_ptr_->encrypt_call_count_, 1);
+  
+  // Verify the plaintext was forwarded correctly
+  EXPECT_EQ(mock_agent_ptr_->last_encrypt_plaintext_, plaintext);
+  
+  // Note: result might be nullptr since we didn't set up a mock result
+  // The important thing is that the call was forwarded
+}
+
+TEST_F(DBPAExecutorTest, DecryptForwardsToWrappedAgent) {
+  // Initialize the executor first
+  executor_->init("test_column", {}, "test_context", "test_key_id",
+                 Type::type::INT32, CompressionCodec::type::UNCOMPRESSED);
+
+  // Create test data
+  std::vector<uint8_t> ciphertext = {5, 4, 3, 2, 1};
+  span<const uint8_t> ciphertext_span(ciphertext);
+
+  // Reset call count before test
+  mock_agent_ptr_->ResetCallCounts();
+  
+  // Decrypt should not throw and should return a result
+  auto result = executor_->Decrypt(ciphertext_span);
+  
+  // Verify the mock agent was called exactly once
+  EXPECT_EQ(mock_agent_ptr_->decrypt_call_count_, 1);
+  
+  // Verify the ciphertext was forwarded correctly
+  EXPECT_EQ(mock_agent_ptr_->last_decrypt_ciphertext_, ciphertext);
+  
+  // Note: result might be nullptr since we didn't set up a mock result
+  // The important thing is that the call was forwarded
+}
+
+// Test that multiple calls are properly forwarded
+TEST_F(DBPAExecutorTest, MultipleCallsAreProperlyForwarded) {
+  // Reset call counts
+  mock_agent_ptr_->ResetCallCounts();
+  
+  // Make multiple init calls with different parameters
+  executor_->init("column1", {{"key1", "value1"}}, "context1", "key1", 
+                 Type::type::INT32, CompressionCodec::type::UNCOMPRESSED);
+  
+  // Verify both calls were made
+  EXPECT_EQ(mock_agent_ptr_->init_call_count_, 1);
+  
+  // Verify the last call parameters (second call)
+  EXPECT_EQ(mock_agent_ptr_->last_init_column_name_, "column1");
+  EXPECT_EQ(mock_agent_ptr_->last_init_connection_config_["key1"], "value1");
+  EXPECT_EQ(mock_agent_ptr_->last_init_app_context_, "context1");
+  EXPECT_EQ(mock_agent_ptr_->last_init_column_key_id_, "key1");
+  EXPECT_EQ(mock_agent_ptr_->last_init_data_type_, Type::type::INT32);
+  EXPECT_EQ(mock_agent_ptr_->last_init_compression_type_, CompressionCodec::type::UNCOMPRESSED);
+  
+  // Make multiple encrypt calls
+  std::vector<uint8_t> data1 = {1, 2, 3};
+  std::vector<uint8_t> data2 = {4, 5, 6, 7};
+  span<const uint8_t> span1(data1);
+  span<const uint8_t> span2(data2);
+  
+  executor_->Encrypt(span1);
+  executor_->Encrypt(span2);
+  
+  // Verify both encrypt calls were made
+  EXPECT_EQ(mock_agent_ptr_->encrypt_call_count_, 2);
+  
+  // Verify the last encrypt call parameters
+  EXPECT_EQ(mock_agent_ptr_->last_encrypt_plaintext_, data2);
+  
+  // Make multiple decrypt calls
+  std::vector<uint8_t> cipher1 = {8, 9, 10};
+  std::vector<uint8_t> cipher2 = {11, 12, 13, 14, 15};
+  span<const uint8_t> cipher_span1(cipher1);
+  span<const uint8_t> cipher_span2(cipher2);
+  
+  executor_->Decrypt(cipher_span1);
+  executor_->Decrypt(cipher_span2);
+  
+  // Verify both decrypt calls were made
+  EXPECT_EQ(mock_agent_ptr_->decrypt_call_count_, 2);
+  
+  // Verify the last decrypt call parameters
+  EXPECT_EQ(mock_agent_ptr_->last_decrypt_ciphertext_, cipher2);
+}
+
+// Test timeout functionality
+TEST_F(DBPAExecutorTest, TimeoutExceptionThrownOnSlowOperation) {
+  // Create a mock agent that simulates slow operations
+  class SlowMockAgent : public DataBatchProtectionAgentInterface {
+  public:
+      void init(std::string, std::map<std::string, std::string>, std::string, 
+                std::string, Type::type, CompressionCodec::type) override {
+          // Simulate slow operation that takes 200ms
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+      
+      std::unique_ptr<EncryptionResult> Encrypt(span<const uint8_t>) override {
+          // Simulate slow operation that takes 150ms
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+          return nullptr;
+      }
+      
+      std::unique_ptr<DecryptionResult> Decrypt(span<const uint8_t>) override {
+          // Simulate slow operation that takes 120ms
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+          return nullptr;
+      }
+  };
+  
+  // Create an executor with very short timeouts
+  auto slow_agent = std::make_unique<SlowMockAgent>();
+  auto timeout_executor = std::make_unique<DBPAExecutor>(std::move(slow_agent), 
+                                                         50,  // init timeout: 50ms (will timeout)
+                                                         55,  // encrypt timeout: 50ms (will timeout)
+                                                         60); // decrypt timeout: 50ms (will timeout)
+
+  // Test init timeout - should throw DBPAExecutorTimeoutException
+  try {
+    timeout_executor->init("test_column", {}, "test_context", "test_key_id",
+                          Type::type::INT32, CompressionCodec::type::UNCOMPRESSED);
+    FAIL() << "Expected DBPAExecutorTimeoutException to be thrown";
+  } catch (const DBPAExecutorTimeoutException& e) {
+    // Verify the timeout exception contains expected information
+    std::string error_msg = e.what();
+    EXPECT_TRUE(error_msg.find("init") != std::string::npos);
+    EXPECT_TRUE(error_msg.find("50") != std::string::npos);
+    EXPECT_TRUE(error_msg.find("milliseconds") != std::string::npos);
+  } catch (...) {
+    FAIL() << "Expected DBPAExecutorTimeoutException, but got different exception type";
+  }
+  
+  // Test encrypt timeout - should throw DBPAExecutorTimeoutException
+  std::vector<uint8_t> data = {1, 2, 3, 4, 5};
+  span<const uint8_t> data_span(data);
+  
+  try {
+    timeout_executor->Encrypt(data_span);
+    FAIL() << "Expected DBPAExecutorTimeoutException to be thrown";
+  } catch (const DBPAExecutorTimeoutException& e) {
+    // Verify the timeout exception contains expected information
+    std::string error_msg = e.what();
+    EXPECT_TRUE(error_msg.find("encrypt") != std::string::npos);
+    EXPECT_TRUE(error_msg.find("55") != std::string::npos);
+    EXPECT_TRUE(error_msg.find("milliseconds") != std::string::npos);
+  } catch (...) {
+    FAIL() << "Expected DBPAExecutorTimeoutException, but got different exception type";
+  }
+  
+  // Test decrypt timeout - should throw DBPAExecutorTimeoutException
+  try {
+    timeout_executor->Decrypt(data_span);
+    FAIL() << "Expected DBPAExecutorTimeoutException to be thrown";
+  } catch (const DBPAExecutorTimeoutException& e) {
+    // Verify the timeout exception contains expected information
+    std::string error_msg = e.what();
+    EXPECT_TRUE(error_msg.find("decrypt") != std::string::npos);
+    EXPECT_TRUE(error_msg.find("60") != std::string::npos);
+    EXPECT_TRUE(error_msg.find("milliseconds") != std::string::npos);
+  } catch (...) {
+    FAIL() << "Expected DBPAExecutorTimeoutException, but got different exception type";
+  }
+}
+
+// Test that original exceptions are preserved (not wrapped)
+TEST_F(DBPAExecutorTest, OriginalExceptionsArePreserved) {
+  // Configure mock agent to throw exceptions
+  mock_agent_ptr_->should_throw_on_init_ = true;
+  mock_agent_ptr_->throw_message_ = "Mock init error";
+  
+  // Test that init exception is preserved
+  try {
+    executor_->init("test_column", {}, "test_context", "test_key_id",
+                   Type::type::INT32, CompressionCodec::type::UNCOMPRESSED);
+    FAIL() << "Expected std::runtime_error to be thrown";
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "Mock init error");
+  } catch (...) {
+    FAIL() << "Unexpected exception type";
+  }
+  
+  // Reset and test encrypt exception
+  mock_agent_ptr_->should_throw_on_init_ = false;
+  mock_agent_ptr_->should_throw_on_encrypt_ = true;
+  mock_agent_ptr_->throw_message_ = "Mock encrypt error";
+  
+  std::vector<uint8_t> data = {1, 2, 3, 4, 5};
+  span<const uint8_t> data_span(data);
+  
+  try {
+    executor_->Encrypt(data_span);
+    FAIL() << "Expected std::runtime_error to be thrown";
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "Mock encrypt error");
+  } catch (...) {
+    FAIL() << "Unexpected exception type";
+  }
+  
+  // Reset and test decrypt exception
+  mock_agent_ptr_->should_throw_on_encrypt_ = false;
+  mock_agent_ptr_->should_throw_on_decrypt_ = true;
+  mock_agent_ptr_->throw_message_ = "Mock decrypt error";
+  
+  try {
+    executor_->Decrypt(data_span);
+    FAIL() << "Expected std::runtime_error to be thrown";
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "Mock decrypt error");
+  } catch (...) {
+    FAIL() << "Unexpected exception type";
+  }
+}
+
+}  // namespace parquet::encryption::external


### PR DESCRIPTION
Defining `DBPAExecutor`, a decorator which ensures that operations of DBPA instances complete in a deterministic amount of time. 

**Motivation**
- The behavior of internal encryptors (e.g. AES) is well understood and controlled heavily at compile time. External Encryptors do not offer the same guarantees around execution (e.g. some operations in external encryptors may take a long time to complete, or may never complete). We want to protect Arrow to ensure that operations in external encryptors complete within a known amount of time.
- Relevant Issue: https://github.com/protegrity/arrow/issues/146

**Useful Context**
- During the Write Column operation, if there are failures (i.e. exceptions thrown) while writing **any** Chunk/Page, Arrow will stop the Write Column operation, and will also stop the file writing operation. In other words, any failure at write/encryption time, will cause the whole file write to fail (no partially-written nor partially-encrypted files will exist).

**Design Considerations**
- The Executor will be mostly a guard against long-running operations.
- Any non-timeout exceptions that occur during execution of operations (`init`, `encrypt`, `decrypt`) will be propagated upwards, without further wrapping into other types of exceptions. This provides a cleaner view of underlying errors to the App writers. 
- For this change, we used C++ `std::future`. While Arrow has an internal implementation of Future (similar in behavior), I chose to use `std::future` instead of Arrow's Futures, as `std::future` makes exception handling simpler i.e. allows the original exceptions to be inspected and re-thrown via a simple `future.get()` once the `future` has completed. Exception handling with Arrow's Futures, while possible, is not as straightforward.
- There were two levels where the "Executor" component could have been implemented: (a) `DBPA` level, (b) `ExternalDBPAEncryptorAdapter` level. While my preference would have been to write the Executor for (b), this would have caused a more complicated implementation (given that some operations exist at `ExternalDBPAEncryptorAdapter` level, such as `encrypt` and `decrypt`, and other operations exist at `DBPA` level, such as `init`).


**Notes**
- In this change, we have not yet integrated the `DBPAExecutor` decorator with the `DBPA Agent`. That will come in a future change, where we will use the Decorator pattern for wrapping the instance used within `ExternalDBPAEncryptorAdapter`.

**Testing**
- Existing Parquet and Arrow tests pass (via `cmake -L parquet`)
- The new  tests for `DBPAExecutor` pass (again, this is not fully integrated yet).