### PR TITLE
Importing the latest DBPAInterface

### DIFF
--- a/cpp/src/parquet/encryption/external/dbpa_executor.h
+++ b/cpp/src/parquet/encryption/external/dbpa_executor.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <map>
+#include <optional>
 #include <exception>
 #include <stdexcept>
 
@@ -57,6 +58,7 @@ class DBPAExecutor : public DataBatchProtectionAgentInterface {
       std::string app_context,
       std::string column_key_id,
       Type::type data_type,
+      std::optional<int> datatype_length,
       CompressionCodec::type compression_type) override;
 
   /**
@@ -68,7 +70,8 @@ class DBPAExecutor : public DataBatchProtectionAgentInterface {
    * @throws Original exceptions from wrapped agent (unchanged!)
    */
   std::unique_ptr<EncryptionResult> Encrypt(
-      span<const uint8_t> plaintext) override;
+      span<const uint8_t> plaintext,
+      std::map<std::string, std::string> encoding_attributes) override;
 
   /**
    * Decrypt the provided ciphertext
@@ -79,7 +82,8 @@ class DBPAExecutor : public DataBatchProtectionAgentInterface {
    * @throws Original exceptions from wrapped agent (unchanged!)
    */
   std::unique_ptr<DecryptionResult> Decrypt(
-      span<const uint8_t> ciphertext) override;
+      span<const uint8_t> ciphertext,
+      std::map<std::string, std::string> encoding_attributes) override;
 
   private:
     std::unique_ptr<DataBatchProtectionAgentInterface> wrapped_agent_;

--- a/cpp/src/parquet/encryption/external/dbpa_library_wrapper.h
+++ b/cpp/src/parquet/encryption/external/dbpa_library_wrapper.h
@@ -4,6 +4,8 @@
 
 #include <memory>
 #include <functional>
+#include <optional>
+#include <map>
 
 #include "parquet/encryption/external/third_party/dbpa_interface.h"
 #include "parquet/encryption/external/third_party/span.hpp"
@@ -60,22 +62,25 @@ class DBPALibraryWrapper : public DataBatchProtectionAgentInterface {
       std::string app_context,
       std::string column_key_id,
       Type::type data_type,
+      std::optional<int> datatype_length,
       CompressionCodec::type compression_type) override {
     wrapped_agent_->init(std::move(column_name), std::move(connection_config),
                         std::move(app_context), std::move(column_key_id),
-                        data_type, compression_type);
+                        data_type, datatype_length, compression_type);
   }
 
   // Decorator implementation of Encrypt method - inlined for performance
   inline std::unique_ptr<EncryptionResult> Encrypt(
-      span<const uint8_t> plaintext) override {
-    return wrapped_agent_->Encrypt(plaintext);
+      span<const uint8_t> plaintext,
+      std::map<std::string, std::string> encoding_attributes) override {
+    return wrapped_agent_->Encrypt(plaintext, std::move(encoding_attributes));
   }
 
   // Decorator implementation of Decrypt method - inlined for performance
   inline std::unique_ptr<DecryptionResult> Decrypt(
-      span<const uint8_t> ciphertext) override {
-    return wrapped_agent_->Decrypt(ciphertext);
+      span<const uint8_t> ciphertext,
+      std::map<std::string, std::string> encoding_attributes) override {
+    return wrapped_agent_->Decrypt(ciphertext, std::move(encoding_attributes));
   }
 };
 

--- a/cpp/src/parquet/encryption/external/dbpa_test_agent.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_test_agent.cc
@@ -74,7 +74,8 @@ DBPATestAgent::DBPATestAgent() {
 }
 
 std::unique_ptr<EncryptionResult> DBPATestAgent::Encrypt(
-    span<const uint8_t> plaintext) {
+    span<const uint8_t> plaintext,
+    std::map<std::string, std::string>) {
   
   // Simple XOR encryption for testing purposes
   // In a real implementation, this would use proper encryption
@@ -88,7 +89,8 @@ std::unique_ptr<EncryptionResult> DBPATestAgent::Encrypt(
 }
 
 std::unique_ptr<DecryptionResult> DBPATestAgent::Decrypt(
-    span<const uint8_t> ciphertext) {
+    span<const uint8_t> ciphertext,
+    std::map<std::string, std::string>) {
   
   // Simple XOR decryption for testing purposes
   // In a real implementation, this would perform actual decryption

--- a/cpp/src/parquet/encryption/external/dbpa_test_agent.h
+++ b/cpp/src/parquet/encryption/external/dbpa_test_agent.h
@@ -32,15 +32,18 @@ class DBPATestAgent : public DataBatchProtectionAgentInterface {
       std::string app_context,
       std::string column_key_id,
       Type::type data_type,
+      std::optional<int> datatype_length,
       CompressionCodec::type compression_type) override {
     // init() intentionally left blank
   }
 
   std::unique_ptr<EncryptionResult> Encrypt(
-      span<const uint8_t> plaintext) override;
+      span<const uint8_t> plaintext,
+      std::map<std::string, std::string> encoding_attributes) override;
 
   std::unique_ptr<DecryptionResult> Decrypt(
-      span<const uint8_t> ciphertext) override;
+      span<const uint8_t> ciphertext,
+      std::map<std::string, std::string> encoding_attributes) override;
 
   ~DBPATestAgent();
 };

--- a/cpp/src/parquet/encryption/external/third_party/dbpa_interface.h
+++ b/cpp/src/parquet/encryption/external/third_party/dbpa_interface.h
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <stdexcept>
@@ -88,22 +89,36 @@ public:
         std::map<std::string, std::string> connection_config,
         std::string app_context,
         std::string column_key_id,
-        Type::type data_type,
+        Type::type datatype,
+        std::optional<int> datatype_length,
         CompressionCodec::type compression_type)
     {
         column_name_ = std::move(column_name);
         connection_config_ = std::move(connection_config);
         app_context_ = std::move(app_context);
         column_key_id_ = std::move(column_key_id);
-        data_type_ = data_type;
+        datatype_ = datatype;
+        datatype_length_ = datatype_length;
         compression_type_ = compression_type;
     }
 
+    /*
+    * Encrypts the provided plaintext data using the configured encryption parameters.
+    *
+    * @param plaintext Binary data to be encrypted, provided as a span of bytes
+    * @param encoding_attributes A map of string key-values. The plaintext is encoded with a type defined in enums.h Format::type.
+    *   Each encoding type requires additional attributes to be properly decoded. These attributes are specified in the map so an
+    *   implementation can properly interpret and process the input text.
+    *
+    * @return A unique pointer to an EncryptionResult containing the encrypted data and operation status
+    */
     virtual std::unique_ptr<EncryptionResult> Encrypt(
-        span<const uint8_t> plaintext) = 0;
+        span<const uint8_t> plaintext,
+        std::map<std::string, std::string> encoding_attributes) = 0;
 
     virtual std::unique_ptr<DecryptionResult> Decrypt(
-        span<const uint8_t> ciphertext) = 0;
+        span<const uint8_t> ciphertext,
+        std::map<std::string, std::string> encoding_attributes) = 0;
 
     virtual ~DataBatchProtectionAgentInterface() = default;
 
@@ -113,7 +128,8 @@ protected:
     std::string app_context_;  // includes user_id
 
     std::string column_key_id_;
-    Type::type data_type_;
+    Type::type datatype_;
+    std::optional<int> datatype_length_;
     CompressionCodec::type compression_type_;
 };
 }

--- a/cpp/src/parquet/encryption/external_dbpa_encryption.h
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <memory>
 #include <vector>
 
@@ -24,7 +25,8 @@ class ExternalDBPAEncryptorAdapter : public EncryptorInterface {
       ParquetCipher::type algorithm, std::string column_name,
       std::string key_id, Type::type data_type, Compression::type compression_type,
       Encoding::type encoding_type, std::string app_context,
-      std::map<std::string, std::string> connection_config);
+      std::map<std::string, std::string> connection_config,
+      std::optional<int> datatype_length);
 
   ~ExternalDBPAEncryptorAdapter() = default;
 
@@ -96,7 +98,8 @@ class ExternalDBPADecryptorAdapter : public DecryptorInterface {
       ParquetCipher::type algorithm, std::string column_name,
       std::string key_id, Type::type data_type, Compression::type compression_type,
       std::vector<Encoding::type> encoding_types, std::string app_context,
-      std::map<std::string, std::string> connection_config);
+      std::map<std::string, std::string> connection_config,
+      std::optional<int> datatype_length);
   
   ~ExternalDBPADecryptorAdapter() = default;
 

--- a/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <map>
+#include <optional>
 
 #include "parquet/encryption/encryption.h"
 #include "parquet/encryption/external_dbpa_encryption.h"
@@ -37,7 +38,7 @@ class ExternalDBPAEncryptorAdapterTest : public ::testing::Test {
     std::unique_ptr<ExternalDBPAEncryptorAdapter> encryptor = ExternalDBPAEncryptorAdapter::Make(
       algorithm, column_name, key_id, data_type, 
       compression_type, encoding_type, app_context_, 
-      connection_config_);
+      connection_config_, std::nullopt);
 
     // Create a simple ColumnChunkProperties for testing using the builder pattern
     std::unique_ptr<ColumnChunkProperties> column_chunk_properties = 
@@ -82,7 +83,7 @@ class ExternalDBPAEncryptorAdapterTest : public ::testing::Test {
     std::unique_ptr<ExternalDBPADecryptorAdapter> decryptor = ExternalDBPADecryptorAdapter::Make(
       algorithm, column_name, key_id, data_type,
       compression_type, {encoding_type}, app_context_,
-      connection_config_);
+      connection_config_, std::nullopt);
 
     int32_t expected_plaintext_length = ciphertext_str.size();
     int32_t actual_plaintext_length = decryptor->PlaintextLength(ciphertext_str.size());


### PR DESCRIPTION
Importing the latest version of DBPAInterface.

**Changes**
- The signature for `init()`, `encrypt()` and `decrypt()` changed. `init()` added a new `datatype_length` parameter, and `decrypt()` and `encrypt()` added a `encoding attributes` parameter. Made the necessary adjustments in this PR.
- Wired in the `datatype_length` parameter all the way down to the encryptor/decryptor.

**Testing**
- Existing and modified tests pass (via `cmake -L parquet`)
- Additional tests which exercise the new params and datatypelength fields will be written in an upcoming PR.