### PR TITLE
Adding the string representation to ToPropertiesMap()

### DIFF
--- a/cpp/src/parquet/encryption/encoding_properties.cc
+++ b/cpp/src/parquet/encryption/encoding_properties.cc
@@ -136,7 +136,7 @@ std::unique_ptr<EncodingProperties> EncodingProperties::MakeFromMetadata(
         builder.PageEncoding(dict_page.encoding());
     }
     else {
-        throw std::invalid_argument("Unknown Page Type:: " + std::to_string(column_page.type()));
+        throw std::invalid_argument(std::string("Unknown Page Type:: ") + EnumToString(column_page.type()));
     }
 
     return builder.Build();
@@ -146,10 +146,10 @@ std::map<std::string, std::string> EncodingProperties::ToPropertiesMap() const {
     std::map<std::string, std::string> result;
 
     result["column_path"] = std::string(column_path_.value());
-    result["physical_type"] = std::to_string(physical_type_.value());
-    result["compression_codec"] = std::to_string(compression_codec_.value());
-    result["page_type"] = std::to_string(page_type_);
-    result["page_encoding"] = std::to_string(page_encoding_.value());
+    result["physical_type"] = EnumToString(physical_type_.value());
+    result["compression_codec"] = EnumToString(compression_codec_.value());
+    result["page_type"] = EnumToString(page_type_);
+    result["page_encoding"] = EnumToString(page_encoding_.value());
 
     if (fixed_length_bytes_.has_value()) {
         result["fixed_length_bytes"] = std::to_string(fixed_length_bytes_.value());
@@ -157,8 +157,8 @@ std::map<std::string, std::string> EncodingProperties::ToPropertiesMap() const {
 
     if (page_type_ == parquet::PageType::DATA_PAGE) {
         result["data_page_num_values"] = std::to_string(data_page_num_values_.value());
-        result["page_v1_definition_level_encoding"] = std::to_string(page_v1_definition_level_encoding_.value());
-        result["page_v1_repetition_level_encoding"] = std::to_string(page_v1_repetition_level_encoding_.value());
+        result["page_v1_definition_level_encoding"] = EnumToString(page_v1_definition_level_encoding_.value());
+        result["page_v1_repetition_level_encoding"] = EnumToString(page_v1_repetition_level_encoding_.value());
     }
     else if (page_type_ == parquet::PageType::DATA_PAGE_V2) {
         result["data_page_num_values"] = std::to_string(data_page_num_values_.value());

--- a/cpp/src/parquet/encryption/encoding_properties.h
+++ b/cpp/src/parquet/encryption/encoding_properties.h
@@ -159,6 +159,69 @@ private:
     std::optional<bool> page_v2_is_compressed_;    
 }; // class EncodingPropertiesBuilder
 
+//--------------------------------
+// Enum to string helpers
+// Kept inline in the header for convenient reuse and zero-link overhead.
+inline std::string EnumToString(parquet::Type::type t) {
+    switch (t) {
+        case parquet::Type::BOOLEAN: return "BOOLEAN";
+        case parquet::Type::INT32: return "INT32";
+        case parquet::Type::INT64: return "INT64";
+        case parquet::Type::INT96: return "INT96";
+        case parquet::Type::FLOAT: return "FLOAT";
+        case parquet::Type::DOUBLE: return "DOUBLE";
+        case parquet::Type::BYTE_ARRAY: return "BYTE_ARRAY";
+        case parquet::Type::FIXED_LEN_BYTE_ARRAY: return "FIXED_LEN_BYTE_ARRAY";
+        case parquet::Type::UNDEFINED: return "UNDEFINED";
+        default: throw std::invalid_argument(std::string("Unknown parquet Type:: ") + std::to_string(t));
+    }
+}
+
+inline std::string EnumToString(::arrow::Compression::type t) {
+    // Use uppercase names for consistency with other enums
+    switch (t) {
+        case ::arrow::Compression::UNCOMPRESSED: return "UNCOMPRESSED";
+        case ::arrow::Compression::SNAPPY: return "SNAPPY";
+        case ::arrow::Compression::GZIP: return "GZIP";
+        case ::arrow::Compression::BROTLI: return "BROTLI";
+        case ::arrow::Compression::ZSTD: return "ZSTD";
+        case ::arrow::Compression::LZ4: return "LZ4";
+        case ::arrow::Compression::LZ4_FRAME: return "LZ4_FRAME";
+        case ::arrow::Compression::LZO: return "LZO";
+        case ::arrow::Compression::BZ2: return "BZ2";
+        case ::arrow::Compression::LZ4_HADOOP: return "LZ4_HADOOP";
+        default: throw std::invalid_argument(std::string("Unknown arrow Compression::type:: ") + std::to_string(t));
+    }
+}
+
+inline std::string EnumToString(parquet::Encoding::type t) {
+    switch (t) {
+        case parquet::Encoding::PLAIN: return "PLAIN";
+        case parquet::Encoding::PLAIN_DICTIONARY: return "PLAIN_DICTIONARY";
+        case parquet::Encoding::RLE: return "RLE";
+        case parquet::Encoding::BIT_PACKED: return "BIT_PACKED";
+        case parquet::Encoding::DELTA_BINARY_PACKED: return "DELTA_BINARY_PACKED";
+        case parquet::Encoding::DELTA_LENGTH_BYTE_ARRAY: return "DELTA_LENGTH_BYTE_ARRAY";
+        case parquet::Encoding::DELTA_BYTE_ARRAY: return "DELTA_BYTE_ARRAY";
+        case parquet::Encoding::RLE_DICTIONARY: return "RLE_DICTIONARY";
+        case parquet::Encoding::BYTE_STREAM_SPLIT: return "BYTE_STREAM_SPLIT";
+        case parquet::Encoding::UNDEFINED: return "UNDEFINED";
+        case parquet::Encoding::UNKNOWN: return "UNKNOWN";
+        default: throw std::invalid_argument(std::string("Unknown parquet Encoding::type:: ") + std::to_string(t));
+    }
+}
+
+inline std::string EnumToString(parquet::PageType::type t) {
+    switch (t) {
+        case parquet::PageType::DATA_PAGE: return "DATA_PAGE";
+        case parquet::PageType::INDEX_PAGE: return "INDEX_PAGE";
+        case parquet::PageType::DICTIONARY_PAGE: return "DICTIONARY_PAGE";
+        case parquet::PageType::DATA_PAGE_V2: return "DATA_PAGE_V2";
+        case parquet::PageType::UNDEFINED: return "UNDEFINED";
+        default: throw std::invalid_argument(std::string("Unknown parquet PageType::type:: ") + std::to_string(t));
+    }
+}
+
 } //namespace parquet::encryption
 
 


### PR DESCRIPTION
In encryption_encodings.cc - for enum types, adding the string representation to ToPropertiesMap()

**Testing**
- Existing tests pass (via `ctest -L parquet`)
- Manual testing using `base_app.py`
- More comprehensive tests for `encoding_properties.*` will be part of a future PR.