### PR TITLE
Adding max_definition_level and max_repetition_level to EncodingProperties

### DIFF
--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -105,6 +105,8 @@ struct CryptoContext {
   bool start_decrypt_with_dictionary_page = false;
   int16_t row_group_ordinal = -1;
   int16_t column_ordinal = -1;
+  // Optional: descriptor for the column; may be used to enrich encoding properties
+  const ColumnDescriptor* column_descriptor = nullptr;
   std::function<std::unique_ptr<Decryptor>()> meta_decryptor_factory;
   std::function<std::unique_ptr<Decryptor>()> data_decryptor_factory;
 };

--- a/cpp/src/parquet/encryption/encoding_properties.h
+++ b/cpp/src/parquet/encryption/encoding_properties.h
@@ -80,6 +80,8 @@ private:
 
     //common between V1 and V2 data pages.
     std::optional<int64_t> data_page_num_values_;
+    std::optional<int16_t> data_page_max_definition_level_;
+    std::optional<int16_t> data_page_max_repetition_level_;
 
     //--------------------------------
     // V1 data page properties.
@@ -122,6 +124,10 @@ public:
     // V1 data page properties
     EncodingPropertiesBuilder& PageV1DefinitionLevelEncoding(parquet::Encoding::type encoding);
     EncodingPropertiesBuilder& PageV1RepetitionLevelEncoding(parquet::Encoding::type encoding);
+
+    // Data page common properties (apply to V1 and V2)
+    EncodingPropertiesBuilder& DataPageMaxDefinitionLevel(int16_t level);
+    EncodingPropertiesBuilder& DataPageMaxRepetitionLevel(int16_t level);
     
     // V2 data page properties
     EncodingPropertiesBuilder& PageV2DefinitionLevelsByteLength(int32_t byte_length);
@@ -147,6 +153,8 @@ private:
     // data page properties
     std::optional<parquet::Encoding::type> page_encoding_;
     std::optional<int64_t> data_page_num_values_;
+    std::optional<int16_t> data_page_max_definition_level_;
+    std::optional<int16_t> data_page_max_repetition_level_;
     
     // V1 data page properties
     std::optional<parquet::Encoding::type> page_v1_definition_level_encoding_;

--- a/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
@@ -59,6 +59,8 @@ class ExternalDBPAEncryptorAdapterTest : public ::testing::Test {
             .PageV2RepetitionLevelsByteLength(10)
             .PageV2NumNulls(10)
             .PageV2IsCompressed(true)
+            .DataPageMaxDefinitionLevel(10)
+            .DataPageMaxRepetitionLevel(1)
             .PageEncoding(encoding_type)
             .DataPageNumValues(100) 
             .Build();

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -273,8 +273,11 @@ class SerializedRowGroup : public RowGroupReader::Contents {
       throw ParquetException("Encrypted files cannot contain more than 32767 columns");
     }
 
+    const ColumnDescriptor* descr = file_metadata_->schema()->Column(i);
     CryptoContext ctx{col->has_dictionary_page(),
-                      static_cast<int16_t>(row_group_ordinal_), static_cast<int16_t>(i),
+                      static_cast<int16_t>(row_group_ordinal_), 
+                      static_cast<int16_t>(i),
+                      descr,
                       std::move(meta_decryptor_factory),
                       std::move(data_decryptor_factory)};
     return PageReader::Open(stream, col->num_values(), col->compression(), properties_,


### PR DESCRIPTION
Adding max_definition_level and max_repetition_level to EncodingProperties

In order to achieve this, we modified `CryptoContext` (inside `parquet/column_reader.h`) to include a reference to the `ColumnDescriptor`. This is needed because `max_definition_level` and `max_repetition_level` are defined as column-level properties, and direct access to `ColumnDescriptor` was not available in the Decryption workflow.

**Testing**
- Manual testing using `base_app.py`
- Modified tests pass. 
- Additional testing (for validation, building of `EncodingProperties`) is left for an upcoming PR.
