### PR TITLE
Ciphertext length solution

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -400,6 +400,7 @@ add_parquet_test(reader-test
 add_parquet_test(writer-test
                  SOURCES
                  column_writer_test.cc
+                 encryption/external/test_utils.cc
                  file_serialize_test.cc
                  stream_writer_test.cc)
 

--- a/cpp/src/parquet/encryption/aes_encryption.h
+++ b/cpp/src/parquet/encryption/aes_encryption.h
@@ -71,6 +71,10 @@ class PARQUET_EXPORT AesEncryptor : public AesCryptoContext, public EncryptorInt
 
   /// Start of Encryptor Interface methods.
 
+  /// Signal whether the encryptor can calculate a valid ciphertext length before performing
+  /// encryption.
+  [[nodiscard]] bool CanCalculateCiphertextLength() const override { return true; }
+
   /// The size of the ciphertext, for this cipher and the specified plaintext length.
   [[nodiscard]] int32_t CiphertextLength(int64_t plaintext_len) const override;
 
@@ -80,6 +84,14 @@ class PARQUET_EXPORT AesEncryptor : public AesCryptoContext, public EncryptorInt
                   ::arrow::util::span<const uint8_t> key,
                   ::arrow::util::span<const uint8_t> aad,
                   ::arrow::util::span<uint8_t> ciphertext) override;
+
+  /// Encrypt the plaintext and leave the results in the ciphertext buffer. This method is
+  /// not supported as we can calculate the ciphertext length before encryption.
+  int32_t EncryptWithManagedBuffer(::arrow::util::span<const uint8_t> plaintext,
+                                  ::arrow::ResizableBuffer* ciphertext) override {
+    throw ParquetException(
+      "EncryptWithManagedBuffer is not supported in AesEncryptor, use Encrypt instead");
+  }
 
   /// Encrypts plaintext footer, in order to compute footer signature (tag).
   int32_t SignedFooterEncrypt(::arrow::util::span<const uint8_t> footer,

--- a/cpp/src/parquet/encryption/aes_encryption_test.cc
+++ b/cpp/src/parquet/encryption/aes_encryption_test.cc
@@ -138,4 +138,14 @@ TEST_F(TestAesEncryption, AesGcmCtrDecryptCiphertextBufferTooSmall) {
   DecryptCiphertextBufferTooSmall(ParquetCipher::AES_GCM_CTR_V1);
 }
 
+TEST_F(TestAesEncryption, AesGcmEncryptWithManagedBuffer) {
+  AesEncryptor encryptor(
+    ParquetCipher::AES_GCM_V1, /*key_length*/ 16, /*metadata*/ false, /*write_length*/ true);
+  std::unique_ptr<::arrow::ResizableBuffer> ciphertext_buffer;
+  ASSERT_TRUE(encryptor.CanCalculateCiphertextLength());
+  EXPECT_THROW(
+    encryptor.EncryptWithManagedBuffer(str2span("plain_text_"), ciphertext_buffer.get()),
+    ParquetException);
+}
+
 }  // namespace parquet::encryption::test

--- a/cpp/src/parquet/encryption/external_dbpa_encryption.cc
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption.cc
@@ -177,9 +177,8 @@ void ExternalDBPAEncryptorAdapter::UpdateEncodingProperties(std::unique_ptr<Enco
   encoding_properties_updated_ = true;
 }
 
-int32_t ExternalDBPAEncryptorAdapter::Encrypt(
-    ::arrow::util::span<const uint8_t> plaintext, ::arrow::util::span<const uint8_t> key,
-    ::arrow::util::span<const uint8_t> aad, ::arrow::util::span<uint8_t> ciphertext) {
+int32_t ExternalDBPAEncryptorAdapter::EncryptWithManagedBuffer(
+    ::arrow::util::span<const uint8_t> plaintext, ::arrow::ResizableBuffer* ciphertext) {
 
   if (!encoding_properties_updated_) {
     std::cout << "[ERROR] ExternalDBPAEncryptorAdapter:: EncryptionParams not updated" << std::endl;
@@ -200,7 +199,7 @@ int32_t ExternalDBPAEncryptorAdapter::SignedFooterEncrypt(
 
 int32_t ExternalDBPAEncryptorAdapter::InvokeExternalEncrypt(
     ::arrow::util::span<const uint8_t> plaintext, 
-    ::arrow::util::span<uint8_t> ciphertext,
+    ::arrow::ResizableBuffer* ciphertext,
     std::map<std::string, std::string> encoding_attrs) {
 
       std::cout << "\n*-*-*- START: ExternalDBPAEncryptor::Encrypt *-*-*-" << std::endl;
@@ -228,14 +227,15 @@ int32_t ExternalDBPAEncryptorAdapter::InvokeExternalEncrypt(
       std::cout << "  result size: " << result->size() << " bytes" << std::endl;
       std::cout << "  result ciphertext size: " << result->ciphertext().size() << " bytes" << std::endl;
   
-      if (ciphertext.size() < result->ciphertext().size()) {
-        std::cout << "[ERROR] Ciphertext buffer too small. Need " << result->ciphertext().size()
-                  << " bytes, have " << ciphertext.size() << " bytes" << std::endl;
-        throw ParquetException("Ciphertext buffer too small for encrypted result");
+      int32_t ciphertext_size = result->ciphertext().size();
+      auto status = ciphertext->Resize(ciphertext_size, false);
+      if (!status.ok()) {
+        std::cout << "[ERROR] Ciphertext buffer resize failed: " << status.ToString() << std::endl;
+        throw ParquetException("Ciphertext buffer resize failed");
       }
   
       std::cout << "[DEBUG] Copying result to ciphertext buffer..." << std::endl;
-      std::copy(result->ciphertext().begin(), result->ciphertext().end(), ciphertext.begin());
+      std::memcpy(ciphertext->mutable_data(), result->ciphertext().data(), ciphertext_size);
       std::cout << "[DEBUG] Encryption completed successfully" << std::endl;
   
       return static_cast<int32_t>(result->size());

--- a/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
@@ -146,4 +146,23 @@ TEST_F(ExternalDBPAEncryptorAdapterTest, SignedFooterEncryptionThrowsException) 
     encrypted_footer), ParquetException);
 }
 
+TEST_F(ExternalDBPAEncryptorAdapterTest, EncryptCallShouldFail) {
+  ParquetCipher::type algorithm = ParquetCipher::EXTERNAL_DBPA_V1;
+  std::string column_name = "employee_name";
+  std::string key_id = "employee_name_key";
+  Type::type data_type = Type::BYTE_ARRAY;
+  Compression::type compression_type = Compression::UNCOMPRESSED;
+  Encoding::type encoding_type = Encoding::PLAIN;
+  std::string plaintext = "Jean-Luc Picard";
+  std::vector<uint8_t> ciphertext_buffer(plaintext.size(), '\0');
+
+  std::unique_ptr<ExternalDBPAEncryptorAdapter> encryptor = CreateEncryptor(
+    algorithm, column_name, key_id, data_type, compression_type, encoding_type);
+  ASSERT_FALSE(encryptor->CanCalculateCiphertextLength());
+  EXPECT_THROW(
+    encryptor->Encrypt(
+      str2span(plaintext), str2span(/*key*/""), str2span(/*aad*/""), ciphertext_buffer),
+    ParquetException);
+}
+
 }  // namespace parquet::encryption::test

--- a/cpp/src/parquet/encryption/internal_file_encryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.cc
@@ -37,9 +37,18 @@ int32_t Encryptor::CiphertextLength(int64_t plaintext_len) const {
   return encryptor_instance_->CiphertextLength(plaintext_len);
 }
 
+bool Encryptor::CanCalculateCiphertextLength() const {
+  return encryptor_instance_->CanCalculateCiphertextLength();
+}
+
 int32_t Encryptor::Encrypt(::arrow::util::span<const uint8_t> plaintext,
                            ::arrow::util::span<uint8_t> ciphertext) {
   return encryptor_instance_->Encrypt(plaintext, str2span(key_), str2span(aad_), ciphertext);
+}
+
+int32_t Encryptor::EncryptWithManagedBuffer(::arrow::util::span<const uint8_t> plaintext,
+                                           ::arrow::ResizableBuffer* ciphertext) {
+  return encryptor_instance_->EncryptWithManagedBuffer(plaintext, ciphertext);
 }
 
 void Encryptor::UpdateEncodingProperties(std::unique_ptr<EncodingProperties> encoding_properties) {

--- a/cpp/src/parquet/encryption/internal_file_encryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.h
@@ -44,10 +44,14 @@ class PARQUET_EXPORT Encryptor {
   void UpdateAad(const std::string& aad) { aad_ = aad; }
   ::arrow::MemoryPool* pool() { return pool_; }
 
+  [[nodiscard]] bool CanCalculateCiphertextLength() const;
   [[nodiscard]] int32_t CiphertextLength(int64_t plaintext_len) const;
 
   int32_t Encrypt(::arrow::util::span<const uint8_t> plaintext,
                   ::arrow::util::span<uint8_t> ciphertext);
+
+  int32_t EncryptWithManagedBuffer(::arrow::util::span<const uint8_t> plaintext,
+                                  ::arrow::ResizableBuffer* ciphertext);
 
   void UpdateEncodingProperties(std::unique_ptr<EncodingProperties> encoding_properties);
 


### PR DESCRIPTION
Updating encryptor interfaces and implementations so that we can signal whether an encryptor can calculate the ciphertext length before calling the actual encryption.

Added another method for when the encryptor cannot make this calculation, called EncryptWithManagedBuffer. This takes a ResizableBuffer that the encryptor is responsible for managing, resizing, and copying the results during the encryption call.

Encryptors can only implement one of the encrypt call (regular or with managed buffer). The other call should throw an exception.

Modified tests accordingly, testing round trip on the column_writer_test. The changes made in metadata and thrift_internal as tested as part of the round trip test.

See the [document](https://docs.google.com/document/d/1e5VwLyWmjuqPR6wi6UJm0JhLdU7VSn920HjaR_8af1s/edit?tab=t.0#heading=h.pwd3zpq2h302) for discussion.