### PR TITLE
ExternalDBPAEncryptor bug fix: passing datatype_length to UpdateEncodingParams()

### DIFF
--- a/cpp/src/parquet/encryption/external_dbpa_encryption.cc
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption.cc
@@ -100,11 +100,11 @@ std::unique_ptr<dbps::external::DataBatchProtectionAgentInterface> LoadAndInitia
 ExternalDBPAEncryptorAdapter::ExternalDBPAEncryptorAdapter(
   ParquetCipher::type algorithm, std::string column_name, std::string key_id,
   Type::type data_type, Compression::type compression_type, Encoding::type encoding_type,
-  std::string app_context, std::map<std::string, std::string> connection_config,
+  std::optional<int> datatype_length, std::string app_context, std::map<std::string, std::string> connection_config,
   std::unique_ptr<DataBatchProtectionAgentInterface> agent_instance)
   : algorithm_(algorithm), column_name_(column_name), key_id_(key_id),
     data_type_(data_type), compression_type_(compression_type),
-    encoding_type_(encoding_type), app_context_(app_context),
+    encoding_type_(encoding_type), datatype_length_(datatype_length), app_context_(app_context),
     connection_config_(connection_config),
     agent_instance_(std::move(agent_instance)) {
 
@@ -154,6 +154,7 @@ std::unique_ptr<ExternalDBPAEncryptorAdapter> ExternalDBPAEncryptorAdapter::Make
             /*data_type*/ data_type,
             /*compression_type*/ compression_type,
             /*encoding_type*/ encoding_type,
+            /*datatype_length*/ datatype_length,
             /*app_context*/ app_context,
             /*connection_config*/ connection_config,
             /*agent_instance*/ std::move(agent_instance))
@@ -177,7 +178,7 @@ void ExternalDBPAEncryptorAdapter::UpdateEncodingProperties(std::unique_ptr<Enco
 
   //fill-in values from the decryptor constructor.
   encoding_properties->set_column_path(column_name_);
-  encoding_properties->set_physical_type(data_type_);
+  encoding_properties->set_physical_type(data_type_, datatype_length_);
   encoding_properties->set_compression_codec(compression_type_);
 
   encoding_properties->validate();
@@ -308,12 +309,12 @@ ExternalDBPAEncryptorAdapter* ExternalDBPAEncryptorAdapterFactory::GetEncryptor(
 ExternalDBPADecryptorAdapter::ExternalDBPADecryptorAdapter(
   ParquetCipher::type algorithm, std::string column_name, std::string key_id,
   Type::type data_type, Compression::type compression_type,
-  std::vector<Encoding::type> encoding_types, std::string app_context,
+  std::vector<Encoding::type> encoding_types, std::optional<int> datatype_length, std::string app_context,
   std::map<std::string, std::string> connection_config,
   std::unique_ptr<DataBatchProtectionAgentInterface> agent_instance)
   : algorithm_(algorithm), column_name_(column_name), key_id_(key_id),
     data_type_(data_type), compression_type_(compression_type),
-    encoding_types_(encoding_types), app_context_(app_context),
+    encoding_types_(encoding_types), datatype_length_(datatype_length), app_context_(app_context),
     connection_config_(connection_config),
     agent_instance_(std::move(agent_instance)) {
 
@@ -367,6 +368,7 @@ std::unique_ptr<ExternalDBPADecryptorAdapter> ExternalDBPADecryptorAdapter::Make
             /*data_type*/ data_type,
             /*compression_type*/ compression_type,
             /*encoding_types*/ encoding_types,
+            /*datatype_length*/ datatype_length,
             /*app_context*/ app_context,
             /*connection_config*/ connection_config,
             /*agent_instance*/ std::move(agent_instance))
@@ -389,7 +391,7 @@ void ExternalDBPADecryptorAdapter::UpdateEncodingProperties(std::unique_ptr<Enco
 
   //fill-in values from the decryptor constructor.
   encoding_properties->set_column_path(column_name_);
-  encoding_properties->set_physical_type(data_type_);
+  encoding_properties->set_physical_type(data_type_, datatype_length_);
   encoding_properties->set_compression_codec(compression_type_);
   
   encoding_properties->validate();

--- a/cpp/src/parquet/encryption/external_dbpa_encryption.h
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption.h
@@ -56,7 +56,7 @@ class ExternalDBPAEncryptorAdapter : public EncryptorInterface {
     ExternalDBPAEncryptorAdapter(
       ParquetCipher::type algorithm, std::string column_name,
       std::string key_id, Type::type data_type, Compression::type compression_type,
-      Encoding::type encoding_type, std::string app_context,
+      Encoding::type encoding_type, std::optional<int> datatype_length, std::string app_context,
       std::map<std::string, std::string> connection_config,
       std::unique_ptr<DataBatchProtectionAgentInterface> agent_instance);
 
@@ -71,6 +71,7 @@ class ExternalDBPAEncryptorAdapter : public EncryptorInterface {
     Type::type data_type_;
     Compression::type compression_type_;
     Encoding::type encoding_type_;
+    std::optional<int> datatype_length_;
     std::string app_context_;
     std::map<std::string, std::string> connection_config_;
     
@@ -127,7 +128,7 @@ class ExternalDBPADecryptorAdapter : public DecryptorInterface {
     ExternalDBPADecryptorAdapter(
       ParquetCipher::type algorithm, std::string column_name,
       std::string key_id, Type::type data_type, Compression::type compression_type,
-      std::vector<Encoding::type> encoding_types, std::string app_context,
+      std::vector<Encoding::type> encoding_types, std::optional<int> datatype_length, std::string app_context,
       std::map<std::string, std::string> connection_config,
       std::unique_ptr<DataBatchProtectionAgentInterface> agent_instance);
     
@@ -143,6 +144,7 @@ class ExternalDBPADecryptorAdapter : public DecryptorInterface {
     Compression::type compression_type_;
     // Set of all encodings used for this column. Comes directly from the column chunk metadata.
     std::vector<Encoding::type> encoding_types_;
+    std::optional<int> datatype_length_;
     std::string app_context_;
     std::map<std::string, std::string> connection_config_;
 


### PR DESCRIPTION
Fixing a bug in ExternalDBPAEncryptor where `datatype_length` was not being passed to `UpdateEncodingParams()`

