### PR TITLE
Adding plaintext solution to decrypt path

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -592,7 +592,7 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
 
       data_decryptor_->UpdateEncodingProperties(std::move(encoding_properties));
 
-      if (data_decryptor_->CanCalculatePlaintextLength()) {
+      if (data_decryptor_->CanCalculateLengths()) {
         PARQUET_THROW_NOT_OK(
             decryption_buffer_->Resize(data_decryptor_->PlaintextLength(compressed_len),
                                       /*shrink_to_fit=*/false));

--- a/cpp/src/parquet/encryption/aes_encryption.h
+++ b/cpp/src/parquet/encryption/aes_encryption.h
@@ -152,6 +152,12 @@ class PARQUET_EXPORT AesDecryptor : public AesCryptoContext, public DecryptorInt
 
   /// Start of Decryptor Interface methods.
 
+  /// Signal whether the decryptor can calculate a valid plaintext length before performing
+  /// decryption or not. If false, a proper sized buffer cannot be allocated before calling the
+  /// Decrypt method, and Arrow must use this decryptor's DecryptWithManagedBuffer method 
+  /// instead of Decrypt.
+  [[nodiscard]] bool CanCalculatePlaintextLength() const override { return true; }
+
   /// The size of the plaintext, for this cipher and the specified ciphertext length.
   [[nodiscard]] int32_t PlaintextLength(int32_t ciphertext_len) const override;
 
@@ -166,6 +172,14 @@ class PARQUET_EXPORT AesDecryptor : public AesCryptoContext, public DecryptorInt
                   ::arrow::util::span<const uint8_t> key,
                   ::arrow::util::span<const uint8_t> aad,
                   ::arrow::util::span<uint8_t> plaintext) override;
+
+  /// Decrypt the ciphertext and leave the results in the plaintext buffer.
+  /// This method is not supported as we can calculate the plaintext length before decryption.
+  int32_t DecryptWithManagedBuffer(::arrow::util::span<const uint8_t> ciphertext,
+                                  ::arrow::ResizableBuffer* plaintext) override {
+      throw ParquetException(
+        "DecryptWithManagedBuffer is not supported in AesDecryptor, use Decrypt instead");
+  }
 
   /// End of Decryptor Interface methods.
 

--- a/cpp/src/parquet/encryption/aes_encryption.h
+++ b/cpp/src/parquet/encryption/aes_encryption.h
@@ -152,11 +152,11 @@ class PARQUET_EXPORT AesDecryptor : public AesCryptoContext, public DecryptorInt
 
   /// Start of Decryptor Interface methods.
 
-  /// Signal whether the decryptor can calculate a valid plaintext length before performing
-  /// decryption or not. If false, a proper sized buffer cannot be allocated before calling the
-  /// Decrypt method, and Arrow must use this decryptor's DecryptWithManagedBuffer method 
-  /// instead of Decrypt.
-  [[nodiscard]] bool CanCalculatePlaintextLength() const override { return true; }
+  /// Signal whether the decryptor can calculate a valid plaintext or ciphertext length before 
+  /// performing decryption or not. If false, a proper sized buffer cannot be allocated before 
+  /// calling the Decrypt method, and Arrow must use this decryptor's DecryptWithManagedBuffer
+  /// method instead of Decrypt.
+  [[nodiscard]] bool CanCalculateLengths() const override { return true; }
 
   /// The size of the plaintext, for this cipher and the specified ciphertext length.
   [[nodiscard]] int32_t PlaintextLength(int32_t ciphertext_len) const override;

--- a/cpp/src/parquet/encryption/aes_encryption_test.cc
+++ b/cpp/src/parquet/encryption/aes_encryption_test.cc
@@ -148,4 +148,14 @@ TEST_F(TestAesEncryption, AesGcmEncryptWithManagedBuffer) {
     ParquetException);
 }
 
+TEST_F(TestAesEncryption, AesGcmDecryptWithManagedBuffer) {
+  AesDecryptor decryptor(
+    ParquetCipher::AES_GCM_V1, /*key_length*/ 16, /*metadata*/ false, /*write_length*/ true);
+  std::unique_ptr<::arrow::ResizableBuffer> ciphertext_buffer;
+  ASSERT_TRUE(decryptor.CanCalculatePlaintextLength());
+  EXPECT_THROW(
+    decryptor.DecryptWithManagedBuffer(str2span("plain_text_"), ciphertext_buffer.get()),
+    ParquetException);
+}
+
 }  // namespace parquet::encryption::test

--- a/cpp/src/parquet/encryption/aes_encryption_test.cc
+++ b/cpp/src/parquet/encryption/aes_encryption_test.cc
@@ -152,7 +152,7 @@ TEST_F(TestAesEncryption, AesGcmDecryptWithManagedBuffer) {
   AesDecryptor decryptor(
     ParquetCipher::AES_GCM_V1, /*key_length*/ 16, /*metadata*/ false, /*write_length*/ true);
   std::unique_ptr<::arrow::ResizableBuffer> ciphertext_buffer;
-  ASSERT_TRUE(decryptor.CanCalculatePlaintextLength());
+  ASSERT_TRUE(decryptor.CanCalculateLengths());
   EXPECT_THROW(
     decryptor.DecryptWithManagedBuffer(str2span("plain_text_"), ciphertext_buffer.get()),
     ParquetException);

--- a/cpp/src/parquet/encryption/decryptor_interface.h
+++ b/cpp/src/parquet/encryption/decryptor_interface.h
@@ -26,11 +26,11 @@ class PARQUET_EXPORT DecryptorInterface {
  public:
   virtual ~DecryptorInterface() = default;
 
-  /// Signal whether the decryptor can calculate a valid plaintext length before performing
-  /// decryption or not. If false, a proper sized buffer cannot be allocated before calling the
-  /// Decrypt method, and Arrow must use this decryptor's DecryptWithManagedBuffer method 
-  /// instead of Decrypt.
-  [[nodiscard]] virtual bool CanCalculatePlaintextLength() const = 0;
+  /// Signal whether the decryptor can calculate a valid plaintext or ciphertext length before
+  /// performing decryption or not. If false, a proper sized buffer cannot be allocated before 
+  /// calling the Decrypt method, and Arrow must use this decryptor's DecryptWithManagedBuffer 
+  /// method instead of Decrypt.
+  [[nodiscard]] virtual bool CanCalculateLengths() const = 0;
 
   /// Calculate the size of the plaintext for a given ciphertext length.
   [[nodiscard]] virtual int32_t PlaintextLength(int32_t ciphertext_len) const = 0;

--- a/cpp/src/parquet/encryption/external_dbpa_encryption.h
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption.h
@@ -120,11 +120,11 @@ class ExternalDBPADecryptorAdapter : public DecryptorInterface {
   
   ~ExternalDBPADecryptorAdapter() = default;
 
-  /// Signal whether the decryptor can calculate a valid plaintext length before performing
-  /// decryption or not. If false, a proper sized buffer cannot be allocated before calling the
-  /// Decrypt method, and Arrow must use this decryptor's DecryptWithManagedBuffer method 
-  /// instead of Decrypt.
-  [[nodiscard]] bool CanCalculatePlaintextLength() const override { return false; }
+  /// Signal whether the decryptor can calculate a valid plaintext or ciphertext length before 
+  /// performing decryption or not. If false, a proper sized buffer cannot be allocated before 
+  /// calling the Decrypt method, and Arrow must use this decryptor's DecryptWithManagedBuffer
+  /// method instead of Decrypt.
+  [[nodiscard]] bool CanCalculateLengths() const override { return false; }
 
   /// The size of the plaintext, for this cipher and the specified ciphertext length.
   [[nodiscard]] int32_t PlaintextLength(int32_t ciphertext_len) const override;

--- a/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
@@ -40,6 +40,15 @@ class ExternalDBPAEncryptorAdapterTest : public ::testing::Test {
       connection_config_, std::nullopt);
   }
 
+  std::unique_ptr<ExternalDBPADecryptorAdapter> CreateDecryptor(
+    ParquetCipher::type algorithm, std::string column_name, std::string key_id, 
+    Type::type data_type, Compression::type compression_type, Encoding::type encoding_type) {
+    return ExternalDBPADecryptorAdapter::Make(
+      algorithm, column_name, key_id, data_type, 
+      compression_type, {encoding_type}, app_context_, 
+      connection_config_, std::nullopt);
+  }
+
   void RoundtripEncryption(
       ParquetCipher::type algorithm, std::string column_name, std::string key_id, 
       Type::type data_type, Compression::type compression_type, Encoding::type encoding_type,
@@ -92,15 +101,14 @@ class ExternalDBPAEncryptorAdapterTest : public ::testing::Test {
     decryptor->UpdateEncodingProperties(builder.Build());
 
     int32_t expected_plaintext_length = ciphertext_str.size();
-    int32_t actual_plaintext_length = decryptor->PlaintextLength(ciphertext_str.size());
-    ASSERT_EQ(expected_plaintext_length, actual_plaintext_length);
-
-    std::vector<uint8_t> plaintext_buffer(expected_plaintext_length, '\0');
-    int32_t decryption_length = decryptor->Decrypt(
-      str2span(ciphertext_str), str2span(empty_string), str2span(empty_string), plaintext_buffer);
+    std::shared_ptr<ResizableBuffer> plaintext_buffer = AllocateBuffer(
+      ::arrow::default_memory_pool(), expected_plaintext_length);
+    int32_t decryption_length = decryptor->DecryptWithManagedBuffer(
+      str2span(ciphertext_str), plaintext_buffer.get());
     ASSERT_EQ(expected_plaintext_length, decryption_length);
 
-    std::string plaintext_str(plaintext_buffer.begin(), plaintext_buffer.end());
+    std::string plaintext_str(
+      plaintext_buffer->data(), plaintext_buffer->data() + decryption_length);
 
     // Assert that the decrypted plaintext matches the original plaintext
     ASSERT_EQ(plaintext, plaintext_str);
@@ -153,10 +161,11 @@ TEST_F(ExternalDBPAEncryptorAdapterTest, EncryptWithoutUpdateEncodingPropertiesT
     app_context_, connection_config_, std::nullopt);
 
   std::string plaintext = "abc";
-  std::vector<uint8_t> ciphertext_buffer(plaintext.size(), '\0');
+  std::shared_ptr<ResizableBuffer> ciphertext_buffer = AllocateBuffer(
+    ::arrow::default_memory_pool(), 0);
   EXPECT_THROW(
-    encryptor->Encrypt(
-      str2span(plaintext), str2span(empty_string), str2span(empty_string), ciphertext_buffer),
+    encryptor->EncryptWithManagedBuffer(
+      str2span(plaintext), ciphertext_buffer.get()),
     ParquetException);
 }
 
@@ -173,10 +182,11 @@ TEST_F(ExternalDBPAEncryptorAdapterTest, DecryptWithoutUpdateEncodingPropertiesT
     app_context_, connection_config_, std::nullopt);
 
   std::string ciphertext = "xyz";
-  std::vector<uint8_t> plaintext_buffer(ciphertext.size(), '\0');
+  std::shared_ptr<ResizableBuffer> plaintext_buffer = AllocateBuffer(
+    ::arrow::default_memory_pool(), 0);
   EXPECT_THROW(
-    decryptor->Decrypt(
-      str2span(ciphertext), str2span(empty_string), str2span(empty_string), plaintext_buffer),
+    decryptor->DecryptWithManagedBuffer(
+      str2span(ciphertext), plaintext_buffer.get()),
     ParquetException);
 }
 
@@ -337,14 +347,15 @@ TEST_F(ExternalDBPAEncryptorAdapterTest, DecryptWithWrongKeyIdFails) {
 
   std::string plaintext = "Sensitive Data";
   int32_t ct_len = encryptor->CiphertextLength(plaintext.size());
-  std::vector<uint8_t> ciphertext_buffer(ct_len, '\0');
+  std::shared_ptr<ResizableBuffer> ciphertext_buffer = AllocateBuffer(
+    ::arrow::default_memory_pool(), 0);
 
   std::string empty;
-  int32_t enc_len = encryptor->Encrypt(
-    str2span(plaintext), str2span(empty), str2span(empty), ciphertext_buffer);
+  int32_t enc_len = encryptor->EncryptWithManagedBuffer(
+    str2span(plaintext), ciphertext_buffer.get());
   ASSERT_EQ(ct_len, enc_len);
 
-  std::string ciphertext_str(ciphertext_buffer.begin(), ciphertext_buffer.end());
+  std::string ciphertext_str(ciphertext_buffer->data(), ciphertext_buffer->data() + enc_len);
 
   auto decryptor = ExternalDBPADecryptorAdapter::Make(
     algorithm, column_name, wrong_key_id, data_type, compression_type, {encoding_type},
@@ -353,19 +364,21 @@ TEST_F(ExternalDBPAEncryptorAdapterTest, DecryptWithWrongKeyIdFails) {
   decryptor->UpdateEncodingProperties(builder.Build());
 
   int32_t pt_len = decryptor->PlaintextLength(ciphertext_str.size());
-  std::vector<uint8_t> plaintext_buffer(pt_len, '\0');
+  std::shared_ptr<ResizableBuffer> plaintext_buffer = AllocateBuffer(
+    ::arrow::default_memory_pool(), 0);
 
   bool threw = false;
+  int32_t dec_len = 0;
   try {
-    int32_t dec_len = decryptor->Decrypt(
-      str2span(ciphertext_str), str2span(empty), str2span(empty), plaintext_buffer);
+    dec_len = decryptor->DecryptWithManagedBuffer(
+      str2span(ciphertext_str), plaintext_buffer.get());
     ASSERT_EQ(pt_len, dec_len);
   } catch (const ParquetException&) {
     threw = true;
   }
 
   if (!threw) {
-    std::string decrypted(plaintext_buffer.begin(), plaintext_buffer.end());
+    std::string decrypted(plaintext_buffer->data(), plaintext_buffer->data() + dec_len);
     ASSERT_NE(plaintext, decrypted);
   }
 }
@@ -386,6 +399,25 @@ TEST_F(ExternalDBPAEncryptorAdapterTest, EncryptCallShouldFail) {
   EXPECT_THROW(
     encryptor->Encrypt(
       str2span(plaintext), str2span(/*key*/""), str2span(/*aad*/""), ciphertext_buffer),
+    ParquetException);
+}
+
+TEST_F(ExternalDBPAEncryptorAdapterTest, DecryptCallShouldFail) {
+  ParquetCipher::type algorithm = ParquetCipher::EXTERNAL_DBPA_V1;
+  std::string column_name = "employee_name";
+  std::string key_id = "employee_name_key";
+  Type::type data_type = Type::BYTE_ARRAY;
+  Compression::type compression_type = Compression::UNCOMPRESSED;
+  Encoding::type encoding_type = Encoding::PLAIN;
+  std::string ciphertext = "Jean-Luc Picard";
+  std::vector<uint8_t> plaintext_buffer(ciphertext.size(), '\0');
+
+  std::unique_ptr<ExternalDBPADecryptorAdapter> decryptor = CreateDecryptor(
+    algorithm, column_name, key_id, data_type, compression_type, encoding_type);
+  ASSERT_FALSE(decryptor->CanCalculatePlaintextLength());
+  EXPECT_THROW(
+    decryptor->Decrypt(
+      str2span(ciphertext), str2span(/*key*/""), str2span(/*aad*/""), plaintext_buffer),
     ParquetException);
 }
 

--- a/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
@@ -414,7 +414,7 @@ TEST_F(ExternalDBPAEncryptorAdapterTest, DecryptCallShouldFail) {
 
   std::unique_ptr<ExternalDBPADecryptorAdapter> decryptor = CreateDecryptor(
     algorithm, column_name, key_id, data_type, compression_type, encoding_type);
-  ASSERT_FALSE(decryptor->CanCalculatePlaintextLength());
+  ASSERT_FALSE(decryptor->CanCalculateLengths());
   EXPECT_THROW(
     decryptor->Decrypt(
       str2span(ciphertext), str2span(/*key*/""), str2span(/*aad*/""), plaintext_buffer),

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -37,6 +37,10 @@ Decryptor::Decryptor(std::unique_ptr<encryption::DecryptorInterface> decryptor_i
 
 Decryptor::~Decryptor() = default;
 
+bool Decryptor::CanCalculatePlaintextLength() const {
+  return decryptor_instance_->CanCalculatePlaintextLength();
+}
+
 int32_t Decryptor::PlaintextLength(int32_t ciphertext_len) const {
   return decryptor_instance_->PlaintextLength(ciphertext_len);
 }
@@ -52,6 +56,11 @@ void Decryptor::UpdateEncodingProperties(std::unique_ptr<EncodingProperties> enc
 int32_t Decryptor::Decrypt(::arrow::util::span<const uint8_t> ciphertext,
                            ::arrow::util::span<uint8_t> plaintext) {
   return decryptor_instance_->Decrypt(ciphertext, str2span(key_), str2span(aad_), plaintext);
+}
+
+int32_t Decryptor::DecryptWithManagedBuffer(::arrow::util::span<const uint8_t> ciphertext,
+                                           ::arrow::ResizableBuffer* plaintext) {
+  return decryptor_instance_->DecryptWithManagedBuffer(ciphertext, plaintext);
 }
 
 // InternalFileDecryptor

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -37,8 +37,8 @@ Decryptor::Decryptor(std::unique_ptr<encryption::DecryptorInterface> decryptor_i
 
 Decryptor::~Decryptor() = default;
 
-bool Decryptor::CanCalculatePlaintextLength() const {
-  return decryptor_instance_->CanCalculatePlaintextLength();
+bool Decryptor::CanCalculateLengths() const {
+  return decryptor_instance_->CanCalculateLengths();
 }
 
 int32_t Decryptor::PlaintextLength(int32_t ciphertext_len) const {

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -46,10 +46,13 @@ class PARQUET_EXPORT Decryptor {
   void UpdateAad(const std::string& aad) { aad_ = aad; }
   ::arrow::MemoryPool* pool() { return pool_; }
 
+  [[nodiscard]] bool CanCalculatePlaintextLength() const;
   [[nodiscard]] int32_t PlaintextLength(int32_t ciphertext_len) const;
   [[nodiscard]] int32_t CiphertextLength(int32_t plaintext_len) const;
   int32_t Decrypt(::arrow::util::span<const uint8_t> ciphertext,
                   ::arrow::util::span<uint8_t> plaintext);
+  int32_t DecryptWithManagedBuffer(::arrow::util::span<const uint8_t> ciphertext,
+                                  ::arrow::ResizableBuffer* plaintext);
 
   void UpdateEncodingProperties(std::unique_ptr<EncodingProperties> encoding_properties);
 

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -46,7 +46,7 @@ class PARQUET_EXPORT Decryptor {
   void UpdateAad(const std::string& aad) { aad_ = aad; }
   ::arrow::MemoryPool* pool() { return pool_; }
 
-  [[nodiscard]] bool CanCalculatePlaintextLength() const;
+  [[nodiscard]] bool CanCalculateLengths() const;
   [[nodiscard]] int32_t PlaintextLength(int32_t ciphertext_len) const;
   [[nodiscard]] int32_t CiphertextLength(int32_t plaintext_len) const;
   int32_t Decrypt(::arrow::util::span<const uint8_t> ciphertext,

--- a/cpp/src/parquet/file_deserialize_test.cc
+++ b/cpp/src/parquet/file_deserialize_test.cc
@@ -1010,7 +1010,7 @@ class CapturingTestDecryptor : public parquet::encryption::DecryptorInterface {
         physical_type_(physical_type),
         compression_codec_(compression_codec) {}
 
-  [[nodiscard]] bool CanCalculatePlaintextLength() const override {
+  [[nodiscard]] bool CanCalculateLengths() const override {
     return true;
   }
 

--- a/cpp/src/parquet/file_deserialize_test.cc
+++ b/cpp/src/parquet/file_deserialize_test.cc
@@ -1010,6 +1010,10 @@ class CapturingTestDecryptor : public parquet::encryption::DecryptorInterface {
         physical_type_(physical_type),
         compression_codec_(compression_codec) {}
 
+  [[nodiscard]] bool CanCalculatePlaintextLength() const override {
+    return true;
+  }
+
   [[nodiscard]] int32_t PlaintextLength(int32_t ciphertext_len) const override {
     return ciphertext_len;
   }
@@ -1024,6 +1028,11 @@ class CapturingTestDecryptor : public parquet::encryption::DecryptorInterface {
                   ::arrow::util::span<uint8_t> plaintext) override {
     std::copy(ciphertext.begin(), ciphertext.end(), plaintext.begin());
     return static_cast<int32_t>(ciphertext.size());
+  }
+
+  int32_t DecryptWithManagedBuffer(::arrow::util::span<const uint8_t> ciphertext,
+                                  ::arrow::ResizableBuffer* plaintext) override {
+    throw ParquetException("DecryptWithManagedBuffer not supported");
   }
 
   void UpdateEncodingProperties(

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -443,6 +443,15 @@ class ThriftDeserializer {
       // thrift message is not encrypted
       DeserializeUnencryptedMessage(buf, len, deserialized_msg);
     } else {
+      // This method is only used to deserialize metadata or footer data, so it is not expected 
+      // to be called with a decryptor that can't calculate lengths.
+      if (!decryptor->CanCalculateLengths()) {
+        std::stringstream ss;
+        ss << "Decryptor can't calculate plaintext or ciphertext lengths when deserializing metadata or footer data";
+        ss << "and should not be used to deserialize metadata or footer data";
+        throw ParquetException(ss.str());
+      }
+
       // thrift message is encrypted
       uint32_t clen;
       clen = *len;
@@ -452,19 +461,11 @@ class ThriftDeserializer {
         throw ParquetException(ss.str());
       }
       // decrypt
-      uint32_t decrypted_buffer_len;
-      std::shared_ptr<ResizableBuffer> decrypted_buffer;
-      ::arrow::util::span<const uint8_t> cipher_buf(buf, clen);
-      if (decryptor->CanCalculatePlaintextLength()) {
-        decrypted_buffer = AllocateBuffer(
+      auto decrypted_buffer = AllocateBuffer(
           decryptor->pool(), decryptor->PlaintextLength(static_cast<int32_t>(clen)));
-        decrypted_buffer_len = decryptor->Decrypt(
-          cipher_buf, decrypted_buffer->mutable_span_as<uint8_t>());
-      } else {
-        decrypted_buffer = AllocateBuffer(decryptor->pool(), 0);
-        decrypted_buffer_len = decryptor->DecryptWithManagedBuffer(
-          cipher_buf, decrypted_buffer.get());
-      }
+      ::arrow::util::span<const uint8_t> cipher_buf(buf, clen);
+      uint32_t decrypted_buffer_len =
+          decryptor->Decrypt(cipher_buf, decrypted_buffer->mutable_span_as<uint8_t>());
 
       if (decrypted_buffer_len <= 0) {
         throw ParquetException("Couldn't decrypt buffer\n");


### PR DESCRIPTION
Updating decryptor interfaces and implementations so that we can signal whether a decryptor can calculate the plaintext length before calling the actual decryption.

Added another method for when the decryptor cannot make this calculation, called DecryptWithManagedBuffer. This takes a ResizableBuffer that the decryptor is responsible for managing, resizing, and copying the results during the decryption call.

Decryptors can only implement one of the decrypt call (regular or with managed buffer). The other call should throw an exception.

Modified tests accordingly, the round trip test for this has already been done in column_writer_test.
