### PR TITLE
Extracting timeout values from the connection config file

### DIFF
--- a/cpp/src/parquet/encryption/external_dbpa_encryption.cc
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption.cc
@@ -72,15 +72,22 @@ std::unique_ptr<dbps::external::DataBatchProtectionAgentInterface> LoadAndInitia
   int64_t encrypt_timeout_ms = 30*1000; //30 seconds
   int64_t decrypt_timeout_ms = 30*1000; //30 seconds.
   // Override the default values if they are present in the connection_config.
-  if (connection_config.find(INIT_TIMEOUT_KEY) != connection_config.end()) {
-    init_timeout_ms = std::stoi(connection_config.at(INIT_TIMEOUT_KEY));
+  try {
+    if (connection_config.find(INIT_TIMEOUT_KEY) != connection_config.end()) {
+      init_timeout_ms = std::stoi(connection_config.at(INIT_TIMEOUT_KEY));
+    }
+    if (connection_config.find(ENCRYPT_TIMEOUT_KEY) != connection_config.end()) {
+      encrypt_timeout_ms = std::stoi(connection_config.at(ENCRYPT_TIMEOUT_KEY));
+    }
+    if (connection_config.find(DECRYPT_TIMEOUT_KEY) != connection_config.end()) {
+        decrypt_timeout_ms = std::stoi(connection_config.at(DECRYPT_TIMEOUT_KEY));
+    }
+  } catch (const std::exception& e) {
+    std::cout << "[ERROR] Failed to parse timeout values from connection_config: " 
+              << e.what() << std::endl;
+    throw ParquetException("Failed to parse timeout values from connection_config");
   }
-  if (connection_config.find(ENCRYPT_TIMEOUT_KEY) != connection_config.end()) {
-    encrypt_timeout_ms = std::stoi(connection_config.at(ENCRYPT_TIMEOUT_KEY));
-  }
-  if (connection_config.find(DECRYPT_TIMEOUT_KEY) != connection_config.end()) {
-    decrypt_timeout_ms = std::stoi(connection_config.at(DECRYPT_TIMEOUT_KEY));
-  }
+
 
   std::cout << "[DEBUG] init_timeout_ms    = " << init_timeout_ms << std::endl;
   std::cout << "[DEBUG] encrypt_timeout_ms = " << encrypt_timeout_ms << std::endl;

--- a/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
@@ -275,6 +275,29 @@ TEST_F(ExternalDBPAEncryptorAdapterTest, EncryptorInvalidLibraryPathThrows) {
     std::exception);
 }
 
+TEST_F(ExternalDBPAEncryptorAdapterTest, EncryptorInvalidTimeoutValuesThrows) {
+  ParquetCipher::type algorithm = ParquetCipher::EXTERNAL_DBPA_V1;
+  std::string column_name = "employee_name";
+  std::string key_id = "employee_name_key";
+  Type::type data_type = Type::BYTE_ARRAY;
+  Compression::type compression_type = Compression::UNCOMPRESSED;
+  Encoding::type encoding_type = Encoding::PLAIN;
+
+  std::string library_path = parquet::encryption::external::test::TestUtils::GetTestLibraryPath();
+  std::map<std::string, std::string> bad_config = {
+    {"config_path", "path/to/file"}, 
+    {"agent_library_path", library_path},
+    {"init_timeout_ms", "nope"},
+  };
+  std::string app_context = "{}";
+
+  EXPECT_THROW(
+    ExternalDBPAEncryptorAdapter::Make(
+      algorithm, column_name, key_id, data_type, compression_type, encoding_type,
+      app_context, bad_config, std::nullopt),
+    std::exception);
+}
+
 TEST_F(ExternalDBPAEncryptorAdapterTest, DecryptorMissingLibraryPathThrows) {
   ParquetCipher::type algorithm = ParquetCipher::EXTERNAL_DBPA_V1;
   std::string column_name = "employee_name";
@@ -303,6 +326,29 @@ TEST_F(ExternalDBPAEncryptorAdapterTest, DecryptorInvalidLibraryPathThrows) {
 
   std::map<std::string, std::string> bad_config = {
     {"agent_library_path", "/definitely/not/a/real/libDBPA.so"}
+  };
+  std::string app_context = "{}";
+
+  EXPECT_THROW(
+    ExternalDBPADecryptorAdapter::Make(
+      algorithm, column_name, key_id, data_type, compression_type, {encoding_type},
+      app_context, bad_config, std::nullopt),
+    std::exception);
+}
+
+TEST_F(ExternalDBPAEncryptorAdapterTest, DecryptorInvalidTimeoutValuesThrows) {
+  ParquetCipher::type algorithm = ParquetCipher::EXTERNAL_DBPA_V1;
+  std::string column_name = "employee_name";
+  std::string key_id = "employee_name_key";
+  Type::type data_type = Type::BYTE_ARRAY;
+  Compression::type compression_type = Compression::UNCOMPRESSED;
+  Encoding::type encoding_type = Encoding::PLAIN;
+
+  std::string library_path = parquet::encryption::external::test::TestUtils::GetTestLibraryPath();
+  std::map<std::string, std::string> bad_config = {
+    {"config_path", "path/to/file"}, 
+    {"agent_library_path", library_path},
+    {"init_timeout_ms", "nope"},
   };
   std::string app_context = "{}";
 

--- a/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption_test.cc
@@ -27,7 +27,10 @@ class ExternalDBPAEncryptorAdapterTest : public ::testing::Test {
       "{\"user_id\": \"abc123\", \"location\": {\"lat\": 9.7489, \"lon\": -83.7534}}";
     connection_config_ = {
       {"config_path", "path/to/file"}, 
-      {"agent_library_path", library_path}
+      {"agent_library_path", library_path},
+      {"init_timeout_ms", "1000"},
+      {"encrypt_timeout_ms", "2000"},
+      {"decrypt_timeout_ms", "3000"}
     };
   }
 

--- a/python/scripts/base_app.py
+++ b/python/scripts/base_app.py
@@ -193,12 +193,13 @@ def get_dbpa_connection_config():
     agent_library_path = os.environ.get('DBPA_LIBRARY_PATH', 'libDBPATestAgent.so')
 
     connection_config = {
-        #TODO: in early discussions, we thought connection_config would be sent via a file.
-        #https://github.com/protegrity/arrow/issues/123
         "EXTERNAL_DBPA_V1": {
             "agent_library_path": agent_library_path,
             "config_file": "path/to/config/file",
-            "config_file_decryption_key": "some_key"
+            "config_file_decryption_key": "some_key",
+            "init_timeout_ms": "15000",
+            "encrypt_timeout_ms": "35000",
+            "decrypt_timeout_ms": "35000"
         }
     }
 

--- a/python/scripts/base_app.py
+++ b/python/scripts/base_app.py
@@ -200,7 +200,6 @@ def get_dbpa_connection_config():
         "EXTERNAL_DBPA_V1": {
             "agent_library_path": agent_library_path,
             "connection_config_file_path": config_path,
-            "connection_config_file_decryption_key": "some_key",
             "init_timeout_ms": "15000",
             "encrypt_timeout_ms": "35000",
             "decrypt_timeout_ms": "35000"

--- a/python/scripts/base_app.py
+++ b/python/scripts/base_app.py
@@ -11,7 +11,6 @@ import pyarrow
 import pyarrow.parquet as pp
 import pyarrow.parquet.encryption as ppe
 
-
 class FooKmsClient(ppe.KmsClient):
 
     def __init__(self, kms_connection_config):
@@ -191,12 +190,17 @@ def get_dbpa_connection_config():
     #this library performs key-indenpendent, XOR encryption/decryption, and is built as part of the Parquet Arrow tests.
     #It is located in cpp/src/parquet/encryption/external/dbpa_test_agent.cc
     agent_library_path = os.environ.get('DBPA_LIBRARY_PATH', 'libDBPATestAgent.so')
+    script_directory = os.path.dirname(os.path.abspath(__file__))
+    config_path = os.path.join(script_directory, 'test_connection_config_file.json')
+
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"Connection config file not found at [${config_path}]")
 
     connection_config = {
         "EXTERNAL_DBPA_V1": {
             "agent_library_path": agent_library_path,
-            "config_file": "path/to/config/file",
-            "config_file_decryption_key": "some_key",
+            "connection_config_file_path": config_path,
+            "connection_config_file_decryption_key": "some_key",
             "init_timeout_ms": "15000",
             "encrypt_timeout_ms": "35000",
             "decrypt_timeout_ms": "35000"

--- a/python/scripts/test_connection_config_file.json
+++ b/python/scripts/test_connection_config_file.json
@@ -1,0 +1,3 @@
+{
+  "server_url": "http://localhost:8080"
+}


### PR DESCRIPTION
Adding timeout values to the connection config under keys:
- init_timeout_ms
- encrypt_timeout_ms
- decrypt_timeout_ms

There are default values associated with them, but if the keys are present (they are optional), the values are overwritten.