### PR TITLE
Setting correct encryption algorithm to unsigned footer

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -440,7 +440,10 @@ endif()
 
 # Those tests need to use static linking as they access thrift-generated
 # symbols which are not exported by parquet.dll on Windows (PARQUET-1420).
-add_parquet_test(file_deserialize_test SOURCES file_deserialize_test.cc)
+add_parquet_test(file_deserialize_test
+                 SOURCES
+                 file_deserialize_test.cc
+                 encryption/external/test_utils.cc)
 add_parquet_test(schema_test)
 
 add_parquet_benchmark(bloom_filter_benchmark SOURCES bloom_filter_benchmark.cc

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -2059,7 +2059,7 @@ class FileMetaDataBuilder::FileMetaDataBuilderImpl {
       if (!algo.aad.supply_aad_prefix) {
         signing_algorithm.aad.aad_prefix = algo.aad.aad_prefix;
       }
-      signing_algorithm.algorithm = ParquetCipher::AES_GCM_V1;
+      signing_algorithm.algorithm = algo.algorithm;
 
       metadata_->__set_encryption_algorithm(ToThrift(signing_algorithm));
       const std::string& footer_signing_key_metadata =


### PR DESCRIPTION
Correctly set the encryption algorithm to the file's encryption algorithm when a plaintext footer is used in encrypted files.

Previously, AES_GCM_V1 was used, no matter what encryption algorithm was specified. This would later be incorrectly read back as the entire file's encryption algorithm.

