### PR TITLE
Adding app-level tests for combinations of encryption algorithm configurations

### DIFF
--- a/python/pyarrow/tests/parquet/test_external_encryption.py
+++ b/python/pyarrow/tests/parquet/test_external_encryption.py
@@ -63,6 +63,8 @@ def kms_client_factory(kms_connection_config):
 
 
 def get_agent_library_path():
+    # TODO: move this code to a common library
+    # See https://github.com/protegrity/arrow/issues/191
     return os.environ.get(
         'DBPA_LIBRARY_PATH', 
         'libDBPATestAgent.so' if platform.system() == 'Linux' else 'libDBPATestAgent.dylib')


### PR DESCRIPTION
Test that combines all available encryption algorithms in their configuration.

Added per_colulmn_encryption of every available algorithm.
Changing the file-level encryption algorithm and whether the footer is plaintext or not.

All combinations succeed, and the expected failure (using EXTERNAL_DBPA at the file level) fails as expected.