### PR TITLE
Passing and retrieving column_encryption_metadata to dbpa agent (#190)

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -284,7 +284,7 @@ if(PARQUET_REQUIRE_ENCRYPTION)
 
     #TODO: Change to a specific tag/commit when we have one.
     #https://github.com/protegrity/arrow/issues/179
-    GIT_TAG 7ee542399383fb0adc60d0e79a277a6a1a5b6028
+    GIT_TAG 82b98c1e22b58c320c8161b052959602a843b89b
     GIT_SHALLOW FALSE
   )
  

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -325,12 +325,6 @@ class SerializedPageWriter : public PageWriter {
           static_cast<const DictionaryPage&>(page));
       data_encryptor_->UpdateEncodingProperties(std::move(encoding_properties));
 
-      auto data_encryptor_metadata = data_encryptor_->GetKeyValueMetadata(
-        encryption::kDictionaryPage);
-      if (data_encryptor_metadata != nullptr) {
-        metadata_->AddKeyValueMetadata(data_encryptor_metadata);
-      }
-
       if (data_encryptor_->CanCalculateCiphertextLength()) {
         PARQUET_THROW_NOT_OK(encryption_buffer_->Resize(
           data_encryptor_->CiphertextLength(output_data_len), false));
@@ -343,6 +337,13 @@ class SerializedPageWriter : public PageWriter {
                                                       encryption_buffer_.get());
       }
       output_data_buffer = encryption_buffer_->data();
+
+      // after the call to encrypt(), add the column encryption metadata to the metadata_ object
+      auto data_encryptor_metadata = data_encryptor_->GetKeyValueMetadata(
+        encryption::kDictionaryPage);
+      if (data_encryptor_metadata != nullptr) {
+        metadata_->AddKeyValueMetadata(data_encryptor_metadata);
+      }
     }
 
     format::PageHeader page_header;
@@ -449,11 +450,6 @@ class SerializedPageWriter : public PageWriter {
           static_cast<const DataPage&>(page));
       data_encryptor_->UpdateEncodingProperties(std::move(encoding_properties));
 
-      auto data_encryptor_metadata = data_encryptor_->GetKeyValueMetadata(encryption::kDataPage);
-      if (data_encryptor_metadata != nullptr) {
-        metadata_->AddKeyValueMetadata(data_encryptor_metadata);
-      }
-
       if (data_encryptor_->CanCalculateCiphertextLength()) {
         PARQUET_THROW_NOT_OK(encryption_buffer_->Resize(
           data_encryptor_->CiphertextLength(output_data_len), false));
@@ -466,6 +462,13 @@ class SerializedPageWriter : public PageWriter {
                                                       encryption_buffer_.get());
       }
       output_data_buffer = encryption_buffer_->data();
+
+      // after the call to encrypt(), add the column encryption metadata to the metadata_ object
+      auto data_encryptor_metadata = data_encryptor_->GetKeyValueMetadata(
+        encryption::kDataPage);
+      if (data_encryptor_metadata != nullptr) {
+        metadata_->AddKeyValueMetadata(data_encryptor_metadata);
+      }
     }
 
     format::PageHeader page_header;

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -1956,6 +1956,10 @@ TEST_F(TestColumnWriterEncryption, ExternalDBPAEncryption) {
   auto key_value_metadata = rg_reader->metadata()->ColumnChunk(0)->key_value_metadata();
   ASSERT_THAT(key_value_metadata, NotNull());
   ASSERT_EQ(2, key_value_metadata->size());
+  ASSERT_OK_AND_ASSIGN(auto test_v1, key_value_metadata->Get("test_key1"));
+  ASSERT_EQ("test_value1", test_v1);
+  ASSERT_OK_AND_ASSIGN(auto test_v2, key_value_metadata->Get("test_key2"));
+  ASSERT_EQ("test_value2", test_v2);
 
   std::vector<int32_t> read_values(values_.size());
   int64_t values_read;

--- a/cpp/src/parquet/encryption/encoding_properties.h
+++ b/cpp/src/parquet/encryption/encoding_properties.h
@@ -38,6 +38,9 @@ public:
 
     std::map<std::string, std::string> ToPropertiesMap() const;
 
+    // Lightweight accessor to avoid building maps when only page type is needed
+    parquet::PageType::type GetPageType() const { return page_type_; }
+
 private:
     // Private constructor for builder
     EncodingProperties(const EncodingPropertiesBuilder& builder);

--- a/cpp/src/parquet/encryption/external/dbpa_executor.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_executor.cc
@@ -134,7 +134,8 @@ void DBPAExecutor::init(
     std::string column_key_id,
     Type::type data_type,
     std::optional<int> datatype_length,
-    CompressionCodec::type compression_type) {
+    CompressionCodec::type compression_type,
+    std::optional<std::map<std::string, std::string>> column_encryption_metadata) {
 
   std::cout << "[DBPAExecutor] init() called for column: " << column_name 
             << ", key_id: " << column_key_id << std::endl;
@@ -146,14 +147,15 @@ void DBPAExecutor::init(
                        std::string col_key_id,
                        Type::type dt,
                        std::optional<int> dt_len,
-                       CompressionCodec::type comp_type) {
+                       CompressionCodec::type comp_type,
+                       std::optional<std::map<std::string, std::string>> col_enc_metadata) {
                   wrapped_agent_->init(std::move(col_name), std::move(conn_config),
                                       std::move(app_ctx), std::move(col_key_id),
-                                      dt, dt_len, comp_type);
+                                      dt, dt_len, comp_type, std::move(col_enc_metadata));
                 },
                 std::move(column_name), std::move(connection_config),
                 std::move(app_context), std::move(column_key_id),
-                data_type, datatype_length, compression_type);
+                data_type, datatype_length, compression_type, std::move(column_encryption_metadata));
 }
 
 std::unique_ptr<EncryptionResult> DBPAExecutor::Encrypt(

--- a/cpp/src/parquet/encryption/external/dbpa_executor.h
+++ b/cpp/src/parquet/encryption/external/dbpa_executor.h
@@ -58,7 +58,8 @@ class DBPAExecutor : public DataBatchProtectionAgentInterface {
       std::string column_key_id,
       Type::type data_type,
       std::optional<int> datatype_length,
-      CompressionCodec::type compression_type) override;
+      CompressionCodec::type compression_type,
+      std::optional<std::map<std::string, std::string>> column_encryption_metadata) override;
 
   /**
    * Encrypt the provided plaintext

--- a/cpp/src/parquet/encryption/external/dbpa_library_wrapper.h
+++ b/cpp/src/parquet/encryption/external/dbpa_library_wrapper.h
@@ -62,10 +62,11 @@ class DBPALibraryWrapper : public DataBatchProtectionAgentInterface {
       std::string column_key_id,
       Type::type data_type,
       std::optional<int> datatype_length,
-      CompressionCodec::type compression_type) override {
+      CompressionCodec::type compression_type,
+      std::optional<std::map<std::string, std::string>> column_encryption_metadata) override {
     wrapped_agent_->init(std::move(column_name), std::move(connection_config),
                         std::move(app_context), std::move(column_key_id),
-                        data_type, datatype_length, compression_type);
+                        data_type, datatype_length, compression_type, std::move(column_encryption_metadata));
   }
 
   // Decorator implementation of Encrypt method - inlined for performance

--- a/cpp/src/parquet/encryption/external/dbpa_test_agent.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_test_agent.cc
@@ -36,6 +36,9 @@ public:
     bool success() const override { return success_; }
     const std::string& error_message() const override { return error_message_; }
     const std::map<std::string, std::string>& error_fields() const override { return error_fields_; }
+    const std::optional<std::map<std::string, std::string>> encryption_metadata() const override {
+        return std::map<std::string, std::string>{{"test_key1", "test_value1"}, {"test_key2", "test_value2"}};
+    }
 
 private:
     std::vector<uint8_t> ciphertext_data_;

--- a/cpp/src/parquet/encryption/external/dbpa_test_agent.h
+++ b/cpp/src/parquet/encryption/external/dbpa_test_agent.h
@@ -32,7 +32,8 @@ class DBPATestAgent : public DataBatchProtectionAgentInterface {
       std::string column_key_id,
       Type::type data_type,
       std::optional<int> datatype_length,
-      CompressionCodec::type compression_type) override {
+      CompressionCodec::type compression_type,
+      std::optional<std::map<std::string, std::string>> column_encryption_metadata) override {
 
     if (column_key_id.empty()) {
       throw std::invalid_argument("column_key_id cannot be empty");

--- a/cpp/src/parquet/encryption/external_dbpa_encryption.h
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption.h
@@ -95,7 +95,28 @@ class ExternalDBPAEncryptorAdapter : public EncryptorInterface {
     
     std::unique_ptr<EncodingProperties> encoding_properties_;
     bool encoding_properties_updated_ = false;
+
+    // Accumulated column encryption metadata per module type (e.g., data page, dictionary page)
+    // to be used later by GetKeyValueMetadata.
+    std::map<int8_t, std::map<std::string, std::string>> column_encryption_metadata_;
 };
+
+// Utilities for External DBPA adapters
+class ExternalDBPAUtils {
+ public:
+  // Convert Arrow KeyValueMetadata to a std::map<string, string>.
+  // Returns std::nullopt if the input is null or contains no pairs.
+  static std::optional<std::map<std::string, std::string>> KeyValueMetadataToStringMap(
+      const std::shared_ptr<const KeyValueMetadata>& key_value_metadata);
+};
+
+// Update encryptor-level metadata accumulator based on encoding attributes and
+// EncryptionResult-provided metadata. If no metadata is available or page_type is
+// unsupported/absent, function performs no-op.
+void UpdateEncryptorMetadata(
+  std::map<int8_t, std::map<std::string, std::string>>& metadata_by_module,
+  const EncodingProperties& encoding_properties,
+  const dbps::external::EncryptionResult& result);
 
 /// Factory for ExternalDBPAEncryptorAdapter instances. The cache exists while the write
 /// operation is open, and is used to guarantee the lifetime of the encryptor.


### PR DESCRIPTION
Passing and retrieving column_encryption_metadata to dbpa agent (#190)

[Recently](https://github.com/protegrity/DataBatchProtectionService/pull/144), we modified the DBPA Interface (`dbpa_interface.h`) to allow passing and retrieving column metadata encryption information. 

In this PR, we 
(1) Modify the Arrow code base to fulfill the new interface (`dbpa_interface.h`)
(2) Modify `external_dbpa_encryption.cc` so that 
  - At encryption time, the metadata is reader from `EncryptionResult` and  used to update the objects returned in `GetKeyValueMetadata()`
  -  At decryption time, the metadata is passed into the DBPA Agent via `init()`
(3) Modify and add relevant tests. 


**Testing**
- New, existing and modified tests pass (via `ctest -L parquet`)

**Note**
- The PR is on the long side. I was planning to split it into two parts (dbpa_interface updates, then connect the rest of the behavior) - however due to an unfortunate `git squash` incident, I ended up with a single PR/commit. Apologies for the length.