### PR TITLE
Modifying logging to using ArrowLog (#118)

### DIFF
--- a/cpp/src/parquet/encryption/external/dbpa_library_wrapper.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_library_wrapper.cc
@@ -9,6 +9,7 @@
 #include <iostream>
 
 #include "arrow/util/io_util.h"
+#include "arrow/util/logging.h"
 
 namespace parquet::encryption::external {
 
@@ -16,7 +17,7 @@ namespace parquet::encryption::external {
 void DefaultSharedLibraryClosingFn(void* library_handle) {
   auto status = arrow::internal::CloseDynamicLibrary(library_handle);
   if (!status.ok()) {
-    std::cerr << "Error closing library: " << status.message() << std::endl;
+    ARROW_LOG(WARNING) << "Error closing library: " << status.message();
   }
 }
 

--- a/cpp/src/parquet/encryption/external/loadable_encryptor_utils.cc
+++ b/cpp/src/parquet/encryption/external/loadable_encryptor_utils.cc
@@ -6,6 +6,7 @@
 
 #include "arrow/util/io_util.h" //utils for loading shared libraries
 #include "arrow/result.h"
+#include "arrow/util/logging.h"
 
 #include <iostream>
 #include <stdexcept>
@@ -24,7 +25,7 @@ typedef DataBatchProtectionAgentInterface* (*create_encryptor_t)();
 std::unique_ptr<DataBatchProtectionAgentInterface> CreateInstance(void* library_handle) {
   auto symbol_result = arrow::internal::GetSymbol(library_handle, "create_new_instance");
   if (!symbol_result.ok()) {
-    std::cerr << "Error: Cannot load symbol 'create_new_instance()': " << symbol_result.status().message() << std::endl;
+    ARROW_LOG(ERROR) << "Cannot load symbol 'create_new_instance()': " << symbol_result.status().message();
     auto status = arrow::internal::CloseDynamicLibrary(library_handle);
 
     throw std::runtime_error("Failed to load symbol 'create_new_instance()': " + symbol_result.status().message());
@@ -38,7 +39,7 @@ std::unique_ptr<DataBatchProtectionAgentInterface> CreateInstance(void* library_
   DataBatchProtectionAgentInterface* instance = create_instance_fn();
 
   if (instance == nullptr) {
-    std::cerr << "Error: Cannot create instance of DataBatchProtectionAgentInterface" << std::endl;
+    ARROW_LOG(ERROR) << "Cannot create instance of DataBatchProtectionAgentInterface";
     auto status = arrow::internal::CloseDynamicLibrary(library_handle);
     throw std::runtime_error("Failed to create instance of DataBatchProtectionAgentInterface");
   }

--- a/cpp/src/parquet/encryption/external_dbpa_encryption_utils.h
+++ b/cpp/src/parquet/encryption/external_dbpa_encryption_utils.h
@@ -1,0 +1,65 @@
+// What license shall we use for this file?
+
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <mutex>
+#include <optional>
+#include <string>
+
+#include "arrow/util/logging.h"
+
+namespace parquet::encryption {
+
+// Configure Arrow logging threshold from environment (once per procall site).
+//
+// There is currently no mechanism to configure Arrow's logger. 
+// Given that most of the logging changes that we have added are related to external/dbpa encryption, 
+// we decided to keep most of the Arrow base code as-is, and made the config belong to external/dbpa.
+//
+// Env var: PARQUET_DBPA_LOG_LEVEL (case-insensitive: TRACE, DEBUG, INFO, WARN[ING], ERROR, FATAL, or -2..3)
+inline void ConfigureArrowLogLevel() {
+  const char* env_val = std::getenv("PARQUET_DBPA_LOG_LEVEL");
+  if (env_val == nullptr || *env_val == '\0') {
+    return;
+  }
+  std::string s(env_val);
+  std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+
+  using ::arrow::util::ArrowLogLevel;
+  auto to_level = [&](const std::string& v) -> std::optional<ArrowLogLevel> {
+    if (v == "TRACE") return ArrowLogLevel::ARROW_TRACE;
+    if (v == "DEBUG") return ArrowLogLevel::ARROW_DEBUG;
+    if (v == "INFO") return ArrowLogLevel::ARROW_INFO;
+    if (v == "WARN" || v == "WARNING") return ArrowLogLevel::ARROW_WARNING;
+    if (v == "ERROR") return ArrowLogLevel::ARROW_ERROR;
+    if (v == "FATAL") return ArrowLogLevel::ARROW_FATAL;
+    try {
+      int n = std::stoi(v);
+      switch (n) {
+        case -2: return ArrowLogLevel::ARROW_TRACE;
+        case -1: return ArrowLogLevel::ARROW_DEBUG;
+        case  0: return ArrowLogLevel::ARROW_INFO;
+        case  1: return ArrowLogLevel::ARROW_WARNING;
+        case  2: return ArrowLogLevel::ARROW_ERROR;
+        case  3: return ArrowLogLevel::ARROW_FATAL;
+        default: return std::nullopt;
+      }
+    } catch (...) {
+      return std::nullopt;
+    }
+  };
+
+  if (auto lvl = to_level(s)) {
+    ::arrow::util::ArrowLog::StartArrowLog("parquet-dbpa", *lvl, "");
+  }
+}
+
+inline void EnsureDbpaLoggingConfigured() {
+  static std::once_flag once;
+  std::call_once(once, [] { ConfigureArrowLogLevel(); });
+}
+
+}  // namespace parquet::encryption


### PR DESCRIPTION
Modifying Arrow DBPA-related logging to using ArrowLog.

**Testing**
- Exisitng tests (via `ctest -L parquet`) pass
- Manual testing (changing enviroment variables) succesfully performed against `base_app.py`

**Notes**
- Currently there is not a mechanism to allow to configure the logging level in Arrow. For this reason, we created `external_dbpa_encryption_utils.h` with some simple utils for allowing to modify the logging level using env variables. This only affects the DBPA workflow.
- Performed a minor consolidation of some log lines. In future PRs, we may perform a more significant cleanup of logs.