### PR TITLE
Updating to the latest version of DBPA. 

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -284,7 +284,7 @@ if(PARQUET_REQUIRE_ENCRYPTION)
 
     #TODO: Change to a specific tag/commit when we have one.
     #https://github.com/protegrity/arrow/issues/179
-    GIT_TAG be87857e4d8c40977c3143c57805c7cc1c8394a8
+    GIT_TAG 4c808b2233ed0bc04529c3b0dbf7c214c4901043
     GIT_SHALLOW FALSE
   )
  

--- a/cpp/src/parquet/encryption/external/dbpa_executor_test.cc
+++ b/cpp/src/parquet/encryption/external/dbpa_executor_test.cc
@@ -33,9 +33,11 @@ class TestEncryptionResult : public EncryptionResult {
 public:
     TestEncryptionResult(std::vector<uint8_t> data, bool success = true, 
                         std::string error_msg = "", 
-                        std::map<std::string, std::string> error_fields = {})
+                        std::map<std::string, std::string> error_fields = {},
+                        std::optional<std::map<std::string, std::string>> metadata = std::nullopt)
         : ciphertext_data_(std::move(data)), success_(success), 
-          error_message_(std::move(error_msg)), error_fields_(std::move(error_fields)) {}
+          error_message_(std::move(error_msg)), error_fields_(std::move(error_fields)),
+          metadata_(std::move(metadata)) {}
 
     span<const uint8_t> ciphertext() const override {
         return span<const uint8_t>(ciphertext_data_.data(), ciphertext_data_.size());
@@ -43,6 +45,9 @@ public:
 
     std::size_t size() const override { return ciphertext_data_.size(); }
     bool success() const override { return success_; }
+    const std::optional<std::map<std::string, std::string>> encryption_metadata() const override {
+        return metadata_;
+    }
     const std::string& error_message() const override { return error_message_; }
     const std::map<std::string, std::string>& error_fields() const override { return error_fields_; }
 
@@ -51,6 +56,7 @@ private:
     bool success_;
     std::string error_message_;
     std::map<std::string, std::string> error_fields_;
+    std::optional<std::map<std::string, std::string>> metadata_;
 };
 
 class TestDecryptionResult : public DecryptionResult {


### PR DESCRIPTION
Updating to the latest version of DBPA. Includes updates to test regarding encryption metadata

In the latest version of the DBPA interface, the `EncryptionResult` object includes a new field (`metadata`). Because we're upgrading to the latest version of DBPA, we need to update some tests to include this field.

**Testing**
- Existing and updated tests pass (via `ctest -L parquet`)